### PR TITLE
MAIT-41: Align .env.rag.example with host-based MediaWiki config

### DIFF
--- a/.env.rag.example
+++ b/.env.rag.example
@@ -56,10 +56,10 @@ S3_ACCOUNT1_SCHEDULES=
 #S3_ACCOUNT2_BUCKETS=bucket3,bucket4
 #S3_ACCOUNT2_SCHEDULES=60,3600
 
-# MEDIAWIKI CONNECTORS (optional):
+# MEDIAWIKI CONNECTORS (optional; host-based):
 
-#MEDIAWIKI1_API_URL=https://your-mediawiki-instance1.com/w/api.php
-#MEDIAWIKI2_API_URL=https://your-mediawiki-instance2.com/w/api.php
+#MEDIAWIKI_HOST=counselknowledge.teq.wiki
+#MEDIAWIKI_SCHEDULES=3600
 
 # SERPPAPI CONNECTORS (optional):
 


### PR DESCRIPTION
## Summary
Updates `.env.rag.example` to match the host-based MediaWiki connector configuration (MAIT-41).

## Changes
- **Comment:** "MEDIAWIKI CONNECTORS (optional):" → "MEDIAWIKI CONNECTORS (optional; host-based):"
- **Example vars:** Replaced `MEDIAWIKI1_API_URL` / `MEDIAWIKI2_API_URL` with:
  - `MEDIAWIKI_HOST` (e.g. `counselknowledge.teq.wiki`)
  - `MEDIAWIKI_SCHEDULES` (e.g. `3600`)

No other files changed; docs and compose overrides remain uncommitted.