### PR TITLE
Add GitHub connector docs and config example (MAIT-92)

### DIFF
--- a/.env.rag.example
+++ b/.env.rag.example
@@ -130,3 +130,13 @@ S3_ACCOUNT1_SCHEDULES=
 #SHAREPOINT1_CLIENT_SECRET=your-azure-app-client-secret
 #SHAREPOINT1_TENANT_ID=your-azure-tenant-id
 #SHAREPOINT1_SCHEDULES=3600
+
+# GITHUB CONNECTORS (optional):
+#GITHUB1_PERSONAL_TOKEN=your-personal-access-token
+# GitHub App auth (alternative to personal token):
+#GITHUB1_APP_ID=
+#GITHUB1_APP_INSTALLATION_ID=
+#GITHUB1_APP_PRIVATE_KEY=
+#GITHUB1_OWNER=your-org-or-username
+#GITHUB1_REPO=your-repo-name
+#GITHUB1_SCHEDULES=3600

--- a/.env.rag.example
+++ b/.env.rag.example
@@ -136,6 +136,7 @@ S3_ACCOUNT1_SCHEDULES=
 # GitHub App auth (alternative to personal token):
 #GITHUB1_APP_ID=
 #GITHUB1_APP_INSTALLATION_ID=
+# Private key must be the raw PEM contents on a single line with literal \n line breaks
 #GITHUB1_APP_PRIVATE_KEY=
 #GITHUB1_OWNER=your-org-or-username
 #GITHUB1_REPO=your-repo-name

--- a/.env.rag.example
+++ b/.env.rag.example
@@ -132,8 +132,9 @@ S3_ACCOUNT1_SCHEDULES=
 #SHAREPOINT1_SCHEDULES=3600
 
 # GITHUB CONNECTORS (optional):
+# Auth — mutually exclusive: GITHUB1_PERSONAL_TOKEN OR GITHUB1_APP_ID + GITHUB1_APP_INSTALLATION_ID + GITHUB1_APP_PRIVATE_KEY
 #GITHUB1_PERSONAL_TOKEN=your-personal-access-token
-# GitHub App auth (alternative to personal token):
+# GitHub App auth (remove/comment out GITHUB1_PERSONAL_TOKEN above if using this):
 #GITHUB1_APP_ID=
 #GITHUB1_APP_INSTALLATION_ID=
 # Private key must be the raw PEM contents on a single line with literal \n line breaks

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ interact with your knowledge with ease!
 * Slack
 * OneDrive for Business
 * SharePoint
+* GitHub (repository files and issues, PAT or GitHub App auth)
 
 ## 🌐 Extra connectors
 
@@ -51,7 +52,6 @@ Over 100 extra connectors are available at request, including the most popular o
 * Gmail
 * Google Drive
 * Jira
-* GitHub
 * Gitlab
 * Notion
 * Microsoft Teams
@@ -461,6 +461,52 @@ ONEDRIVE1_CLIENT_SECRET=your-azure-app-client-secret
 ONEDRIVE1_TENANT_ID=your-azure-tenant-id
 ONEDRIVE1_USER_PRINCIPAL_NAME=user@your-org.onmicrosoft.com
 ONEDRIVE1_SCHEDULES=3600
+```
+
+### GitHub Connector
+
+The GitHub connector ingests repository files and optionally issues from a GitHub repository.
+Supports PAT and GitHub App authentication, branch or commit targeting, file extension/directory
+filters, and issue label filters.
+
+```yaml
+# config.yaml
+
+sources:
+  - type: "github"
+    name: "github1"
+    config:
+      personal_token: "${GITHUB1_PERSONAL_TOKEN}"
+      # GitHub App auth (mutually exclusive with personal_token):
+      #github_app_id: "${GITHUB1_APP_ID}"
+      #github_app_installation_id: "${GITHUB1_APP_INSTALLATION_ID}"
+      #github_app_private_key: "${GITHUB1_APP_PRIVATE_KEY}"
+      owner: "${GITHUB1_OWNER}"
+      repo: "${GITHUB1_REPO}"
+      branch: "main"                    # optional, default "main" (mutually exclusive with commit_sha)
+      #commit_sha: ""                   # optional (mutually exclusive with branch)
+      include_extensions: "md,py"       # optional, comma-separated (mutually exclusive with exclude_extensions)
+      #exclude_extensions: ""           # optional (mutually exclusive with include_extensions)
+      #include_directories: ""          # optional, comma-separated (mutually exclusive with exclude_directories)
+      #exclude_directories: ""          # optional (mutually exclusive with include_directories)
+      include_issues: false             # optional, default false
+      #include_issues_labels: ""        # optional, comma-separated (mutually exclusive with exclude_issues_labels)
+      #exclude_issues_labels: ""        # optional (mutually exclusive with include_issues_labels)
+      concurrent_requests: 5            # optional, default 5
+      schedules: "${GITHUB1_SCHEDULES}"
+```
+
+```dotenv
+# .env.rag
+
+GITHUB1_PERSONAL_TOKEN=your-personal-access-token
+# GitHub App auth (alternative to personal token):
+#GITHUB1_APP_ID=
+#GITHUB1_APP_INSTALLATION_ID=
+#GITHUB1_APP_PRIVATE_KEY=
+GITHUB1_OWNER=your-org-or-username
+GITHUB1_REPO=your-repo-name
+GITHUB1_SCHEDULES=3600
 ```
 
 ## Single Sign-On (SSO)

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -169,7 +169,8 @@ sources:
   #- type: "github"
   #  name: "github1"
   #  config:
-  #    # Auth — use one of: personal_token OR github_app_id + github_app_installation_id + github_app_private_key
+  #    # Auth — mutually exclusive: personal_token OR github_app_id + github_app_installation_id + github_app_private_key
+  #    # Remove/comment out personal_token if using GitHub App auth.
   #    personal_token: "${GITHUB1_PERSONAL_TOKEN}"
   #    #github_app_id: "${GITHUB1_APP_ID}"
   #    #github_app_installation_id: "${GITHUB1_APP_INSTALLATION_ID}"

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -166,6 +166,28 @@ sources:
   #    recursive: true
   #    schedules: "${SHAREPOINT1_SCHEDULES}"
 
+  #- type: "github"
+  #  name: "github1"
+  #  config:
+  #    # Auth — use one of: personal_token OR github_app_id + github_app_installation_id + github_app_private_key
+  #    personal_token: "${GITHUB1_PERSONAL_TOKEN}"
+  #    #github_app_id: "${GITHUB1_APP_ID}"
+  #    #github_app_installation_id: "${GITHUB1_APP_INSTALLATION_ID}"
+  #    #github_app_private_key: "${GITHUB1_APP_PRIVATE_KEY}"
+  #    owner: "${GITHUB1_OWNER}"
+  #    repo: "${GITHUB1_REPO}"
+  #    branch: "main"            # optional, default "main" (mutually exclusive with commit_sha)
+  #    #commit_sha: ""           # optional (mutually exclusive with branch)
+  #    include_extensions: "md,py"  # optional, comma-separated (mutually exclusive with exclude_extensions)
+  #    #exclude_extensions: ""   # optional (mutually exclusive with include_extensions)
+  #    #include_directories: ""  # optional, comma-separated (mutually exclusive with exclude_directories)
+  #    #exclude_directories: ""  # optional (mutually exclusive with include_directories)
+  #    include_issues: false     # optional, default false
+  #    #include_issues_labels: ""   # optional, comma-separated (mutually exclusive with exclude_issues_labels)
+  #    #exclude_issues_labels: ""   # optional (mutually exclusive with include_issues_labels)
+  #    concurrent_requests: 5    # optional, default 5
+  #    schedules: "${GITHUB1_SCHEDULES}"
+
 embedding:
   # can be `local` or `openrouter`/`openai`
   provider: local

--- a/docs/connectors/github-connector.mdx
+++ b/docs/connectors/github-connector.mdx
@@ -1,0 +1,103 @@
+---
+title: "GitHub"
+description: "Configure the mAItion GitHub connector to ingest repository files and issues from a GitHub repository."
+keywords:
+  - mAItion
+  - GitHub connector
+  - GitHub ingestion
+  - connectors
+---
+
+Use the GitHub Connector to ingest repository files and optionally issues from a [GitHub](https://github.com) repository into the mAItion knowledge base.
+
+## What It Does
+
+- fetches files from a GitHub repository at a given branch or commit
+- optionally fetches repository issues, with label filtering
+- converts file and issue content to Markdown for indexing
+- runs ingestion on configurable schedules
+
+## Authentication
+
+Two authentication methods are supported (mutually exclusive):
+
+- **Personal Access Token** (`personal_token`): a GitHub PAT with access to the target repository.
+- **GitHub App** (`github_app_id` + `github_app_installation_id` + `github_app_private_key`): all three fields are required together when using GitHub App authentication.
+
+## Required Environment Variables
+
+Set these in `.env.rag`:
+
+- `GITHUB1_PERSONAL_TOKEN`: GitHub Personal Access Token — required unless using GitHub App auth
+- `GITHUB1_APP_ID`, `GITHUB1_APP_INSTALLATION_ID`, `GITHUB1_APP_PRIVATE_KEY`: GitHub App credentials — alternative to `GITHUB1_PERSONAL_TOKEN`, all three required together
+- `GITHUB1_OWNER`: repository owner or organization
+- `GITHUB1_REPO`: repository name
+- `GITHUB1_SCHEDULES`: ingestion interval in seconds (default is `3600`)
+
+## `config.yaml` Example
+
+```yaml
+sources:
+  - type: "github"
+    name: "github1"
+    enabled: true  # optional, default: true
+    config:
+      personal_token: "${GITHUB1_PERSONAL_TOKEN}"
+      # GitHub App auth (mutually exclusive with personal_token):
+      #github_app_id: "${GITHUB1_APP_ID}"
+      #github_app_installation_id: "${GITHUB1_APP_INSTALLATION_ID}"
+      #github_app_private_key: "${GITHUB1_APP_PRIVATE_KEY}"
+      owner: "${GITHUB1_OWNER}"
+      repo: "${GITHUB1_REPO}"
+      branch: "main"                    # optional, default "main" (mutually exclusive with commit_sha)
+      #commit_sha: ""                   # optional (mutually exclusive with branch)
+      include_extensions: "md,py"       # optional, comma-separated (mutually exclusive with exclude_extensions)
+      #exclude_extensions: ""           # optional (mutually exclusive with include_extensions)
+      #include_directories: ""          # optional, comma-separated (mutually exclusive with exclude_directories)
+      #exclude_directories: ""          # optional (mutually exclusive with include_directories)
+      include_issues: false             # optional, default false
+      #include_issues_labels: ""        # optional, comma-separated (mutually exclusive with exclude_issues_labels)
+      #exclude_issues_labels: ""        # optional (mutually exclusive with include_issues_labels)
+      concurrent_requests: 5            # optional, default 5
+      schedules: "${GITHUB1_SCHEDULES}"
+```
+
+## `.env.rag` Example
+
+```dotenv
+GITHUB1_PERSONAL_TOKEN=your-personal-access-token
+# GitHub App auth (alternative to personal token):
+#GITHUB1_APP_ID=
+#GITHUB1_APP_INSTALLATION_ID=
+#GITHUB1_APP_PRIVATE_KEY=
+GITHUB1_OWNER=your-org-or-username
+GITHUB1_REPO=your-repo-name
+GITHUB1_SCHEDULES=3600
+```
+
+## Configuration Reference
+
+| Field | Required | Default | Description |
+|---|---|---|---|
+| `enabled` | no | `true` | Set to `false` to skip this source entirely |
+| `personal_token` | yes, unless using GitHub App auth | — | GitHub Personal Access Token (mutually exclusive with GitHub App credentials) |
+| `github_app_id` | yes, when using GitHub App auth | — | GitHub App ID (required together with `github_app_installation_id` and `github_app_private_key`) |
+| `github_app_installation_id` | yes, when using GitHub App auth | — | GitHub App installation ID |
+| `github_app_private_key` | yes, when using GitHub App auth | — | GitHub App private key |
+| `owner` | yes | — | Repository owner or organization |
+| `repo` | yes | — | Repository name |
+| `branch` | no | `main` | Branch to ingest from (mutually exclusive with `commit_sha`) |
+| `commit_sha` | no | — | Commit SHA to ingest from (mutually exclusive with `branch`) |
+| `include_extensions` | no | — | Comma-separated file extensions to include, e.g. `md,py` (mutually exclusive with `exclude_extensions`) |
+| `exclude_extensions` | no | — | Comma-separated file extensions to exclude (mutually exclusive with `include_extensions`) |
+| `include_directories` | no | — | Comma-separated directories to include (mutually exclusive with `exclude_directories`) |
+| `exclude_directories` | no | — | Comma-separated directories to exclude (mutually exclusive with `include_directories`) |
+| `include_issues` | no | `false` | Whether to also ingest repository issues |
+| `include_issues_labels` | no | — | Comma-separated issue labels to include (mutually exclusive with `exclude_issues_labels`) |
+| `exclude_issues_labels` | no | — | Comma-separated issue labels to exclude (mutually exclusive with `include_issues_labels`) |
+| `concurrent_requests` | no | `5` | Number of concurrent API requests |
+| `schedules` | no | `3600` | Ingestion interval in seconds |
+
+## Multiple GitHub Sources
+
+Add more `sources` entries (`github2`, `github3`, etc) with separate env vars per source.

--- a/docs/connectors/github-connector.mdx
+++ b/docs/connectors/github-connector.mdx
@@ -24,6 +24,12 @@ Two authentication methods are supported (mutually exclusive):
 - **Personal Access Token** (`personal_token`): a GitHub PAT with access to the target repository.
 - **GitHub App** (`github_app_id` + `github_app_installation_id` + `github_app_private_key`): all three fields are required together when using GitHub App authentication.
 
+**Minimum permissions:**
+
+- Repository contents: read — required for both PAT and GitHub App auth, to fetch repository files.
+- Issues: read — required in addition to the above when `include_issues` is `true`.
+- For GitHub App auth, the app installation must include the target repository.
+
 ## Environment Variables
 
 Set these in `.env.rag`:

--- a/docs/connectors/github-connector.mdx
+++ b/docs/connectors/github-connector.mdx
@@ -24,15 +24,15 @@ Two authentication methods are supported (mutually exclusive):
 - **Personal Access Token** (`personal_token`): a GitHub PAT with access to the target repository.
 - **GitHub App** (`github_app_id` + `github_app_installation_id` + `github_app_private_key`): all three fields are required together when using GitHub App authentication.
 
-## Required Environment Variables
+## Environment Variables
 
 Set these in `.env.rag`:
 
-- `GITHUB1_PERSONAL_TOKEN`: GitHub Personal Access Token — required unless using GitHub App auth
-- `GITHUB1_APP_ID`, `GITHUB1_APP_INSTALLATION_ID`, `GITHUB1_APP_PRIVATE_KEY`: GitHub App credentials — alternative to `GITHUB1_PERSONAL_TOKEN`, all three required together
-- `GITHUB1_OWNER`: repository owner or organization
-- `GITHUB1_REPO`: repository name
-- `GITHUB1_SCHEDULES`: ingestion interval in seconds (default is `3600`)
+- `GITHUB1_OWNER` (required): repository owner or organization
+- `GITHUB1_REPO` (required): repository name
+- `GITHUB1_PERSONAL_TOKEN` (required, unless using GitHub App auth): GitHub Personal Access Token
+- `GITHUB1_APP_ID`, `GITHUB1_APP_INSTALLATION_ID`, `GITHUB1_APP_PRIVATE_KEY` (required together, alternative to `GITHUB1_PERSONAL_TOKEN`): GitHub App credentials
+- `GITHUB1_SCHEDULES` (optional): ingestion interval in seconds (default is `3600`)
 
 ## `config.yaml` Example
 

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -73,7 +73,8 @@
 							"connectors/web-connector",
 							"connectors/directory-connector",
 							"connectors/slack-connector",
-							"connectors/onedrive-connector"
+							"connectors/onedrive-connector",
+							"connectors/github-connector"
 						]
 					},
 					{

--- a/docs/getting-started/index.mdx
+++ b/docs/getting-started/index.mdx
@@ -73,6 +73,9 @@ for both personal and team workflows.
 	<Card title="OneDrive" href="/connectors/onedrive-connector">
 		Ingest files from Microsoft OneDrive for Business.
 	</Card>
+	<Card title="GitHub" href="/connectors/github-connector">
+		Ingest repository files and issues from GitHub.
+	</Card>
 </CardGroup>
 
 ## Who It Is For


### PR DESCRIPTION
## Summary

- Add GitHub connector example to \`config.yaml.example\` with all options: PAT/GitHub App auth, branch/commit_sha targeting, file extension and directory filters, issue ingestion with label filters, \`concurrent_requests\`
- Move GitHub from \"Extra connectors\" to \"Connectors included\" in README
- Add GitHub Connector documentation section with \`config.yaml\` and \`.env.rag\` examples, including GitHub App auth alternative
- Add GitHub connector ENV vars to \`.env.rag.example\`

## Test plan

- [ ] Review \`config.yaml.example\` — GitHub connector block is commented out and all options documented
- [ ] Review README GitHub Connector section for accuracy
- [ ] Review \`.env.rag.example\` — GitHub connector ENV vars present

🤖 Generated with [Claude Code](https://claude.com/claude-code)