### PR TITLE
Add GitLab connector docs (MAIT-112)

### DIFF
--- a/.env.rag.example
+++ b/.env.rag.example
@@ -125,3 +125,7 @@ S3_ACCOUNT1_SCHEDULES=
 #ONEDRIVE1_USER_PRINCIPAL_NAME=user@your-org.onmicrosoft.com
 #ONEDRIVE1_SCHEDULES=3600
 
+# GITLAB CONNECTORS (optional):
+#GITLAB1_URL=https://gitlab.com
+#GITLAB1_TOKEN=glpat-xxxxxxxxxxxxxxxxxxxx
+#GITLAB1_SCHEDULES=3600

--- a/README.md
+++ b/README.md
@@ -468,15 +468,7 @@ ONEDRIVE1_SCHEDULES=3600
 ### GitLab Connector
 
 The GitLab connector ingests repository files and optionally issues from a GitLab project or group.
-Uses [LlamaIndex GitLab readers](https://llamahub.ai/l/readers/llama-index-readers-gitlab) for all
-discovery and content fetching. Supports both GitLab.com and self-hosted instances via a Personal
-Access Token with the `read_api` scope — it covers both the repository files and issues APIs that this
-connector uses.
-
-> **Known limitation:** `GitLabRepositoryReader.load_data()` re-downloads all repository file content on
-> every scheduled run; ROAT's vector checksum skip does not reduce GitLab API calls for the files
-> connector. This is a limitation of the underlying LlamaIndex reader, not this connector, for the
-> current iteration.
+Supports GitLab.com and self-hosted instances via a Personal Access Token with `read_api` scopes.
 
 ```yaml
 # config.yaml
@@ -485,16 +477,22 @@ sources:
   - type: "gitlab"
     name: "gitlab1"
     config:
-      gitlab_url: "${GITLAB1_URL}"        # e.g. https://gitlab.com
+      gitlab_url: "${GITLAB1_URL}"          # e.g. https://gitlab.com
       personal_token: "${GITLAB1_TOKEN}"
-      project_id: 12345678               # integer project ID; required unless group_id is set, mutually exclusive with group_id
-      #group_id: 999                     # integer group ID, for group-wide issue queries (repository files not supported in group mode); mutually exclusive with project_id
-      ref: "main"                        # optional, branch/tag/commit, default "main"
-      #path: "docs"                      # optional, limit to sub-directory
-      #file_path: "README.md"            # optional, single file only
-      recursive: true                    # optional, default true
-      files_iterator: true               # optional, use iterator pagination to fetch all files (default true); set to false to limit to 20 files (GitLab API default page size)
-      include_issues: false              # optional, default false
+      project_id: 12345678                  # integer project ID (required unless group_id only)
+      #group_id: 999                        # optional, for group-level issue queries
+      ref: "main"                           # optional, branch/tag/commit, default "main"
+      #path: "docs"                         # optional, limit to sub-directory
+      recursive: true                       # optional, default true
+      files_iterator: true                  # optional, use iterator pagination to fetch all files (default true); set to false to limit to 20 files (GitLab API default page size)
+      include_issues: false                 # optional, default false
+      #issues_state: "opened"              # optional: opened/closed/all, default "opened"
+      #issues_labels: "bug,docs"           # optional, comma-separated
+      #issues_assignee: "username"         # optional
+      #issues_author: "username"           # optional
+      #issues_milestone: "v1.0"            # optional
+      #issues_search: "keyword"            # optional
+      #issues_get_all: false               # optional, fetch all pages, default false
       schedules: "${GITLAB1_SCHEDULES}"
 
   # With issue ingestion and filters:

--- a/README.md
+++ b/README.md
@@ -478,8 +478,8 @@ sources:
     config:
       gitlab_url: "${GITLAB1_URL}"          # e.g. https://gitlab.com
       personal_token: "${GITLAB1_TOKEN}"
-      project_id: 12345678                  # integer project ID (required unless group_id only)
-      #group_id: 999                        # optional, for group-level issue queries
+      project_id: 12345678                  # integer project ID (mutually exclusive with group_id; required unless group_id is set)
+      #group_id: 999                        # optional, for group-level issue queries; mutually exclusive with project_id
       ref: "main"                           # optional, branch/tag/commit, default "main"
       #path: "docs"                         # optional, limit to sub-directory
       #file_path: "README.md"               # optional, single file only
@@ -492,7 +492,7 @@ sources:
       #issues_author: "username"           # optional
       #issues_milestone: "v1.0"            # optional
       #issues_search: "keyword"            # optional
-      #issues_get_all: false               # optional, fetch all pages, default false
+      #issues_get_all: true                # optional, fetch all pages, default true; set to false to limit to 20 issues (GitLab API default page size)
       #issues_scope: "created_by_me"       # optional: created_by_me/assigned_to_me/all
       #issues_type: "issue"                # optional: issue/incident/test_case/task
       #issues_confidential: false          # optional

--- a/README.md
+++ b/README.md
@@ -467,7 +467,7 @@ ONEDRIVE1_SCHEDULES=3600
 ### GitLab Connector
 
 The GitLab connector ingests repository files and optionally issues from a GitLab project or group.
-Supports GitLab.com and self-hosted instances via a Personal Access Token with `read_api` scopes.
+Supports GitLab.com and self-hosted instances via a Personal Access Token with `read_api` scope.
 
 ```yaml
 # config.yaml

--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ interact with your knowledge with ease!
 * SerpAPI
 * Slack
 * OneDrive for Business
+* GitHub (repository files and issues, PAT or GitHub App auth)
+* GitLab (repository files and issues, supports GitLab.com and self-hosted)
 
 ## 🌐 Extra connectors
 
@@ -52,6 +54,7 @@ Over 100 extra connectors are available at request, including the most popular o
 * Jira
 * GitHub
 * Gitlab
+* Slack
 * Notion
 * Microsoft Teams
 * Microsoft Office 365
@@ -460,6 +463,73 @@ ONEDRIVE1_CLIENT_SECRET=your-azure-app-client-secret
 ONEDRIVE1_TENANT_ID=your-azure-tenant-id
 ONEDRIVE1_USER_PRINCIPAL_NAME=user@your-org.onmicrosoft.com
 ONEDRIVE1_SCHEDULES=3600
+```
+
+### GitLab Connector
+
+The GitLab connector ingests repository files and optionally issues from a GitLab project or group.
+Uses [LlamaIndex GitLab readers](https://llamahub.ai/l/readers/llama-index-readers-gitlab) for all
+discovery and content fetching. Supports both GitLab.com and self-hosted instances via a Personal
+Access Token with the `read_api` scope — it covers both the repository files and issues APIs that this
+connector uses.
+
+> **Known limitation:** `GitLabRepositoryReader.load_data()` re-downloads all repository file content on
+> every scheduled run; ROAT's vector checksum skip does not reduce GitLab API calls for the files
+> connector. This is a limitation of the underlying LlamaIndex reader, not this connector, for the
+> current iteration.
+
+```yaml
+# config.yaml
+
+sources:
+  - type: "gitlab"
+    name: "gitlab1"
+    config:
+      gitlab_url: "${GITLAB1_URL}"        # e.g. https://gitlab.com
+      personal_token: "${GITLAB1_TOKEN}"
+      project_id: 12345678               # integer project ID; required unless group_id is set, mutually exclusive with group_id
+      #group_id: 999                     # integer group ID, for group-wide issue queries (repository files not supported in group mode); mutually exclusive with project_id
+      ref: "main"                        # optional, branch/tag/commit, default "main"
+      #path: "docs"                      # optional, limit to sub-directory
+      #file_path: "README.md"            # optional, single file only
+      recursive: true                    # optional, default true
+      files_iterator: true               # optional, use iterator pagination to fetch all files (default true); set to false to limit to 20 files (GitLab API default page size)
+      include_issues: false              # optional, default false
+      schedules: "${GITLAB1_SCHEDULES}"
+
+  # With issue ingestion and filters:
+  #- type: "gitlab"
+  #  name: "gitlab2"
+  #  config:
+  #    gitlab_url: "${GITLAB2_URL}"
+  #    personal_token: "${GITLAB2_TOKEN}"
+  #    project_id: 87654321
+  #    include_issues: true
+  #    issues_state: "opened"            # opened/closed/all, default "opened"
+  #    issues_labels: "bug,feature"      # optional, comma-separated
+  #    issues_assignee: "username"       # optional
+  #    issues_author: "username"         # optional
+  #    issues_milestone: "v2.0"          # optional
+  #    issues_search: "keyword"          # optional
+  #    issues_get_all: true              # optional, fetch all pages, default true; set to false to limit to 20 issues (GitLab API default page size)
+  #    issues_scope: "created_by_me"     # optional: created_by_me/assigned_to_me/all
+  #    issues_type: "issue"              # optional: issue/incident/test_case/task
+  #    issues_confidential: false        # optional
+  #    issues_non_archived: true         # optional
+  #    issues_iids: [1, 2, 3]            # optional, filter by specific issue IIDs; a YAML list or a comma-separated string ("1,2,3") both work
+  #    issues_created_after: "2024-01-01T00:00:00Z"   # optional, ISO-8601
+  #    issues_created_before: "2024-12-31T23:59:59Z"  # optional, ISO-8601
+  #    issues_updated_after: "2024-01-01T00:00:00Z"   # optional, ISO-8601
+  #    issues_updated_before: "2024-12-31T23:59:59Z"  # optional, ISO-8601
+  #    schedules: "${GITLAB2_SCHEDULES}"
+```
+
+```dotenv
+# .env.rag
+
+GITLAB1_URL=https://gitlab.com
+GITLAB1_TOKEN=glpat-xxxxxxxxxxxxxxxxxxxx
+GITLAB1_SCHEDULES=3600
 ```
 
 ## Single Sign-On (SSO)

--- a/README.md
+++ b/README.md
@@ -483,6 +483,7 @@ sources:
       #group_id: 999                        # optional, for group-level issue queries
       ref: "main"                           # optional, branch/tag/commit, default "main"
       #path: "docs"                         # optional, limit to sub-directory
+      #file_path: "README.md"               # optional, single file only
       recursive: true                       # optional, default true
       files_iterator: true                  # optional, use iterator pagination to fetch all files (default true); set to false to limit to 20 files (GitLab API default page size)
       include_issues: false                 # optional, default false
@@ -493,6 +494,15 @@ sources:
       #issues_milestone: "v1.0"            # optional
       #issues_search: "keyword"            # optional
       #issues_get_all: false               # optional, fetch all pages, default false
+      #issues_scope: "created_by_me"       # optional: created_by_me/assigned_to_me/all
+      #issues_type: "issue"                # optional: issue/incident/test_case/task
+      #issues_confidential: false          # optional
+      #issues_non_archived: true           # optional
+      #issues_iids: [1, 2, 3]              # optional, filter by specific issue IDs
+      #issues_created_after: "2024-01-01T00:00:00Z"   # optional, ISO-8601
+      #issues_created_before: "2024-12-31T23:59:59Z"  # optional, ISO-8601
+      #issues_updated_after: "2024-01-01T00:00:00Z"   # optional, ISO-8601
+      #issues_updated_before: "2024-12-31T23:59:59Z"  # optional, ISO-8601
       schedules: "${GITLAB1_SCHEDULES}"
 
   # With issue ingestion and filters:

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ of the `.env` file. The default ones are:
 If you did not change the `ENABLE_OPENAI_API` you will also have LLM provider
 pre-configured with the values you have in the `.env` including the default chat model
 
-Three components handle RAG service communication:
+Three components handle RAG service communication and web search integration:
 
 - **Filter function** (`functions/function.py`) — intercepts every user message and injects ROAT context automatically. Enabled globally via Admin Panel → Functions.
 - **Knowledge Base Search tool** (`tools/roat_retrieval.py`) — a Workspace Tool that lets the LLM decide when to query ROAT. Requires a model with native function calling support. Both are automatically provisioned on first boot.
@@ -478,8 +478,8 @@ sources:
     config:
       gitlab_url: "${GITLAB1_URL}"          # e.g. https://gitlab.com
       personal_token: "${GITLAB1_TOKEN}"
-      project_id: 12345678                  # integer project ID (mutually exclusive with group_id; required unless group_id is set)
-      #group_id: 999                        # optional, for group-level issue queries; mutually exclusive with project_id
+      project_id: 12345678                  # integer project ID; required for repository file ingestion
+      #group_id: 999                        # optional; does not select a repository — only used for group-level issue queries when include_issues is true; mutually exclusive with project_id for issue queries
       ref: "main"                           # optional, branch/tag/commit, default "main"
       #path: "docs"                         # optional, limit to sub-directory
       #file_path: "README.md"               # optional, single file only

--- a/README.md
+++ b/README.md
@@ -42,7 +42,6 @@ interact with your knowledge with ease!
 * SerpAPI
 * Slack
 * OneDrive for Business
-* GitHub (repository files and issues, PAT or GitHub App auth)
 * GitLab (repository files and issues, supports GitLab.com and self-hosted)
 
 ## 🌐 Extra connectors
@@ -115,7 +114,7 @@ of the `.env` file. The default ones are:
 If you did not change the `ENABLE_OPENAI_API` you will also have LLM provider
 pre-configured with the values you have in the `.env` including the default chat model
 
-Two components handle RAG service communication:
+Three components handle RAG service communication:
 
 - **Filter function** (`functions/function.py`) — intercepts every user message and injects ROAT context automatically. Enabled globally via Admin Panel → Functions.
 - **Knowledge Base Search tool** (`tools/roat_retrieval.py`) — a Workspace Tool that lets the LLM decide when to query ROAT. Requires a model with native function calling support. Both are automatically provisioned on first boot.

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -152,8 +152,8 @@ sources:
   #  config:
   #    gitlab_url: "${GITLAB1_URL}"              # e.g. https://gitlab.com
   #    personal_token: "${GITLAB1_TOKEN}"
-  #    project_id: 12345678                      # integer project ID (mutually exclusive with group_id; required unless group_id is set)
-  #    #group_id: 999                            # optional, for group-level issue queries; mutually exclusive with project_id
+  #    project_id: 12345678                      # integer project ID; required for repository file ingestion
+  #    #group_id: 999                            # optional; does not select a repository — only used for group-level issue queries when include_issues is true; mutually exclusive with project_id for issue queries
   #    ref: "main"                               # optional, branch/tag/commit, default "main"
   #    #path: "docs"                             # optional, limit to sub-directory
   #    #file_path: "README.md"                   # optional, single file only

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -158,6 +158,7 @@ sources:
   #    #path: "docs"                             # optional, limit to sub-directory
   #    #file_path: "README.md"                   # optional, single file only
   #    recursive: true                           # optional, default true
+  #    files_iterator: true                      # optional, use iterator pagination to fetch all files (default true); set to false to limit to 20 files (GitLab API default page size)
   #    include_issues: false                     # optional, default false
   #    #issues_state: "opened"                   # optional: opened/closed/all, default "opened"
   #    #issues_labels: "bug,docs"                # optional, comma-separated

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -147,6 +147,36 @@ sources:
   #    max_file_size_mb: 50              # optional, default 50; files larger than this are skipped
   #    schedules: "${ONEDRIVE1_SCHEDULES}"
 
+  #- type: "gitlab"
+  #  name: "gitlab1"
+  #  config:
+  #    gitlab_url: "${GITLAB1_URL}"              # e.g. https://gitlab.com
+  #    personal_token: "${GITLAB1_TOKEN}"
+  #    project_id: 12345678                      # integer project ID (required unless group_id only)
+  #    #group_id: 999                            # optional, for group-level issue queries
+  #    ref: "main"                               # optional, branch/tag/commit, default "main"
+  #    #path: "docs"                             # optional, limit to sub-directory
+  #    #file_path: "README.md"                   # optional, single file only
+  #    recursive: true                           # optional, default true
+  #    include_issues: false                     # optional, default false
+  #    #issues_state: "opened"                   # optional: opened/closed/all, default "opened"
+  #    #issues_labels: "bug,docs"                # optional, comma-separated
+  #    #issues_assignee: "username"              # optional
+  #    #issues_author: "username"                # optional
+  #    #issues_milestone: "v1.0"                 # optional
+  #    #issues_search: "keyword"                 # optional
+  #    #issues_get_all: false                    # optional, fetch all pages, default false
+  #    #issues_scope: "created_by_me"            # optional: created_by_me/assigned_to_me/all
+  #    #issues_type: "issue"                     # optional: issue/incident/test_case/task
+  #    #issues_confidential: false               # optional
+  #    #issues_non_archived: true                # optional
+  #    #issues_iids: [1, 2, 3]                   # optional, filter by specific issue IDs
+  #    #issues_created_after: "2024-01-01T00:00:00Z"   # optional, ISO-8601
+  #    #issues_created_before: "2024-12-31T23:59:59Z"  # optional, ISO-8601
+  #    #issues_updated_after: "2024-01-01T00:00:00Z"   # optional, ISO-8601
+  #    #issues_updated_before: "2024-12-31T23:59:59Z"  # optional, ISO-8601
+  #    schedules: "${GITLAB1_SCHEDULES}"
+
 embedding:
   # can be `local` or `openrouter`/`openai`
   provider: local

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -152,8 +152,8 @@ sources:
   #  config:
   #    gitlab_url: "${GITLAB1_URL}"              # e.g. https://gitlab.com
   #    personal_token: "${GITLAB1_TOKEN}"
-  #    project_id: 12345678                      # integer project ID (required unless group_id only)
-  #    #group_id: 999                            # optional, for group-level issue queries
+  #    project_id: 12345678                      # integer project ID (mutually exclusive with group_id; required unless group_id is set)
+  #    #group_id: 999                            # optional, for group-level issue queries; mutually exclusive with project_id
   #    ref: "main"                               # optional, branch/tag/commit, default "main"
   #    #path: "docs"                             # optional, limit to sub-directory
   #    #file_path: "README.md"                   # optional, single file only
@@ -166,7 +166,7 @@ sources:
   #    #issues_author: "username"                # optional
   #    #issues_milestone: "v1.0"                 # optional
   #    #issues_search: "keyword"                 # optional
-  #    #issues_get_all: false                    # optional, fetch all pages, default false
+  #    #issues_get_all: true                     # optional, fetch all pages, default true; set to false to limit to 20 issues (GitLab API default page size)
   #    #issues_scope: "created_by_me"            # optional: created_by_me/assigned_to_me/all
   #    #issues_type: "issue"                     # optional: issue/incident/test_case/task
   #    #issues_confidential: false               # optional

--- a/docs/connectors/gitlab-connector.mdx
+++ b/docs/connectors/gitlab-connector.mdx
@@ -39,8 +39,8 @@ sources:
     config:
       gitlab_url: "${GITLAB1_URL}"
       personal_token: "${GITLAB1_TOKEN}"
-      project_id: 12345678              # integer project ID (required unless group_id only)
-      #group_id: 999                    # optional, for group-level issue queries
+      project_id: 12345678              # integer project ID (mutually exclusive with group_id; required unless group_id is set)
+      #group_id: 999                    # optional, for group-level issue queries; mutually exclusive with project_id
       ref: "main"                       # optional, branch/tag/commit, default "main"
       #path: "docs"                     # optional, limit to sub-directory
       #file_path: "README.md"           # optional, single file only
@@ -53,7 +53,7 @@ sources:
       #issues_author: "username"        # optional
       #issues_milestone: "v1.0"         # optional
       #issues_search: "keyword"         # optional
-      #issues_get_all: false            # optional, fetch all pages, default false
+      #issues_get_all: true             # optional, fetch all pages, default true; set to false to limit to 20 issues (GitLab API default page size)
       #issues_scope: "created_by_me"    # optional: created_by_me/assigned_to_me/all
       #issues_type: "issue"             # optional: issue/incident/test_case/task
       #issues_confidential: false       # optional
@@ -81,8 +81,8 @@ GITLAB1_SCHEDULES=3600
 | `enabled` | no | `true` | Set to `false` to skip this source entirely |
 | `gitlab_url` | yes | — | Base URL of the GitLab instance |
 | `personal_token` | yes | — | Personal Access Token with `read_api` scope |
-| `project_id` | required unless `group_id` only | — | Integer project ID to ingest files (and optionally issues) from |
-| `group_id` | no | — | Group ID, for group-level issue queries |
+| `project_id` | required unless `group_id` is set | — | Integer project ID to ingest files (and optionally issues) from; mutually exclusive with `group_id` |
+| `group_id` | no | — | Group ID, for group-level issue queries; mutually exclusive with `project_id` |
 | `ref` | no | `main` | Branch, tag, or commit to read files from |
 | `path` | no | — | Limit file ingestion to a sub-directory |
 | `file_path` | no | — | Limit file ingestion to a single file |
@@ -95,7 +95,7 @@ GITLAB1_SCHEDULES=3600
 | `issues_author` | no | — | Filter by author username |
 | `issues_milestone` | no | — | Filter by milestone title |
 | `issues_search` | no | — | Free-text search filter |
-| `issues_get_all` | no | `false` | Fetch all pages of results |
+| `issues_get_all` | no | `true` | Fetch all pages of results; set `false` to limit to 20 issues (GitLab API default page size) |
 | `issues_scope` | no | — | `created_by_me`, `assigned_to_me`, or `all` |
 | `issues_type` | no | — | `issue`, `incident`, `test_case`, or `task` |
 | `issues_confidential` | no | — | Filter by confidential flag |

--- a/docs/connectors/gitlab-connector.mdx
+++ b/docs/connectors/gitlab-connector.mdx
@@ -1,0 +1,110 @@
+---
+title: "GitLab"
+description: "Configure the mAItion GitLab connector to ingest repository files and issues from GitLab into the knowledge base."
+keywords:
+  - mAItion
+  - GitLab connector
+  - GitLab ingestion
+  - connectors
+---
+
+Use the GitLab Connector to ingest repository files and, optionally, issues from a GitLab project or group into the mAItion knowledge base.
+
+## What It Does
+
+- fetches files from a GitLab project's repository at a given branch, tag, or commit
+- optionally limits ingestion to a sub-directory or a single file
+- optionally ingests issues from the project or a group, with filtering by state, labels, assignee, author, milestone, and more
+- runs ingestion on configurable schedules
+
+## Authentication
+
+Authenticate with a GitLab Personal Access Token scoped to `read_api`. Supports both GitLab.com and self-hosted GitLab instances via `gitlab_url`.
+
+## Required Environment Variables
+
+Set these in `.env.rag`:
+
+- `GITLAB1_URL`: base URL of your GitLab instance (example: `https://gitlab.com`)
+- `GITLAB1_TOKEN`: Personal Access Token with `read_api` scope
+- `GITLAB1_SCHEDULES`: ingestion interval in seconds (default: `3600`)
+
+## `config.yaml` Example
+
+```yaml
+sources:
+  - type: "gitlab"
+    name: "gitlab1"
+    enabled: true  # optional, default: true
+    config:
+      gitlab_url: "${GITLAB1_URL}"
+      personal_token: "${GITLAB1_TOKEN}"
+      project_id: 12345678              # integer project ID (required unless group_id only)
+      #group_id: 999                    # optional, for group-level issue queries
+      ref: "main"                       # optional, branch/tag/commit, default "main"
+      #path: "docs"                     # optional, limit to sub-directory
+      #file_path: "README.md"           # optional, single file only
+      recursive: true                   # optional, default true
+      files_iterator: true              # optional, use iterator pagination to fetch all files (default true); set to false to limit to 20 files (GitLab API default page size)
+      include_issues: false             # optional, default false
+      #issues_state: "opened"           # optional: opened/closed/all, default "opened"
+      #issues_labels: "bug,docs"        # optional, comma-separated
+      #issues_assignee: "username"      # optional
+      #issues_author: "username"        # optional
+      #issues_milestone: "v1.0"         # optional
+      #issues_search: "keyword"         # optional
+      #issues_get_all: false            # optional, fetch all pages, default false
+      #issues_scope: "created_by_me"    # optional: created_by_me/assigned_to_me/all
+      #issues_type: "issue"             # optional: issue/incident/test_case/task
+      #issues_confidential: false       # optional
+      #issues_non_archived: true        # optional
+      #issues_iids: [1, 2, 3]           # optional, filter by specific issue IDs
+      #issues_created_after: "2024-01-01T00:00:00Z"   # optional, ISO-8601
+      #issues_created_before: "2024-12-31T23:59:59Z"  # optional, ISO-8601
+      #issues_updated_after: "2024-01-01T00:00:00Z"   # optional, ISO-8601
+      #issues_updated_before: "2024-12-31T23:59:59Z"  # optional, ISO-8601
+      schedules: "${GITLAB1_SCHEDULES}"
+```
+
+## `.env.rag` Example
+
+```dotenv
+GITLAB1_URL=https://gitlab.com
+GITLAB1_TOKEN=glpat-xxxxxxxxxxxxxxxxxxxx
+GITLAB1_SCHEDULES=3600
+```
+
+## Configuration Reference
+
+| Field | Required | Default | Description |
+|---|---|---|---|
+| `enabled` | no | `true` | Set to `false` to skip this source entirely |
+| `gitlab_url` | yes | — | Base URL of the GitLab instance |
+| `personal_token` | yes | — | Personal Access Token with `read_api` scope |
+| `project_id` | required unless `group_id` only | — | Integer project ID to ingest files (and optionally issues) from |
+| `group_id` | no | — | Group ID, for group-level issue queries |
+| `ref` | no | `main` | Branch, tag, or commit to read files from |
+| `path` | no | — | Limit file ingestion to a sub-directory |
+| `file_path` | no | — | Limit file ingestion to a single file |
+| `recursive` | no | `true` | Recurse into sub-directories when listing repository files |
+| `files_iterator` | no | `true` | Use iterator pagination to fetch all files; set `false` to limit to 20 files (GitLab API default page size) |
+| `include_issues` | no | `false` | Set to `true` to also ingest issues |
+| `issues_state` | no | `opened` | `opened`, `closed`, or `all` |
+| `issues_labels` | no | — | Comma-separated label filter |
+| `issues_assignee` | no | — | Filter by assignee username |
+| `issues_author` | no | — | Filter by author username |
+| `issues_milestone` | no | — | Filter by milestone title |
+| `issues_search` | no | — | Free-text search filter |
+| `issues_get_all` | no | `false` | Fetch all pages of results |
+| `issues_scope` | no | — | `created_by_me`, `assigned_to_me`, or `all` |
+| `issues_type` | no | — | `issue`, `incident`, `test_case`, or `task` |
+| `issues_confidential` | no | — | Filter by confidential flag |
+| `issues_non_archived` | no | `true` | Exclude issues from archived projects |
+| `issues_iids` | no | — | List of specific issue IIDs to fetch |
+| `issues_created_after` / `issues_created_before` | no | — | ISO-8601 date bounds on issue creation |
+| `issues_updated_after` / `issues_updated_before` | no | — | ISO-8601 date bounds on issue updates |
+| `schedules` | no | `3600` | Ingestion interval in seconds |
+
+## Multiple GitLab Sources
+
+Add more `sources` entries (`gitlab2`, `gitlab3`, etc) with separate env vars per source.

--- a/docs/connectors/gitlab-connector.mdx
+++ b/docs/connectors/gitlab-connector.mdx
@@ -39,8 +39,8 @@ sources:
     config:
       gitlab_url: "${GITLAB1_URL}"
       personal_token: "${GITLAB1_TOKEN}"
-      project_id: 12345678              # integer project ID (mutually exclusive with group_id; required unless group_id is set)
-      #group_id: 999                    # optional, for group-level issue queries; mutually exclusive with project_id
+      project_id: 12345678              # integer project ID; required for repository file ingestion
+      #group_id: 999                    # optional; does not select a repository — only used for group-level issue queries when include_issues is true; mutually exclusive with project_id for issue queries
       ref: "main"                       # optional, branch/tag/commit, default "main"
       #path: "docs"                     # optional, limit to sub-directory
       #file_path: "README.md"           # optional, single file only
@@ -81,8 +81,8 @@ GITLAB1_SCHEDULES=3600
 | `enabled` | no | `true` | Set to `false` to skip this source entirely |
 | `gitlab_url` | yes | — | Base URL of the GitLab instance |
 | `personal_token` | yes | — | Personal Access Token with `read_api` scope |
-| `project_id` | required unless `group_id` is set | — | Integer project ID to ingest files (and optionally issues) from; mutually exclusive with `group_id` |
-| `group_id` | no | — | Group ID, for group-level issue queries; mutually exclusive with `project_id` |
+| `project_id` | yes | — | Integer project ID to ingest files (and optionally issues) from; required for repository file ingestion |
+| `group_id` | no | — | Group ID; does not select a repository — only used for group-level issue queries when `include_issues` is true; mutually exclusive with `project_id` for issue queries |
 | `ref` | no | `main` | Branch, tag, or commit to read files from |
 | `path` | no | — | Limit file ingestion to a sub-directory |
 | `file_path` | no | — | Limit file ingestion to a single file |

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -72,7 +72,8 @@
 							"connectors/web-connector",
 							"connectors/directory-connector",
 							"connectors/slack-connector",
-							"connectors/onedrive-connector"
+							"connectors/onedrive-connector",
+							"connectors/gitlab-connector"
 						]
 					},
 					{

--- a/docs/getting-started/index.mdx
+++ b/docs/getting-started/index.mdx
@@ -70,6 +70,9 @@ for both personal and team workflows.
 	<Card title="OneDrive" href="/connectors/onedrive-connector">
 		Ingest files from Microsoft OneDrive for Business.
 	</Card>
+	<Card title="GitLab" href="/connectors/gitlab-connector">
+		Ingest repository files and issues from GitLab.
+	</Card>
 </CardGroup>
 
 ## Who It Is For


### PR DESCRIPTION
## Summary

- Add GitLab connector section to README with full filter options documentation
- Update `config.yaml.example` with all supported issue filters: `scope`, `type`, `confidential`, `iids`, date ranges, `group_id`, `file_path`

## Related

RAG-of-all-trades PR: https://github.com/WikiTeq/rag-of-all-trades/pull/26

## Test plan

- [ ] Review README GitLab section for accuracy and completeness
- [ ] Review config.yaml.example for all filter options

🤖 Generated with [Claude Code](https://claude.com/claude-code)