### PR TITLE
Fix login page meta tags showing Open WebUI instead of mAItion (MAIT-134)

### DIFF
--- a/patches/branding.patch
+++ b/patches/branding.patch
@@ -336,3 +336,39 @@ index 0310014cf..97a891dff 100644
          )
      finally:
          if not streaming and session:
+
+diff --git build/index.html build/index.html
+--- build/index.html
++++ build/index.html
+@@ -7,7 +7,7 @@
+ 		<link rel="icon" type="image/svg+xml" href="/static/favicon.svg" />
+ 		<link rel="shortcut icon" href="/static/favicon.ico" />
+ 		<link rel="apple-touch-icon" sizes="180x180" href="/static/apple-touch-icon.png" />
+-		<meta name="apple-mobile-web-app-title" content="Open WebUI" />
++		<meta name="apple-mobile-web-app-title" content="mAItion" />
+ 
+ 		<link rel="manifest" href="/manifest.json" crossorigin="use-credentials" />
+ 		<meta
+@@ -16,11 +16,11 @@
+ 		/>
+ 		<meta name="theme-color" content="#171717" />
+ 		<meta name="robots" content="noindex,nofollow" />
+-		<meta name="description" content="Open WebUI" />
++		<meta name="description" content="mAItion" />
+ 		<link
+ 			rel="search"
+ 			type="application/opensearchdescription+xml"
+-			title="Open WebUI"
++			title="mAItion"
+ 			href="/opensearch.xml"
+ 		/>
+ 		<script src="/static/loader.js" defer></script>
+@@ -101,7 +101,7 @@
+ 			})();
+ 		</script>
+ 
+-		<title>Open WebUI</title>
++		<title>mAItion</title>
+ 
+ 		
+ 		<link rel="modulepreload" href="/_app/immutable/entry/start.EK3-Hvgz.js">


### PR DESCRIPTION
## Summary

- Added a new hunk to `patches/branding.patch` targeting `build/index.html`
- Replaces `Open WebUI` with `mAItion` in four tags on the login page: `<title>`, `<meta name="description">`, `<meta name="apple-mobile-web-app-title">`, and `<link rel="search" title>`

## Verification

```bash
curl -s localhost:3000 | grep 'mAItion'
```

Output:
```
<meta name="apple-mobile-web-app-title" content="mAItion" />
<meta name="description" content="mAItion" />
        title="mAItion"
<title>mAItion</title>
```

## Test plan

- [ ] Run `docker compose up -d --build` in mAItion repo
- [ ] Run `curl -s localhost:3000 | grep 'mAItion'` and confirm all 4 tags show `mAItion`
- [ ] Confirm browser tab shows `mAItion` on the login page

🤖 Generated with [Claude Code](https://claude.com/claude-code)