### PR TITLE
MAIT-106: Add web scraper connector docs

### DIFF
--- a/.env.rag.example
+++ b/.env.rag.example
@@ -66,3 +66,7 @@ S3_ACCOUNT1_SCHEDULES=
 #SERPAPI_KEY=your-serpapi-api-key
 #SERPAPI_QUERIES="OpenAI news, Bitcoin price, Tesla updates"
 #SERPAPI_SCHEDULES=60
+
+# WEB CONNECTORS (optional):
+#WEB1_SCHEDULES=60
+#WEB2_SCHEDULES=60

--- a/.env.rag.example
+++ b/.env.rag.example
@@ -68,5 +68,8 @@ S3_ACCOUNT1_SCHEDULES=
 #SERPAPI_SCHEDULES=60
 
 # WEB CONNECTORS (optional):
+#WEB1_URLS=https://example.com/page1,https://example.com/page2
 #WEB1_SCHEDULES=60
+#WEB2_SITEMAP_URL=https://example.com/sitemap.xml
+#WEB2_INCLUDE_PREFIX=/blog/
 #WEB2_SCHEDULES=60

--- a/README.md
+++ b/README.md
@@ -243,9 +243,7 @@ sources:
   - type: "web"
     name: "web1"
     config:
-      urls:
-        - "https://example.com/page1"
-        - "https://example.com/page2"
+      urls: "${WEB1_URLS}"
       html_to_text: true
       schedules: "${WEB1_SCHEDULES}"
 
@@ -253,8 +251,8 @@ sources:
   - type: "web"
     name: "web2"
     config:
-      sitemap_url: "https://example.com/sitemap.xml"
-      include_prefix: "/blog/"
+      sitemap_url: "${WEB2_SITEMAP_URL}"
+      include_prefix: "${WEB2_INCLUDE_PREFIX}"
       html_to_text: true
       schedules: "${WEB2_SCHEDULES}"
 ```
@@ -262,7 +260,10 @@ sources:
 ```dotenv
 # .env.rag
 
+WEB1_URLS=https://example.com/page1,https://example.com/page2
 WEB1_SCHEDULES=60
+WEB2_SITEMAP_URL=https://example.com/sitemap.xml
+WEB2_INCLUDE_PREFIX=/blog/
 WEB2_SCHEDULES=60
 ```
 

--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ Over 100 extra connectors are available at request, including the most popular o
 * Microsoft Office 365
 * Dropbox
 * Trello
+* Web scraper
 * YouTube
 * FTP
 * SCP
@@ -227,6 +228,43 @@ SERPAPI1_KEY=xxxx
 SERPAPI1_QUERIES=aaa
 SERPAPI1_SCHEDULES=3600
 ````
+
+### Web Connector
+
+The Web connector ingests content from web pages. It supports two mutually exclusive modes:
+- **URLs mode**: scrapes a fixed list of URLs
+- **Sitemap mode**: discovers URLs from a `sitemap.xml` with optional `include_prefix` filter
+
+```yaml
+# config.yaml
+
+sources:
+  # URLs mode
+  - type: "web"
+    name: "web1"
+    config:
+      urls:
+        - "https://example.com/page1"
+        - "https://example.com/page2"
+      html_to_text: true
+      schedules: "${WEB1_SCHEDULES}"
+
+  # Sitemap mode
+  - type: "web"
+    name: "web2"
+    config:
+      sitemap_url: "https://example.com/sitemap.xml"
+      include_prefix: "/blog/"
+      html_to_text: true
+      schedules: "${WEB2_SCHEDULES}"
+```
+
+```dotenv
+# .env.rag
+
+WEB1_SCHEDULES=60
+WEB2_SCHEDULES=60
+```
 
 ## Embeddings and Inference
 

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -40,6 +40,25 @@ sources:
   #    queries: "${SERPAPI_QUERIES}"
   #    schedules: "${SERPAPI_SCHEDULES}"
 
+  # Web scraper — URLs mode
+  #- type: "web"
+  #  name: "web1"
+  #  config:
+  #    urls:
+  #      - "https://example.com/page1"
+  #      - "https://example.com/page2"
+  #    html_to_text: true
+  #    schedules: "${WEB1_SCHEDULES}"
+
+  # Web scraper — sitemap mode
+  #- type: "web"
+  #  name: "web2"
+  #  config:
+  #    sitemap_url: "https://example.com/sitemap.xml"
+  #    include_prefix: "/blog/"
+  #    html_to_text: true
+  #    schedules: "${WEB2_SCHEDULES}"
+
 embedding:
   # can be `local` or `openrouter`/`openai`
   provider: local

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -44,9 +44,7 @@ sources:
   #- type: "web"
   #  name: "web1"
   #  config:
-  #    urls:
-  #      - "https://example.com/page1"
-  #      - "https://example.com/page2"
+  #    urls: "${WEB1_URLS}"
   #    html_to_text: true
   #    schedules: "${WEB1_SCHEDULES}"
 
@@ -54,8 +52,8 @@ sources:
   #- type: "web"
   #  name: "web2"
   #  config:
-  #    sitemap_url: "https://example.com/sitemap.xml"
-  #    include_prefix: "/blog/"
+  #    sitemap_url: "${WEB2_SITEMAP_URL}"
+  #    include_prefix: "${WEB2_INCLUDE_PREFIX}"
   #    html_to_text: true
   #    schedules: "${WEB2_SCHEDULES}"
 


### PR DESCRIPTION
## Summary

- Adds Web scraper connector documentation to README
- Adds `config.yaml.example` entries for both URLs and sitemap modes
- Adds `.env.rag.example` entries for `WEB1_SCHEDULES` and `WEB2_SCHEDULES`

Related: WikiTeq/rag-of-all-trades#31

🤖 Generated with [Claude Code](https://claude.com/claude-code)