### PR TITLE
MAIT-121: Add Outlook connector config and docs

### DIFF
--- a/.env.rag.example
+++ b/.env.rag.example
@@ -118,6 +118,8 @@ S3_ACCOUNT1_SCHEDULES=
 #IMAP1_SCHEDULES=3600
 
 # OUTLOOK CONNECTORS (optional):
+# Note: Mail.Read app permission grants access to every mailbox in the tenant by default;
+# restrict with RBAC for Applications in Exchange Online
 #OUTLOOK1_CLIENT_ID=your-azure-app-client-id
 #OUTLOOK1_CLIENT_SECRET=your-azure-app-client-secret
 #OUTLOOK1_TENANT_ID=your-azure-tenant-id

--- a/.env.rag.example
+++ b/.env.rag.example
@@ -116,3 +116,10 @@ S3_ACCOUNT1_SCHEDULES=
 #IMAP1_PASSWORD=your-app-password
 #IMAP1_MAILBOXES=INBOX,Sent
 #IMAP1_SCHEDULES=3600
+
+# OUTLOOK CONNECTORS (optional):
+#OUTLOOK1_CLIENT_ID=your-azure-app-client-id
+#OUTLOOK1_CLIENT_SECRET=your-azure-app-client-secret
+#OUTLOOK1_TENANT_ID=your-azure-tenant-id
+#OUTLOOK1_USER_EMAIL=user@company.onmicrosoft.com
+#OUTLOOK1_SCHEDULES=3600

--- a/README.md
+++ b/README.md
@@ -428,6 +428,12 @@ Authenticates directly against Microsoft Entra ID using the OAuth2 client creden
 > **Note:** Client credentials authentication (app-only flow) is only supported for
 > **Microsoft 365 / Entra ID work or school accounts**. Personal Microsoft accounts are not supported.
 > Requires an Azure app registration with `Mail.Read` application permission and admin consent.
+>
+> **Warning:** `Mail.Read` application permission grants access to **every mailbox in the
+> tenant** by default — `user_email` only selects which mailbox this connector queries, it does
+> not restrict what the app registration can reach. Scope access to specific mailboxes with
+> [RBAC for Applications in Exchange Online](https://learn.microsoft.com/en-us/graph/auth-limit-mailbox-access)
+> (the successor to the older Application Access Policy mechanism).
 
 ```yaml
 # config.yaml

--- a/README.md
+++ b/README.md
@@ -419,6 +419,43 @@ IMAP1_MAILBOXES=INBOX,Sent
 IMAP1_SCHEDULES=3600
 ```
 
+### Outlook Connector
+
+The Outlook connector ingests emails from a Microsoft 365 mailbox via the Microsoft Graph API.
+Authenticates directly against Microsoft Entra ID using the OAuth2 client credentials flow
+(app-only, non-interactive) and fetches messages via Graph.
+
+> **Note:** Client credentials authentication (app-only flow) is only supported for
+> **Microsoft 365 / Entra ID work or school accounts**. Personal Microsoft accounts are not supported.
+> Requires an Azure app registration with `Mail.Read` application permission and admin consent.
+
+```yaml
+# config.yaml
+
+sources:
+  - type: "outlook"
+    name: "outlook1"
+    config:
+      client_id: "${OUTLOOK1_CLIENT_ID}"
+      client_secret: "${OUTLOOK1_CLIENT_SECRET}"
+      tenant_id: "${OUTLOOK1_TENANT_ID}"
+      user_email: "${OUTLOOK1_USER_EMAIL}"
+      folder: "Inbox"           # optional, default Inbox; custom display names are resolved automatically
+      num_mails: 100            # optional, default 10
+      html_to_text: true        # optional, default true; set to false to keep raw HTML email bodies
+      schedules: "${OUTLOOK1_SCHEDULES}"
+```
+
+```dotenv
+# .env.rag
+
+OUTLOOK1_CLIENT_ID=your-azure-app-client-id
+OUTLOOK1_CLIENT_SECRET=your-azure-app-client-secret
+OUTLOOK1_TENANT_ID=your-azure-tenant-id
+OUTLOOK1_USER_EMAIL=user@company.onmicrosoft.com
+OUTLOOK1_SCHEDULES=3600
+```
+
 ## Single Sign-On (SSO)
 
 mAItion inherits full SSO support from OpenWebUI. SSO is disabled by default and configured

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -134,6 +134,8 @@ sources:
   #- type: "outlook"
   #  name: "outlook1"
   #  config:
+  #    # Mail.Read app permission grants access to every mailbox in the tenant by default;
+  #    # restrict with RBAC for Applications in Exchange Online
   #    client_id: "${OUTLOOK1_CLIENT_ID}"
   #    client_secret: "${OUTLOOK1_CLIENT_SECRET}"
   #    tenant_id: "${OUTLOOK1_TENANT_ID}"

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -131,6 +131,17 @@ sources:
   #    # use_starttls: false             # optional, default false; STARTTLS instead of implicit TLS
   #    schedules: "${IMAP1_SCHEDULES}"
 
+  #- type: "outlook"
+  #  name: "outlook1"
+  #  config:
+  #    client_id: "${OUTLOOK1_CLIENT_ID}"
+  #    client_secret: "${OUTLOOK1_CLIENT_SECRET}"
+  #    tenant_id: "${OUTLOOK1_TENANT_ID}"
+  #    user_email: "${OUTLOOK1_USER_EMAIL}"
+  #    folder: "Inbox"           # optional, default Inbox; display names like "My Folder" are supported
+  #    num_mails: 100            # optional, default 10
+  #    schedules: "${OUTLOOK1_SCHEDULES}"
+
 embedding:
   # can be `local` or `openrouter`/`openai`
   provider: local

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -140,6 +140,7 @@ sources:
   #    user_email: "${OUTLOOK1_USER_EMAIL}"
   #    folder: "Inbox"           # optional, default Inbox; display names like "My Folder" are supported
   #    num_mails: 100            # optional, default 10
+  #    html_to_text: true        # optional, default true; set to false to keep raw HTML email bodies
   #    schedules: "${OUTLOOK1_SCHEDULES}"
 
 embedding:

--- a/docs/connectors/outlook-connector.mdx
+++ b/docs/connectors/outlook-connector.mdx
@@ -1,0 +1,82 @@
+---
+title: "Outlook"
+description: "Configure the mAItion Outlook connector to ingest emails from a Microsoft 365 mailbox into the knowledge base."
+keywords:
+  - mAItion
+  - Outlook connector
+  - Microsoft Graph
+  - connectors
+  - ingestion
+---
+
+Use the Outlook Connector to ingest emails from a Microsoft 365 mailbox via the [Microsoft Graph API](https://learn.microsoft.com/en-us/graph/overview) into the mAItion knowledge base.
+
+## What It Does
+
+- fetches emails from a configurable mail folder in a Microsoft 365 mailbox
+- authenticates directly against Microsoft Entra ID using the OAuth2 client credentials flow (app-only, non-interactive)
+- converts HTML email bodies to Markdown for indexing
+- runs ingestion on configurable schedules
+
+## Authentication
+
+Only the client credentials flow (app-only) is supported. This requires:
+
+- An Azure app registration with the `Mail.Read` **application** permission and admin consent granted.
+- A **Microsoft 365 / Entra ID work or school account** mailbox. Personal Microsoft accounts are not supported — client credentials flow is not available for them.
+
+## Required Environment Variables
+
+Set these in `.env.rag`:
+
+- `OUTLOOK1_CLIENT_ID`: Azure app registration client ID
+- `OUTLOOK1_CLIENT_SECRET`: Azure app registration client secret
+- `OUTLOOK1_TENANT_ID`: Azure tenant / directory ID
+- `OUTLOOK1_USER_EMAIL`: mailbox owner email address (example: `user@company.onmicrosoft.com`)
+- `OUTLOOK1_SCHEDULES`: ingestion interval in seconds (default is `3600`)
+
+## `config.yaml` Example
+
+```yaml
+sources:
+  - type: "outlook"
+    name: "outlook1"
+    enabled: true  # optional, default: true
+    config:
+      client_id: "${OUTLOOK1_CLIENT_ID}"
+      client_secret: "${OUTLOOK1_CLIENT_SECRET}"
+      tenant_id: "${OUTLOOK1_TENANT_ID}"
+      user_email: "${OUTLOOK1_USER_EMAIL}"
+      folder: "Inbox"           # optional, default Inbox; custom display names are resolved automatically
+      num_mails: 100            # optional, default 10
+      html_to_text: true        # optional, default true; set to false to keep raw HTML email bodies
+      schedules: "${OUTLOOK1_SCHEDULES}"
+```
+
+## `.env.rag` Example
+
+```dotenv
+OUTLOOK1_CLIENT_ID=your-azure-app-client-id
+OUTLOOK1_CLIENT_SECRET=your-azure-app-client-secret
+OUTLOOK1_TENANT_ID=your-azure-tenant-id
+OUTLOOK1_USER_EMAIL=user@company.onmicrosoft.com
+OUTLOOK1_SCHEDULES=3600
+```
+
+## Configuration Reference
+
+| Field | Required | Default | Description |
+|---|---|---|---|
+| `enabled` | no | `true` | Set to `false` to skip this source entirely |
+| `client_id` | yes | — | Azure app registration client ID |
+| `client_secret` | yes | — | Azure app registration client secret |
+| `tenant_id` | yes | — | Azure tenant / directory ID |
+| `user_email` | yes | — | Mailbox owner email address |
+| `folder` | no | `Inbox` | Mail folder to ingest. Well-known folder names (e.g. `Inbox`, `SentItems`) are used directly; custom display names are resolved automatically |
+| `num_mails` | no | `10` | Maximum number of emails to fetch |
+| `html_to_text` | no | `true` | Convert HTML email bodies to Markdown; set to `false` to keep raw HTML |
+| `schedules` | no | `3600` | Ingestion interval in seconds |
+
+## Multiple Outlook Sources
+
+Add more `sources` entries (`outlook2`, `outlook3`, etc) with separate env vars per source.

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -71,7 +71,8 @@
 							"connectors/pipedrive-connector",
 							"connectors/web-connector",
 							"connectors/directory-connector",
-							"connectors/slack-connector"
+							"connectors/slack-connector",
+							"connectors/outlook-connector"
 						]
 					},
 					{

--- a/docs/getting-started/index.mdx
+++ b/docs/getting-started/index.mdx
@@ -67,6 +67,9 @@ for both personal and team workflows.
 	<Card title="Slack" href="/connectors/slack-connector">
 		Ingest channel messages and thread replies from Slack.
 	</Card>
+	<Card title="Outlook" href="/connectors/outlook-connector">
+		Ingest emails from a Microsoft 365 mailbox via Microsoft Graph.
+	</Card>
 </CardGroup>
 
 ## Who It Is For


### PR DESCRIPTION
## Summary

Adds platform config and documentation for the Outlook connector.

- `config.yaml.example` / `.env.rag.example` — Outlook source block and env vars
- `README.md` — Outlook Connector section, plus a fix for a merge issue that had dropped Slack's config/env examples
- Docs — new Outlook connector page, nav entry, and connector card
- Added a note that `Mail.Read` grants access to every mailbox in the tenant by default, with the correct way to restrict it