### PR TITLE
Add Jira connector docs to examples and README (MAIT-188)

### DIFF
--- a/.env.rag.example
+++ b/.env.rag.example
@@ -79,3 +79,10 @@ S3_ACCOUNT1_SCHEDULES=
 #WEB2_SITEMAP_URL=https://example.com/sitemap.xml
 #WEB2_INCLUDE_PREFIX=/blog/
 #WEB2_SCHEDULES=60
+
+# JIRA CONNECTORS (optional):
+#JIRA1_SERVER_URL=https://your-org.atlassian.net
+#JIRA1_EMAIL=your-email@example.com
+#JIRA1_API_TOKEN=your-api-token
+#JIRA1_JQL=project = MYPROJECT ORDER BY updated DESC
+#JIRA1_SCHEDULES=3600

--- a/README.md
+++ b/README.md
@@ -274,7 +274,7 @@ WEB2_SCHEDULES=60
 ### Jira Connector
 
 The Jira connector ingests issues from Jira Cloud or Jira Server/Data Center.
-It supports two authentication modes: basic auth (email + API token, for Jira Cloud) and token auth (Personal Access Token, for Jira Server/Data Center).
+It supports two authentication modes: `basic` (email + API token) and `token` (Personal Access Token / PAT).
 
 ```yaml
 # config.yaml
@@ -284,7 +284,7 @@ sources:
     name: "jira1"
     config:
       server_url: "${JIRA1_SERVER_URL}"
-      auth_type: "basic"        # "basic" for Jira Cloud, "token" for Jira Server/Data Center
+      auth_type: "basic"        # "basic" (email + API token) or "token" (PAT)
       email: "${JIRA1_EMAIL}"   # required when auth_type is "basic"
       api_token: "${JIRA1_API_TOKEN}"
       jql: "${JIRA1_JQL}"       # JQL query to select issues

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 ![mAItion](https://github.com/WikiTeq/mAItion/blob/main/mAItion.png?raw=true)
 
-mAItion is an all-in-one ready-to-use AI-powered tool that combines your existing knowledge with LLMs, 
+mAItion is an all-in-one ready-to-use AI-powered tool that combines your existing knowledge with LLMs,
 allowing you to chat, search and interact with your data through a slick chat interface. With mAItion
-you can aggregate all your knowledge from many sources using Connectors into a central place and 
+you can aggregate all your knowledge from many sources using Connectors into a central place and
 interact with your knowledge with ease!
 
 ## ✨ Features
@@ -33,13 +33,13 @@ interact with your knowledge with ease!
 * A tool to find secret knowledge that can not be found in the other was across your scattered data
 * An entry-point into your on-premise hosted LLM models supporting evaluations and per-model settings
 
-### 🌐 Connectors included
+## 🌐 Connectors included
 
 * S3 (any AWS compatible Object Storage including AWS, Contabo, B2, Cloudflare R2, OVH, etc)
 * MediaWiki (all versions supported, both private and public wiki)
 * SerpAPI
 
-### 🌐 Extra connectors
+## 🌐 Extra connectors
 
 Over 100 extra connectors are available at request, including the most popular ones:
 
@@ -77,8 +77,8 @@ Over 100 extra connectors are available at request, including the most popular o
 * Create `config.yaml` out of `config.yaml.example`
     * The default config works OK and is configured to:
         * Use a single S3 bucket as data source
-        * Use `openai/gpt-oss-20b:free` [model](https://openrouter.ai/openai/gpt-oss-20b:free) for rerphrase
-        * User local `sentence-transformers/all-mpnet-base-v2` [model](https://huggingface.co/sentence-transformers/all-mpnet-base-v2) for embeddings
+        * Use `openai/gpt-oss-20b:free` [model](https://openrouter.ai/openai/gpt-oss-20b:free) for rephrase
+        * Use local `sentence-transformers/all-mpnet-base-v2` [model](https://huggingface.co/sentence-transformers/all-mpnet-base-v2) for embeddings
         * You can change the values if necessary, refer to https://github.com/wikiteq/rag-of-all-trades for details
 * Create `.env` file by copying `.env.openwebui.example`
     * Set `OPENAI_API_KEY`
@@ -127,7 +127,6 @@ The connector has the following configuration options:
 # config.yaml
 
 sources:
-  - 
   - type: "s3" # must be s3
     name: "account1" # arbitrary name for the connector, will be stored in metadata
     config:
@@ -138,7 +137,7 @@ sources:
       use_ssl: "${S3_ACCOUNT1_USE_SSL}" # use ssl for s3 connection, can be True or False
       buckets: "${S3_ACCOUNT1_BUCKETS}" # single entry or comma-separated list i.e. bucket1,bucket2
       schedules: "${S3_ACCOUNT1_SCHEDULES}" # single entry or comma-separated list i.e. 3600,60
-      
+
   - type: "s3"
     name: "account2"
     config:
@@ -150,7 +149,7 @@ sources:
       ...
 ```
 
-````dotenv
+```dotenv
 # .env.rag
 
 S3_ACCOUNT1_ENDPOINT=https://s3.amazonaws.com
@@ -160,7 +159,7 @@ S3_ACCOUNT1_REGION=us-east-1
 S3_ACCOUNT1_USE_SSL=True
 S3_ACCOUNT1_BUCKETS=bucket1,bucket2
 S3_ACCOUNT1_SCHEDULES=3600,60
-````
+```
 
 ### MediaWiki Connector
 
@@ -199,7 +198,7 @@ MEDIAWIKI1_SCHEDULES=3600
 # Only needed for private wikis requiring login:
 #MEDIAWIKI1_USERNAME=your-bot-username
 #MEDIAWIKI1_PASSWORD=your-bot-password
-````
+```
 
 ### SerpAPI Connector
 
@@ -232,7 +231,7 @@ sources:
 SERPAPI1_KEY=xxxx
 SERPAPI1_QUERIES=aaa
 SERPAPI1_SCHEDULES=3600
-````
+```
 
 ### Web Connector
 
@@ -270,6 +269,39 @@ WEB1_SCHEDULES=60
 WEB2_SITEMAP_URL=https://example.com/sitemap.xml
 WEB2_INCLUDE_PREFIX=/blog/
 WEB2_SCHEDULES=60
+```
+
+### Jira Connector
+
+The Jira connector ingests issues from Jira Cloud or Jira Server/Data Center.
+It supports two authentication modes: basic auth (email + API token, for Jira Cloud) and token auth (Personal Access Token, for Jira Server/Data Center).
+
+```yaml
+# config.yaml
+
+sources:
+  - type: "jira"
+    name: "jira1"
+    config:
+      server_url: "${JIRA1_SERVER_URL}"
+      auth_type: "basic"        # "basic" for Jira Cloud, "token" for Jira Server/Data Center
+      email: "${JIRA1_EMAIL}"   # required when auth_type is "basic"
+      api_token: "${JIRA1_API_TOKEN}"
+      jql: "${JIRA1_JQL}"       # JQL query to select issues
+      max_results: 50
+      load_comments: false
+      max_comments: 10
+      schedules: "${JIRA1_SCHEDULES}"
+```
+
+```dotenv
+# .env.rag
+
+JIRA1_SERVER_URL=https://your-org.atlassian.net
+JIRA1_EMAIL=your-email@example.com
+JIRA1_API_TOKEN=your-api-token
+JIRA1_JQL=project = MYPROJECT ORDER BY updated DESC
+JIRA1_SCHEDULES=3600
 ```
 
 ## Embeddings and Inference

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -64,6 +64,20 @@ sources:
   #    html_to_text: true
   #    schedules: "${WEB2_SCHEDULES}"
 
+  # Jira connector (basic auth for Jira Cloud; use auth_type: token for Jira Server/Data Center)
+  #- type: "jira"
+  #  name: "jira1"
+  #  config:
+  #    server_url: "${JIRA1_SERVER_URL}"
+  #    auth_type: "basic"
+  #    email: "${JIRA1_EMAIL}"
+  #    api_token: "${JIRA1_API_TOKEN}"
+  #    jql: "${JIRA1_JQL}"
+  #    max_results: 50
+  #    load_comments: false
+  #    max_comments: 10
+  #    schedules: "${JIRA1_SCHEDULES}"
+
 embedding:
   # can be `local` or `openrouter`/`openai`
   provider: local

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -64,7 +64,7 @@ sources:
   #    html_to_text: true
   #    schedules: "${WEB2_SCHEDULES}"
 
-  # Jira connector (basic auth for Jira Cloud; use auth_type: token for Jira Server/Data Center)
+  # Jira connector (auth_type: "basic" = email + API token; "token" = Personal Access Token / PAT)
   #- type: "jira"
   #  name: "jira1"
   #  config:


### PR DESCRIPTION
## Summary

- Added `JIRA1_*` env var examples (commented out) to `.env.rag.example`
- Added commented-out Jira source block to `config.yaml.example`
- Added "Jira Connector" section to `README.md` under "Connectors configuration"
- Fixed README.md code fence inconsistencies (normalized to 3 backticks) and removed a duplicate `s3` list entry

## Test plan

- [ ] Verify `.env.rag.example` Jira section matches the `rag-of-all-trades` Jira connector env var names
- [ ] Verify `config.yaml.example` Jira block fields match the connector implementation
- [ ] Review README.md Jira Connector section for accuracy and formatting

🤖 Generated with [Claude Code](https://claude.com/claude-code)