### PR TITLE
Add Jira connector to homepage connectors block (WIK-2401)

### DIFF
--- a/docs/getting-started/index.mdx
+++ b/docs/getting-started/index.mdx
@@ -55,6 +55,9 @@ for both personal and team workflows.
 	<Card title="Web" href="/connectors/web-connector">
 		Ingest content from web pages and sitemaps.
 	</Card>
+	<Card title="Jira" href="/connectors/jira-connector">
+		Ingest issues and projects from Jira.
+	</Card>
 </CardGroup>
 
 ## Who It Is For


### PR DESCRIPTION
## Summary
- Adds Jira connector card to the connectors section on the homepage (`docs/getting-started/index.mdx`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)