### PR TITLE
MAIT-120: Add Microsoft OneDrive for Business connector docs and config

### DIFF
--- a/.env.rag.example
+++ b/.env.rag.example
@@ -84,6 +84,7 @@ S3_ACCOUNT1_SCHEDULES=
 #SERPAPI_SCHEDULES=60
 
 # WEB CONNECTORS (optional):
+
 #WEB1_URLS=https://example.com/page1,https://example.com/page2
 #WEB1_SCHEDULES=60
 #WEB2_SITEMAP_URL=https://example.com/sitemap.xml
@@ -116,3 +117,11 @@ S3_ACCOUNT1_SCHEDULES=
 #IMAP1_PASSWORD=your-app-password
 #IMAP1_MAILBOXES=INBOX,Sent
 #IMAP1_SCHEDULES=3600
+
+# ONEDRIVE CONNECTORS (optional):
+#ONEDRIVE1_CLIENT_ID=your-azure-app-client-id
+#ONEDRIVE1_CLIENT_SECRET=your-azure-app-client-secret
+#ONEDRIVE1_TENANT_ID=your-azure-tenant-id
+#ONEDRIVE1_USER_PRINCIPAL_NAME=user@your-org.onmicrosoft.com
+#ONEDRIVE1_SCHEDULES=3600
+

--- a/README.md
+++ b/README.md
@@ -428,6 +428,9 @@ paths. Recursive subfolder traversal and MIME type filtering are supported.
 
 > **Note:** Only OneDrive for Business is supported. OneDrive Personal accounts are not supported.
 
+The Azure app registration needs the **application** permission `Files.Read.All` with admin consent
+granted. Without it, Graph API calls fail with a 403 error.
+
 ```yaml
 # config.yaml
 
@@ -445,6 +448,7 @@ sources:
       file_paths:                       # optional: comma-separated file paths
       mime_types:                       # optional: comma-separated MIME types to filter
       recursive: true                   # optional, default true
+      max_file_size_mb: 50              # optional, default 50; files larger than this are skipped
       schedules: "${ONEDRIVE1_SCHEDULES}"
 ```
 

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ interact with your knowledge with ease!
 * MediaWiki (all versions supported, both private and public wiki)
 * SerpAPI
 * Slack
+* OneDrive for Business
 
 ## 🌐 Extra connectors
 
@@ -417,6 +418,44 @@ IMAP1_USERNAME=user@example.com
 IMAP1_PASSWORD=your-app-password
 IMAP1_MAILBOXES=INBOX,Sent
 IMAP1_SCHEDULES=3600
+```
+
+### OneDrive Connector
+
+The OneDrive connector ingests files from Microsoft OneDrive for Business (Microsoft 365) using App
+authentication (client credentials). Files can be selected by folder ID, folder path, file IDs, or file
+paths. Recursive subfolder traversal and MIME type filtering are supported.
+
+> **Note:** Only OneDrive for Business is supported. OneDrive Personal accounts are not supported.
+
+```yaml
+# config.yaml
+
+sources:
+  - type: "onedrive"
+    name: "onedrive1"
+    config:
+      client_id: "${ONEDRIVE1_CLIENT_ID}"
+      client_secret: "${ONEDRIVE1_CLIENT_SECRET}"
+      tenant_id: "${ONEDRIVE1_TENANT_ID}"
+      userprincipalname: "${ONEDRIVE1_USER_PRINCIPAL_NAME}"
+      folder_path: "Documents/Reports"  # optional: hardcode directly in config
+      folder_id:                        # optional: OneDrive folder ID
+      file_ids:                         # optional: comma-separated file IDs
+      file_paths:                       # optional: comma-separated file paths
+      mime_types:                       # optional: comma-separated MIME types to filter
+      recursive: true                   # optional, default true
+      schedules: "${ONEDRIVE1_SCHEDULES}"
+```
+
+```dotenv
+# .env.rag
+
+ONEDRIVE1_CLIENT_ID=your-azure-app-client-id
+ONEDRIVE1_CLIENT_SECRET=your-azure-app-client-secret
+ONEDRIVE1_TENANT_ID=your-azure-tenant-id
+ONEDRIVE1_USER_PRINCIPAL_NAME=user@your-org.onmicrosoft.com
+ONEDRIVE1_SCHEDULES=3600
 ```
 
 ## Single Sign-On (SSO)

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -131,6 +131,21 @@ sources:
   #    # use_starttls: false             # optional, default false; STARTTLS instead of implicit TLS
   #    schedules: "${IMAP1_SCHEDULES}"
 
+  #- type: "onedrive"
+  #  name: "onedrive1"
+  #  config:
+  #    client_id: "${ONEDRIVE1_CLIENT_ID}"
+  #    client_secret: "${ONEDRIVE1_CLIENT_SECRET}"
+  #    tenant_id: "${ONEDRIVE1_TENANT_ID}"
+  #    userprincipalname: "${ONEDRIVE1_USER_PRINCIPAL_NAME}"
+  #    folder_path: "Documents/Reports"  # optional: relative folder path
+  #    folder_id:                        # optional: OneDrive folder ID
+  #    file_ids:                         # optional: comma-separated file IDs
+  #    file_paths:                       # optional: comma-separated file paths
+  #    mime_types:                       # optional: comma-separated MIME types to filter
+  #    recursive: true                   # optional, default true
+  #    schedules: "${ONEDRIVE1_SCHEDULES}"
+
 embedding:
   # can be `local` or `openrouter`/`openai`
   provider: local

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -144,6 +144,7 @@ sources:
   #    file_paths:                       # optional: comma-separated file paths
   #    mime_types:                       # optional: comma-separated MIME types to filter
   #    recursive: true                   # optional, default true
+  #    max_file_size_mb: 50              # optional, default 50; files larger than this are skipped
   #    schedules: "${ONEDRIVE1_SCHEDULES}"
 
 embedding:

--- a/docs/connectors/onedrive-connector.mdx
+++ b/docs/connectors/onedrive-connector.mdx
@@ -1,0 +1,92 @@
+---
+title: "OneDrive"
+description: "Configure the mAItion OneDrive connector to ingest files from Microsoft OneDrive for Business."
+keywords:
+  - mAItion
+  - OneDrive connector
+  - Microsoft 365
+  - connectors
+  - ingestion
+---
+
+Use the OneDrive Connector to ingest files from [Microsoft OneDrive for Business](https://www.microsoft.com/en-us/microsoft-365/onedrive/online-cloud-storage) (Microsoft 365) into the mAItion knowledge base.
+
+## What It Does
+
+- discovers files via the Microsoft Graph API by folder ID, folder path, file IDs, file paths, or the whole drive
+- recursively traverses subfolders and follows OneDrive shared/remote items
+- converts downloaded files to Markdown for indexing
+- filters by MIME type and skips files above a configurable size limit
+- runs ingestion on configurable schedules
+
+## Authentication
+
+The connector uses App authentication (client credentials) via `client_id`, `client_secret`, and `tenant_id`. Only OneDrive for Business is supported — OneDrive Personal accounts are not supported.
+
+The Azure app registration needs the **application** permission `Files.Read.All` with admin consent granted. Without it, Graph API calls fail with a 403 error.
+
+## Required Environment Variables
+
+Set these in `.env.rag`:
+
+- `ONEDRIVE1_CLIENT_ID`: Azure app registration client ID
+- `ONEDRIVE1_CLIENT_SECRET`: Azure app registration client secret
+- `ONEDRIVE1_TENANT_ID`: Azure tenant ID
+- `ONEDRIVE1_USER_PRINCIPAL_NAME`: user principal name / email of the OneDrive owner (example: `user@your-org.onmicrosoft.com`)
+- `ONEDRIVE1_SCHEDULES`: ingestion interval in seconds (default: `3600`)
+
+## `config.yaml` Example
+
+```yaml
+sources:
+  - type: "onedrive"
+    name: "onedrive1"
+    enabled: true  # optional, default: true
+    config:
+      client_id: "${ONEDRIVE1_CLIENT_ID}"
+      client_secret: "${ONEDRIVE1_CLIENT_SECRET}"
+      tenant_id: "${ONEDRIVE1_TENANT_ID}"
+      userprincipalname: "${ONEDRIVE1_USER_PRINCIPAL_NAME}"
+      folder_path: "Documents/Reports"  # optional: hardcode directly in config
+      folder_id:                        # optional: OneDrive folder ID
+      file_ids:                         # optional: comma-separated file IDs
+      file_paths:                       # optional: comma-separated file paths
+      mime_types:                       # optional: comma-separated MIME types to filter
+      recursive: true                   # optional, default true
+      max_file_size_mb: 50              # optional, default 50; files larger than this are skipped
+      schedules: "${ONEDRIVE1_SCHEDULES}"
+```
+
+## `.env.rag` Example
+
+```dotenv
+ONEDRIVE1_CLIENT_ID=your-azure-app-client-id
+ONEDRIVE1_CLIENT_SECRET=your-azure-app-client-secret
+ONEDRIVE1_TENANT_ID=your-azure-tenant-id
+ONEDRIVE1_USER_PRINCIPAL_NAME=user@your-org.onmicrosoft.com
+ONEDRIVE1_SCHEDULES=3600
+```
+
+## Configuration Reference
+
+| Field | Required | Default | Description |
+|---|---|---|---|
+| `enabled` | no | `true` | Set to `false` to skip this source entirely |
+| `client_id` | yes | — | Azure app registration client ID |
+| `client_secret` | yes | — | Azure app registration client secret |
+| `tenant_id` | yes | — | Azure tenant ID |
+| `userprincipalname` | yes | — | User principal name / email of the OneDrive owner |
+| `folder_id` | no | — | OneDrive folder ID to ingest |
+| `folder_path` | no | — | Relative path of the OneDrive folder to ingest |
+| `file_ids` | no | — | Comma-separated OneDrive file IDs to ingest |
+| `file_paths` | no | — | Comma-separated OneDrive file paths to ingest |
+| `mime_types` | no | all | Comma-separated MIME types to filter |
+| `recursive` | no | `true` | Traverse subfolders recursively |
+| `max_file_size_mb` | no | `50` | Skip files larger than this size |
+| `schedules` | no | `3600` | Ingestion interval in seconds |
+
+If none of `folder_id`, `folder_path`, `file_ids`, or `file_paths` are set, all files from the drive root are loaded.
+
+## Multiple OneDrive Sources
+
+Add more `sources` entries (`onedrive2`, `onedrive3`, etc) with separate env vars per source.

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -71,7 +71,8 @@
 							"connectors/pipedrive-connector",
 							"connectors/web-connector",
 							"connectors/directory-connector",
-							"connectors/slack-connector"
+							"connectors/slack-connector",
+							"connectors/onedrive-connector"
 						]
 					},
 					{

--- a/docs/getting-started/index.mdx
+++ b/docs/getting-started/index.mdx
@@ -67,6 +67,9 @@ for both personal and team workflows.
 	<Card title="Slack" href="/connectors/slack-connector">
 		Ingest channel messages and thread replies from Slack.
 	</Card>
+	<Card title="OneDrive" href="/connectors/onedrive-connector">
+		Ingest files from Microsoft OneDrive for Business.
+	</Card>
 </CardGroup>
 
 ## Who It Is For


### PR DESCRIPTION
## Summary

- Adds OneDrive for Business to the connectors list in README
- Adds commented connector block to `config.yaml.example`
- Adds `ONEDRIVE1_*` env vars to `.env.rag.example`

Companion PR: WikiTeq/rag-of-all-trades#40