### PR TITLE
MAIT-41: Update MediaWiki connector config templates to new host-based schema

### DIFF
--- a/.env.rag.example
+++ b/.env.rag.example
@@ -58,8 +58,14 @@ S3_ACCOUNT1_SCHEDULES=
 
 # MEDIAWIKI CONNECTORS (optional):
 
-#MEDIAWIKI1_API_URL=https://your-mediawiki-instance1.com/w/api.php
-#MEDIAWIKI2_API_URL=https://your-mediawiki-instance2.com/w/api.php
+#MEDIAWIKI1_HOST=wiki.example.org
+#MEDIAWIKI1_SCHEDULES=3600
+# Only needed for private wikis requiring login:
+#MEDIAWIKI1_USERNAME=your-bot-username
+#MEDIAWIKI1_PASSWORD=your-bot-password
+
+#MEDIAWIKI2_HOST=wiki2.example.org
+#MEDIAWIKI2_SCHEDULES=3600
 
 # SERPPAPI CONNECTORS (optional):
 

--- a/README.md
+++ b/README.md
@@ -174,26 +174,31 @@ sources:
   - type: "mediawiki"
     name: "wiki1"
     config:
-      api_url: "${MEDIAWIKI1_API_URL}"
-      request_delay: 0.1
+      host: "${MEDIAWIKI1_HOST}"
+      path: "/w/"          # optional, default /w/
+      scheme: "https"      # optional, default https
+      page_limit: 500      # optional, max pages per namespace (default: unlimited)
+      namespaces: "0,1"    # optional, comma-separated namespace IDs (default: content namespaces)
+      filter_redirects: true  # optional, exclude redirect pages (default: true)
+      username: "${MEDIAWIKI1_USERNAME}"  # optional, for private wikis
+      password: "${MEDIAWIKI1_PASSWORD}"  # optional, for private wikis
       schedules: "${MEDIAWIKI1_SCHEDULES}"
 
   - type: "mediawiki"
     name: "wiki2"
     config:
-      ...
-
-  - type: "mediawiki"
-    name: "wiki3"
-    config:
-      ...
+      host: "${MEDIAWIKI2_HOST}"
+      schedules: "${MEDIAWIKI2_SCHEDULES}"
 ```
 
 ```dotenv
 # .env.rag
 
-MEDIAWIKI1_API_URL=https://en.wikipedia.org/w/api.php
+MEDIAWIKI1_HOST=wiki.example.org
 MEDIAWIKI1_SCHEDULES=3600
+# Only needed for private wikis requiring login:
+#MEDIAWIKI1_USERNAME=your-bot-username
+#MEDIAWIKI1_PASSWORD=your-bot-password
 ````
 
 ### SerpAPI Connector

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -21,17 +21,24 @@ sources:
   #    buckets: "${S3_ACCOUNT2_BUCKETS}"
   #    schedules: "${S3_ACCOUNT2_SCHEDULES}"
 
-  #- type: "mediawiki1"
+  #- type: "mediawiki"
   #  name: "wiki1"
   #  config:
-  #    api_url: "${MEDIAWIKI1_API_URL}"
-  #    request_delay: 0.1
+  #    host: "${MEDIAWIKI1_HOST}"
+  #    path: "/w/"          # optional, default /w/
+  #    scheme: "https"      # optional, default https
+  #    page_limit: 500      # optional, max pages per namespace (default: unlimited)
+  #    namespaces: "0,1"    # optional, comma-separated namespace IDs (default: content namespaces)
+  #    filter_redirects: true  # optional, exclude redirect pages (default: true)
+  #    username: "${MEDIAWIKI1_USERNAME}"  # optional, for private wikis
+  #    password: "${MEDIAWIKI1_PASSWORD}"  # optional, for private wikis
+  #    schedules: "${MEDIAWIKI1_SCHEDULES}"
 
-  #- type: "mediawiki2"
+  #- type: "mediawiki"
   #  name: "wiki2"
   #  config:
-  #    api_url: "${MEDIAWIKI2_API_URL}"
-  #    request_delay: 0.1
+  #    host: "${MEDIAWIKI2_HOST}"
+  #    schedules: "${MEDIAWIKI2_SCHEDULES}"
 
   #- type: "serpapi"
   #  name: "serp_ingestion"


### PR DESCRIPTION
## Summary

- Replaces deprecated `api_url`/`request_delay` fields in `config.yaml.example` and `.env.rag.example` with the new `host`, `path`, `scheme`, `page_limit`, `namespaces`, `filter_redirects`, `username`, `password`, and `schedules` fields
- Updates `README.md` MediaWiki Connector section to reflect the new schema
- Aligns mAItion config templates with the MediaWikiReader migration done in rag-of-all-trades