### PR TITLE
WIK-2431: Document request_delay common config parameter

### DIFF
--- a/docs/configuration/config-reference.mdx
+++ b/docs/configuration/config-reference.mdx
@@ -32,6 +32,15 @@ Each item:
 
 Connector `config` fields differ by connector type. See connector pages for exact keys.
 
+### Common Connector Fields
+
+The following fields are supported by all connector types:
+
+| Field | Required | Default | Description |
+|---|---|---|---|
+| `schedules` | no | `3600` | Ingestion interval in seconds |
+| `request_delay` | no | `0` | Seconds to wait between outbound API requests. Increase to avoid rate-limiting (e.g. `0.1`) |
+
 ## `embedding`
 
 ```yaml

--- a/docs/connectors/jira-connector.mdx
+++ b/docs/connectors/jira-connector.mdx
@@ -84,6 +84,7 @@ sources:
 | `load_comments` | no | `false` | Whether to ingest issue comments |
 | `max_comments` | no | `10` | Maximum comments to include per issue |
 | `schedules` | no | `3600` | Ingestion interval in seconds |
+| `request_delay` | no | `0` | Seconds to wait between API requests. Increase to avoid rate-limiting (e.g. `0.1`) |
 
 ## Multiple Jira Sources
 

--- a/docs/connectors/s3-connector.mdx
+++ b/docs/connectors/s3-connector.mdx
@@ -44,6 +44,19 @@ sources:
       schedules: "${S3_ACCOUNT1_SCHEDULES}"
 ```
 
+## Configuration Reference
+
+| Field | Required | Default | Description |
+|---|---|---|---|
+| `endpoint` | yes | — | S3 API endpoint URL |
+| `access_key` | yes | — | Access key ID |
+| `secret_key` | yes | — | Secret access key |
+| `region` | yes | — | Bucket region |
+| `use_ssl` | no | `True` | Whether to use HTTPS |
+| `buckets` | yes | — | Bucket name(s), comma-separated |
+| `schedules` | no | `3600` | Ingestion interval in seconds |
+| `request_delay` | no | `0` | Seconds to wait between API requests. Increase to avoid rate-limiting (e.g. `0.1`) |
+
 ## Multiple S3 Accounts
 
 Add more `sources` entries (`account2`, `account3`, etc) with separate env vars per account.

--- a/docs/connectors/serpapi-connector.mdx
+++ b/docs/connectors/serpapi-connector.mdx
@@ -36,6 +36,15 @@ sources:
       schedules: "${SERPAPI1_SCHEDULES}"
 ```
 
+## Configuration Reference
+
+| Field | Required | Default | Description |
+|---|---|---|---|
+| `api_key` | yes | — | SerpAPI API key |
+| `queries` | yes | — | One query or comma-separated list of queries |
+| `schedules` | no | `3600` | Ingestion interval in seconds |
+| `request_delay` | no | `0` | Seconds to wait between API requests. Increase to avoid rate-limiting (e.g. `0.1`) |
+
 ## Multiple SerpAPI Sources
 
 Add more `sources` entries (`serp_ingestion2`, `serp_ingestion3`, etc) with separate env vars per source.

--- a/docs/connectors/web-connector.mdx
+++ b/docs/connectors/web-connector.mdx
@@ -79,6 +79,7 @@ WEB2_SCHEDULES=3600
 | `exclude_prefix` | no | — | Skip URLs with this path prefix (mutually exclusive with `include_prefix`) |
 | `html_to_text` | no | `true` | Convert HTML to plain text before indexing |
 | `schedules` | no | `3600` | Ingestion interval in seconds |
+| `request_delay` | no | `0` | Seconds to wait between outbound requests. Increase to avoid rate-limiting (e.g. `0.1`) |
 
 ## Multiple Web Sources
 


### PR DESCRIPTION
## Summary

- Added `request_delay` to the Configuration Reference table in all connector docs (Jira, S3, SerpAPI, Web)
- Added a Common Connector Fields section to `config-reference.mdx` documenting `request_delay` and `schedules` as fields available to all connectors
- Added full Configuration Reference tables to S3 and SerpAPI connector docs (previously missing)