### PR TITLE
MAIT-191: Pin ROAT image to 4e6664e

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -79,7 +79,7 @@ services:
 
   # rag-of-all-trades API
   api:
-    image: ghcr.io/wikiteq/rag-of-all-trades:latest
+    image: ghcr.io/wikiteq/rag-of-all-trades:4e6664e
     extra_hosts:
       - "host.docker.internal:host-gateway"
     depends_on:
@@ -103,7 +103,7 @@ services:
 
   # rag-of-all-trades WORKER
   celery_worker:
-    image: ghcr.io/wikiteq/rag-of-all-trades:latest
+    image: ghcr.io/wikiteq/rag-of-all-trades:4e6664e
     extra_hosts:
       - "host.docker.internal:host-gateway"
     depends_on:
@@ -129,7 +129,7 @@ services:
 
   # rag-of-all-trades BEAT
   celery_beat:
-    image: ghcr.io/wikiteq/rag-of-all-trades:latest
+    image: ghcr.io/wikiteq/rag-of-all-trades:4e6664e
     depends_on:
       postgres:
         condition: service_healthy

--- a/compose.yaml
+++ b/compose.yaml
@@ -79,7 +79,7 @@ services:
 
   # rag-of-all-trades API
   api:
-    image: ghcr.io/wikiteq/rag-of-all-trades:4e6664e
+    image: ghcr.io/wikiteq/rag-of-all-trades:600a11e
     extra_hosts:
       - "host.docker.internal:host-gateway"
     depends_on:
@@ -103,7 +103,7 @@ services:
 
   # rag-of-all-trades WORKER
   celery_worker:
-    image: ghcr.io/wikiteq/rag-of-all-trades:4e6664e
+    image: ghcr.io/wikiteq/rag-of-all-trades:600a11e
     extra_hosts:
       - "host.docker.internal:host-gateway"
     depends_on:
@@ -129,7 +129,7 @@ services:
 
   # rag-of-all-trades BEAT
   celery_beat:
-    image: ghcr.io/wikiteq/rag-of-all-trades:4e6664e
+    image: ghcr.io/wikiteq/rag-of-all-trades:600a11e
     depends_on:
       postgres:
         condition: service_healthy


### PR DESCRIPTION
## Summary
- Pin `ghcr.io/wikiteq/rag-of-all-trades` image tag from `:latest` to `4e6664e` for `api`, `celery_worker`, and `celery_beat` services