### PR TITLE
MAIT-139: Add Box connector configuration and documentation

### DIFF
--- a/.env.rag.example
+++ b/.env.rag.example
@@ -98,5 +98,6 @@ S3_ACCOUNT1_SCHEDULES=
 #BOX1_CLIENT_ID=your-box-app-client-id
 #BOX1_CLIENT_SECRET=your-box-app-client-secret
 #BOX1_ENTERPRISE_ID=your-box-enterprise-id
-#BOX1_USER_ID=                 # optional: Box user ID for user-level CCG access
+# optional: Box user ID for user-level CCG access
+#BOX1_USER_ID=
 #BOX1_SCHEDULES=3600

--- a/.env.rag.example
+++ b/.env.rag.example
@@ -95,9 +95,19 @@ S3_ACCOUNT1_SCHEDULES=
 #PIPEDRIVE2_SCHEDULES=3600
 
 # BOX CONNECTORS (optional):
+# CCG auth
 #BOX1_CLIENT_ID=your-box-app-client-id
 #BOX1_CLIENT_SECRET=your-box-app-client-secret
 #BOX1_ENTERPRISE_ID=your-box-enterprise-id
-# optional: Box user ID for user-level CCG access
-#BOX1_USER_ID=
+#BOX1_USER_ID=                 # optional: Box user ID for user-level CCG access
 #BOX1_SCHEDULES=3600
+
+# JWT auth
+#BOX2_CLIENT_ID=your-box-app-client-id2
+#BOX2_CLIENT_SECRET=your-box-app-client-secret2
+#BOX2_ENTERPRISE_ID=your-box-enterprise-id2
+#BOX2_JWT_KEY_ID=your-jwt-public-key-id
+#BOX2_PRIVATE_KEY=-----BEGIN RSA PRIVATE KEY-----\n...\n-----END RSA PRIVATE KEY-----
+#BOX2_PRIVATE_KEY_PASSPHRASE=your-passphrase
+#BOX2_FILE_IDS=123,456
+#BOX2_SCHEDULES=3600

--- a/.env.rag.example
+++ b/.env.rag.example
@@ -93,3 +93,10 @@ S3_ACCOUNT1_SCHEDULES=
 #PIPEDRIVE1_SCHEDULES=3600
 #PIPEDRIVE2_API_TOKEN=your-second-pipedrive-api-token
 #PIPEDRIVE2_SCHEDULES=3600
+
+# BOX CONNECTORS (optional):
+#BOX1_CLIENT_ID=your-box-app-client-id
+#BOX1_CLIENT_SECRET=your-box-app-client-secret
+#BOX1_ENTERPRISE_ID=your-box-enterprise-id
+#BOX1_USER_ID=                 # optional: Box user ID for user-level CCG access
+#BOX1_SCHEDULES=3600

--- a/README.md
+++ b/README.md
@@ -335,8 +335,8 @@ sources:
     config:
       box_client_id: "${BOX1_CLIENT_ID}"
       box_client_secret: "${BOX1_CLIENT_SECRET}"
-      box_enterprise_id: "${BOX1_ENTERPRISE_ID}"  # required unless box_user_id is set
-      # box_user_id: "${BOX1_USER_ID}"            # optional: user-level CCG access
+      box_enterprise_id: "${BOX1_ENTERPRISE_ID}"  # required
+      # box_user_id: "${BOX1_USER_ID}"            # optional: act as a specific user
       folder_id: "0"       # ingest root folder
       is_recursive: true   # optional, default false
       schedules: "${BOX1_SCHEDULES}"

--- a/README.md
+++ b/README.md
@@ -348,7 +348,6 @@ sources:
 BOX1_CLIENT_ID=your-box-app-client-id
 BOX1_CLIENT_SECRET=your-box-app-client-secret
 BOX1_ENTERPRISE_ID=your-box-enterprise-id
-BOX1_USER_ID=
 BOX1_SCHEDULES=3600
 ```
 

--- a/README.md
+++ b/README.md
@@ -348,6 +348,7 @@ sources:
 BOX1_CLIENT_ID=your-box-app-client-id
 BOX1_CLIENT_SECRET=your-box-app-client-secret
 BOX1_ENTERPRISE_ID=your-box-enterprise-id
+BOX1_USER_ID=
 BOX1_SCHEDULES=3600
 ```
 

--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ Over 100 extra connectors are available at request, including the most popular o
 * Notion
 * Microsoft Teams
 * Microsoft Office 365
+* Box
 * Dropbox
 * Trello
 * Web scraper
@@ -306,6 +307,81 @@ JIRA1_EMAIL=your-email@example.com
 JIRA1_API_TOKEN=your-api-token
 JIRA1_JQL=project = MYPROJECT ORDER BY updated DESC
 JIRA1_SCHEDULES=3600
+```
+
+### Box Connector
+
+The Box connector ingests files from Box cloud storage using the [LlamaIndex Box reader](https://llamahub.ai/l/readers/llama-index-readers-box).
+It supports CCG and JWT authentication, folder-based ingestion, file-ID-based ingestion, full-text content search, and metadata-based search.
+One or more ingestion modes can be combined in a single source.
+
+**Ingestion modes** (at least one required):
+
+| Mode | Config keys |
+|---|---|
+| Folder | `folder_id`, `is_recursive` |
+| File IDs | `file_ids` |
+| Content search | `search_query`, `search_file_extensions`, `search_ancestor_folder_ids` |
+| Metadata search | `metadata_template`, `metadata_ancestor_folder_id`, `metadata_query`, `metadata_query_params` |
+
+**CCG auth (default)** — Client Credentials Grant, enterprise or user-level:
+
+```yaml
+# config.yaml
+
+sources:
+  - type: "box"
+    name: "box1"
+    config:
+      box_client_id: "${BOX1_CLIENT_ID}"
+      box_client_secret: "${BOX1_CLIENT_SECRET}"
+      box_enterprise_id: "${BOX1_ENTERPRISE_ID}"  # required unless box_user_id is set
+      # box_user_id: "${BOX1_USER_ID}"            # optional: user-level CCG access
+      folder_id: "0"       # ingest root folder
+      is_recursive: true   # optional, default false
+      schedules: "${BOX1_SCHEDULES}"
+```
+
+```dotenv
+# .env.rag
+
+BOX1_CLIENT_ID=your-box-app-client-id
+BOX1_CLIENT_SECRET=your-box-app-client-secret
+BOX1_ENTERPRISE_ID=your-box-enterprise-id
+BOX1_SCHEDULES=3600
+```
+
+**JWT auth** — for server-side authentication with a private key:
+
+```yaml
+# config.yaml
+
+sources:
+  - type: "box"
+    name: "box2"
+    config:
+      box_client_id: "${BOX2_CLIENT_ID}"
+      box_client_secret: "${BOX2_CLIENT_SECRET}"
+      auth_type: "jwt"
+      box_jwt_key_id: "${BOX2_JWT_KEY_ID}"
+      box_private_key: "${BOX2_PRIVATE_KEY}"
+      box_private_key_passphrase: "${BOX2_PRIVATE_KEY_PASSPHRASE}"
+      box_enterprise_id: "${BOX2_ENTERPRISE_ID}"  # optional for JWT
+      file_ids: "${BOX2_FILE_IDS}"
+      schedules: "${BOX2_SCHEDULES}"
+```
+
+```dotenv
+# .env.rag
+
+BOX2_CLIENT_ID=your-box-app-client-id2
+BOX2_CLIENT_SECRET=your-box-app-client-secret2
+BOX2_ENTERPRISE_ID=your-box-enterprise-id2
+BOX2_JWT_KEY_ID=your-jwt-public-key-id
+BOX2_PRIVATE_KEY=-----BEGIN RSA PRIVATE KEY-----\n...\n-----END RSA PRIVATE KEY-----
+BOX2_PRIVATE_KEY_PASSPHRASE=your-passphrase
+BOX2_FILE_IDS=123,456
+BOX2_SCHEDULES=3600
 ```
 
 ### Pipedrive Connector

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -105,6 +105,19 @@ sources:
   #    api_token: "${PIPEDRIVE2_API_TOKEN}"
   #    schedules: "${PIPEDRIVE2_SCHEDULES}"
 
+  # Box cloud storage
+  #- type: "box"
+  #  name: "box1"
+  #  config:
+  #    box_client_id: "${BOX1_CLIENT_ID}"
+  #    box_client_secret: "${BOX1_CLIENT_SECRET}"
+  #    box_enterprise_id: "${BOX1_ENTERPRISE_ID}"
+  #    folder_id: "0"           # optional: Box folder ID ("0" = root)
+  #    is_recursive: true       # optional: traverse subfolders, default false
+  #    # file_ids: "123,456"    # optional: comma-separated file IDs (mutually exclusive with folder_id)
+  #    # box_user_id: "${BOX1_USER_ID}"  # optional: user ID for user-level CCG access
+  #    schedules: "${BOX1_SCHEDULES}"
+
 embedding:
   # can be `local` or `openrouter`/`openai`
   provider: local

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -106,16 +106,60 @@ sources:
   #    schedules: "${PIPEDRIVE2_SCHEDULES}"
 
   # Box cloud storage
+  # Box connector — CCG auth, folder-based ingestion
   #- type: "box"
   #  name: "box1"
   #  config:
+  #    auth_type: "ccg"                      # optional: "ccg" (default) or "jwt"
   #    box_client_id: "${BOX1_CLIENT_ID}"
   #    box_client_secret: "${BOX1_CLIENT_SECRET}"
   #    box_enterprise_id: "${BOX1_ENTERPRISE_ID}"
-  #    folder_id: "0"           # optional: Box folder ID ("0" = root)
-  #    is_recursive: true       # optional: traverse subfolders, default false
-  #    # file_ids: "123,456"    # optional: comma-separated file IDs (mutually exclusive with folder_id)
-  #    # box_user_id: "${BOX1_USER_ID}"  # optional: user ID for user-level CCG access
+  #    box_user_id: "${BOX1_USER_ID}"        # optional: user ID for user-level CCG access
+  #    folder_id: "0"                        # optional: Box folder ID ("0" = root)
+  #    is_recursive: true                    # optional: traverse subfolders, default false
+  #    file_ids: "123,456"                   # optional: comma-separated file IDs
+  #    # folder_id and file_ids can be combined — both are ingested
+  #    schedules: "${BOX1_SCHEDULES}"
+
+  # Box connector — JWT auth, file-ID ingestion
+  #- type: "box"
+  #  name: "box2"
+  #  config:
+  #    auth_type: "jwt"
+  #    box_client_id: "${BOX2_CLIENT_ID}"
+  #    box_client_secret: "${BOX2_CLIENT_SECRET}"
+  #    box_jwt_key_id: "${BOX2_JWT_KEY_ID}"
+  #    box_private_key: "${BOX2_PRIVATE_KEY}"
+  #    box_private_key_passphrase: "${BOX2_PRIVATE_KEY_PASSPHRASE}"
+  #    box_enterprise_id: "${BOX2_ENTERPRISE_ID}"  # optional for JWT
+  #    file_ids: "${BOX2_FILE_IDS}"                # comma-separated file IDs
+  #    schedules: "${BOX2_SCHEDULES}"
+
+  # Box connector — full-text content search
+  #- type: "box"
+  #  name: "box-search"
+  #  config:
+  #    auth_type: "ccg"
+  #    box_client_id: "${BOX1_CLIENT_ID}"
+  #    box_client_secret: "${BOX1_CLIENT_SECRET}"
+  #    box_enterprise_id: "${BOX1_ENTERPRISE_ID}"
+  #    search_query: "quarterly report"             # required for search mode
+  #    search_file_extensions: "pdf,docx"           # optional: filter by extension
+  #    search_ancestor_folder_ids: "0"              # optional: scope to folder(s)
+  #    schedules: "${BOX1_SCHEDULES}"
+
+  # Box connector — metadata search
+  #- type: "box"
+  #  name: "box-meta"
+  #  config:
+  #    auth_type: "ccg"
+  #    box_client_id: "${BOX1_CLIENT_ID}"
+  #    box_client_secret: "${BOX1_CLIENT_SECRET}"
+  #    box_enterprise_id: "${BOX1_ENTERPRISE_ID}"
+  #    metadata_template: "enterprise_12345.myTemplate"  # required for metadata search
+  #    metadata_ancestor_folder_id: "0"                  # required for metadata search
+  #    metadata_query: "status = :status"                # optional
+  #    metadata_query_params: "status=active"            # optional: key=value pairs
   #    schedules: "${BOX1_SCHEDULES}"
 
 embedding:


### PR DESCRIPTION
## Summary

- Adds Box cloud storage connector block to `config.yaml.example` (folder mode, file_ids, user-level access)
- Adds `BOX1_*` env vars to `.env.rag.example`
- Adds `### Box Connector` section to `README.md` with config and dotenv examples