### PR TITLE
MAIT-159: Add Slab connector config

### DIFF
--- a/.env.rag.example
+++ b/.env.rag.example
@@ -83,6 +83,10 @@ S3_ACCOUNT1_SCHEDULES=
 #SERPAPI_QUERIES="OpenAI news, Bitcoin price, Tesla updates"
 #SERPAPI_SCHEDULES=60
 
+# SLAB CONNECTORS (optional):
+#SLAB1_API_TOKEN=your-slab-api-token
+#SLAB1_SCHEDULES=3600
+
 # WEB CONNECTORS (optional):
 #WEB1_URLS=https://example.com/page1,https://example.com/page2
 #WEB1_SCHEDULES=60

--- a/README.md
+++ b/README.md
@@ -237,6 +237,31 @@ SERPAPI1_QUERIES=aaa
 SERPAPI1_SCHEDULES=3600
 ```
 
+### Slab Connector
+
+The Slab connector ingests posts from a [Slab](https://slab.com/) knowledge base via the GraphQL API.
+When `topic_ids` is configured, only posts belonging to those topics are ingested.
+When omitted, all organisation posts are fetched using cursor-based pagination.
+
+```yaml
+# config.yaml
+
+sources:
+  - type: "slab"
+    name: "slab1"
+    config:
+      api_token: "${SLAB1_API_TOKEN}"
+      # topic_ids: "topic_abc123,topic_def456"  # optional
+      schedules: "${SLAB1_SCHEDULES}"
+```
+
+```dotenv
+# .env.rag
+
+SLAB1_API_TOKEN=your-slab-api-token
+SLAB1_SCHEDULES=3600
+```
+
 ### Web Connector
 
 The Web connector ingests content from web pages. It supports two mutually exclusive modes:

--- a/README.md
+++ b/README.md
@@ -243,6 +243,13 @@ The Slab connector ingests posts from a [Slab](https://slab.com/) knowledge base
 When `topic_ids` is configured, only posts belonging to those topics are ingested.
 When omitted, all organisation posts are fetched using cursor-based pagination.
 
+> **Plan requirement:** Slab's API and webhooks are only available on the Business or Enterprise plan
+> ([Slab developer tools docs](https://help.slab.com/en/articles/6545629-developer-tools-api-webhooks)).
+> On the Free plan, this connector cannot be used. Instead, use Slab's
+> [full export](https://help.slab.com/en/articles/2271952-export-or-download-your-content) feature to
+> download all pages as Markdown, then ingest the exported files with the Directory connector
+> (see the [rag-of-all-trades README](https://github.com/WikiTeq/rag-of-all-trades#directory-connector)).
+
 ```yaml
 # config.yaml
 

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -48,6 +48,17 @@ sources:
   #    queries: "${SERPAPI_QUERIES}"
   #    schedules: "${SERPAPI_SCHEDULES}"
 
+
+  #- type: "slab"
+  #  name: "slab1"
+  #  config:
+  #    api_token: "${SLAB1_API_TOKEN}"
+  #    # topic_ids: "topic_abc123,topic_def456"  # optional
+  #    max_retries: 3      # optional, default 3
+  #    retry_delay: 2      # optional, seconds between retries (default 2)
+  #    search_batch_size: 100  # optional, posts per search page (default 100)
+  #    schedules: "${SLAB1_SCHEDULES}"
+
   # Web scraper — URLs mode
   #- type: "web"
   #  name: "web1"


### PR DESCRIPTION
## Summary

- Add `slab` source block to `config.yaml.example` (alphabetically between serpapi and web)
- Add `SLAB1_API_TOKEN` and `SLAB1_SCHEDULES` to `.env.rag.example`
- Add `### Slab Connector` section to `README.md` with config and env example

Depends on: WikiTeq/rag-of-all-trades#51