### PR TITLE
MAIT-198: Add Mintlify documentation link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ allowing you to chat, search and interact with your data through a slick chat in
 you can aggregate all your knowledge from many sources using Connectors into a central place and 
 interact with your knowledge with ease!
 
+📚 **Documentation:** [docs.maition.com](https://docs.maition.com/)
+
 ## ✨ Features
 
 * Support for both local and remote LLMs for embedding and inference


### PR DESCRIPTION
## Summary

- Adds a link to [docs.maition.com](https://docs.maition.com/) in README.md, between the intro paragraph and the Features section

## Note

The GitHub repo About section (website field) currently shows `maition.com` — updating that to the docs URL needs to be done manually via the GitHub UI.