### PR TITLE
MAIT-77: Hide Connections tab for non-admin users

### DIFF
--- a/patches/connections.patch
+++ b/patches/connections.patch
@@ -1,0 +1,46 @@
+diff --git build/index.html build/index.html
+--- build/index.html
++++ build/index.html
+@@ -225,2 +225,38 @@
+-	</body>
+-</html>
++	<script>
++		(function () {
++			var role = null;
++			var fetching = false;
++			function getToken() {
++				try { return localStorage.getItem('token') || ''; } catch (e) { return ''; }
++			}
++			function applyVisibility() {
++				var c = document.querySelector('#settings-tabs-container');
++				if (!c) return;
++				var btns = c.querySelectorAll('button');
++				for (var i = 0; i < btns.length; i++) {
++					var b = btns[i];
++					if (b.textContent.trim() === 'Connections') {
++						if (role !== 'admin') {
++							b.style.setProperty('display', 'none', 'important');
++						} else {
++							b.style.removeProperty('display');
++						}
++					}
++				}
++			}
++			function fetchRole() {
++				if (fetching) return;
++				var token = getToken();
++				if (!token) { role = null; applyVisibility(); return; }
++				fetching = true;
++				fetch('/api/v1/auths/', { headers: { Authorization: 'Bearer ' + token } })
++					.then(function (r) { return r && r.ok ? r.json() : null; })
++					.then(function (u) { fetching = false; role = u && u.role ? u.role : null; applyVisibility(); })
++					.catch(function () { fetching = false; role = null; applyVisibility(); });
++			}
++			new MutationObserver(fetchRole).observe(document.documentElement, { childList: true, subtree: true });
++			document.addEventListener('visibilitychange', fetchRole);
++			window.addEventListener('focus', fetchRole);
++			fetchRole();
++		})();
++	</script>
++	</body>
++</html>

--- a/patches/connections.patch
+++ b/patches/connections.patch
@@ -1,46 +1,49 @@
 diff --git build/index.html build/index.html
 --- build/index.html
 +++ build/index.html
-@@ -225,2 +225,38 @@
--	</body>
--</html>
-+	<script>
-+		(function () {
-+			var role = null;
-+			var fetching = false;
-+			function getToken() {
-+				try { return localStorage.getItem('token') || ''; } catch (e) { return ''; }
-+			}
-+			function applyVisibility() {
-+				var c = document.querySelector('#settings-tabs-container');
-+				if (!c) return;
-+				var btns = c.querySelectorAll('button');
-+				for (var i = 0; i < btns.length; i++) {
-+					var b = btns[i];
-+					if (b.textContent.trim() === 'Connections') {
-+						if (role !== 'admin') {
-+							b.style.setProperty('display', 'none', 'important');
-+						} else {
-+							b.style.removeProperty('display');
-+						}
+@@ -279,1 +279,45 @@
+ </style>
++<script>
++	(function () {
++		var role = null;
++		var fetching = false;
++		function getToken() {
++			try { return localStorage.getItem('token') || ''; } catch (e) { return ''; }
++		}
++		function applyVisibility() {
++			var c = document.querySelector('#settings-tabs-container');
++			if (!c) return;
++			var btns = c.querySelectorAll('button');
++			for (var i = 0; i < btns.length; i++) {
++				var b = btns[i];
++				// Case-insensitive includes: Open WebUI has no stable id/aria/data
++				// attribute on this tab button, so text content is the only anchor.
++				if (b.textContent.trim().toLowerCase().includes('connections')) {
++					if (role !== 'admin') {
++						b.style.setProperty('display', 'none', 'important');
++					} else {
++						b.style.removeProperty('display');
 +					}
 +				}
 +			}
-+			function fetchRole() {
-+				if (fetching) return;
-+				var token = getToken();
-+				if (!token) { role = null; applyVisibility(); return; }
-+				fetching = true;
-+				fetch('/api/v1/auths/', { headers: { Authorization: 'Bearer ' + token } })
-+					.then(function (r) { return r && r.ok ? r.json() : null; })
-+					.then(function (u) { fetching = false; role = u && u.role ? u.role : null; applyVisibility(); })
-+					.catch(function () { fetching = false; role = null; applyVisibility(); });
-+			}
-+			new MutationObserver(fetchRole).observe(document.documentElement, { childList: true, subtree: true });
-+			document.addEventListener('visibilitychange', fetchRole);
-+			window.addEventListener('focus', fetchRole);
-+			fetchRole();
-+		})();
-+	</script>
-+	</body>
-+</html>
++		}
++		function fetchRole() {
++			if (fetching) return;
++			var token = getToken();
++			if (!token) { role = null; applyVisibility(); return; }
++			fetching = true;
++			fetch('/api/v1/auths/', { headers: { Authorization: 'Bearer ' + token } })
++				.then(function (r) { return r && r.ok ? r.json() : null; })
++				.then(function (u) { fetching = false; role = u && u.role ? u.role : null; applyVisibility(); })
++				.catch(function () { fetching = false; role = null; applyVisibility(); });
++		}
++		// Observer re-applies visibility on DOM changes; also triggers fetchRole
++		// once if role is still unknown (covers SPA render race on initial load).
++		new MutationObserver(function () {
++			if (role === null) { fetchRole(); } else { applyVisibility(); }
++		}).observe(document.documentElement, { childList: true, subtree: true });
++		document.addEventListener('visibilitychange', fetchRole);
++		window.addEventListener('focus', fetchRole);
++		fetchRole();
++	})();
++</script>


### PR DESCRIPTION
## Summary

- Adds `patches/connections.patch` which injects a small inline script into `build/index.html` at container startup
- The script fetches the current user's role from `/api/v1/auths/` and hides the **Connections** button in the settings modal for non-admin users
- Admins continue to see and use the Connections tab normally
- Patch is picked up automatically by the existing patch mechanism in `helpers/entrypoint.sh` — no other changes required

## Test plan

- [ ] Log in as a regular user (role: `user`) → open Settings → Connections tab should not be visible
- [ ] Log in as admin → open Settings → Connections tab should be visible
- [ ] Switch between accounts in the same browser session → tab visibility updates correctly on each login