### PR TITLE
MAIT-76: Modify About tab to show only mAItion version

### DIFF
--- a/patches/about.patch
+++ b/patches/about.patch
@@ -1,23 +1,33 @@
 diff --git build/index.html build/index.html
 --- build/index.html
 +++ build/index.html
-@@ -111,6 +111,22 @@
+@@ -111,6 +111,32 @@
  		<link rel="modulepreload" href="/_app/immutable/entry/app.C9FWDgJY.js">
  		<link rel="modulepreload" href="/_app/immutable/chunks/C1FmrZbK.js">
  		<link rel="modulepreload" href="/_app/immutable/chunks/Cdll-xsj.js">
++	<style>[data-about-stripped] a,[data-about-stripped] button{display:none}</style>
 +	<script>
 +		(function () {
++			var _stripped = false;
 +			function stripAbout() {
 +				var panels = document.querySelectorAll('.space-y-3.overflow-y-scroll');
 +				for (var i = 0; i < panels.length; i++) {
 +					var panel = panels[i];
-+					if (!panel.textContent.includes('mAItion Version')) continue;
++					if (panel.dataset.aboutStripped) continue;
++					var name = (window.__WEBUI_NAME__ || '');
++					var hasVersion = /\d+\.\d+\.\d+/.test(panel.textContent);
++					var hasName = name ? panel.textContent.includes(name) : panel.textContent.includes('Version');
++					if (!hasVersion || !hasName) continue;
 +					Array.from(panel.children).slice(1).forEach(function (c) { c.remove(); });
 +					var first = panel.children[0];
 +					if (first) Array.from(first.querySelectorAll('a, button')).forEach(function (c) { c.remove(); });
++					panel.dataset.aboutStripped = '1';
++					_stripped = true;
 +				}
++				if (_stripped) { _o.disconnect(); return; }
++				if (document.readyState === 'complete') console.warn('[about-patch] About panel not found');
 +			}
-+			var _o = new MutationObserver(function () { stripAbout(); });
++			var _o = new MutationObserver(stripAbout);
 +			_o.observe(document.documentElement, { childList: true, subtree: true });
 +		})();
 +	</script>

--- a/patches/about.patch
+++ b/patches/about.patch
@@ -1,0 +1,26 @@
+diff --git build/index.html build/index.html
+--- build/index.html
++++ build/index.html
+@@ -111,6 +111,22 @@
+ 		<link rel="modulepreload" href="/_app/immutable/entry/app.C9FWDgJY.js">
+ 		<link rel="modulepreload" href="/_app/immutable/chunks/C1FmrZbK.js">
+ 		<link rel="modulepreload" href="/_app/immutable/chunks/Cdll-xsj.js">
++	<script>
++		(function () {
++			function stripAbout() {
++				var panels = document.querySelectorAll('.space-y-3.overflow-y-scroll');
++				for (var i = 0; i < panels.length; i++) {
++					var panel = panels[i];
++					if (!panel.textContent.includes('mAItion Version')) continue;
++					Array.from(panel.children).slice(1).forEach(function (c) { c.remove(); });
++					var first = panel.children[0];
++					if (first) Array.from(first.querySelectorAll('a, button')).forEach(function (c) { c.remove(); });
++				}
++			}
++			var _o = new MutationObserver(function () { stripAbout(); });
++			_o.observe(document.documentElement, { childList: true, subtree: true });
++		})();
++	</script>
+ 	</head>
+ 
+ 	<body data-sveltekit-preload-data="hover">


### PR DESCRIPTION
## Summary
- Adds `patches/about.patch` which injects a `MutationObserver` script into `build/index.html`
- The script strips all content from the About tab except the mAItion version block, and removes any buttons/links within it
- Patch applies cleanly via the existing `patch -p0` mechanism in `entrypoint.sh`

## Test plan
- [ ] Verify only "mAItion Version" with version string is shown