### PR TITLE
MAIT-77: Disable Direct Connections for regular users

### DIFF
--- a/helpers/entrypoint.sh
+++ b/helpers/entrypoint.sh
@@ -125,6 +125,13 @@ do_first_start() {
     	  -H "Authorization: Bearer ${API_KEY}" \
     	  -H "Content-Type: application/json"
 
+    	echo ""
+    	echo "[Custom entrypoint] Disabling Direct Connections for regular users"
+    	curl -s -X POST "http://localhost:8080/api/v1/configs/direct_connections" \
+    	  -H "Authorization: Bearer ${API_KEY}" \
+    	  -H "Content-Type: application/json" \
+    	  --data-raw '{"ENABLE_DIRECT_CONNECTIONS":false}'
+
     	# extra
     	if [ "$ENABLE_OPENAI_API" == "True" ]; then
     		if [ ! -z "$OPENAI_DEFAULT_MODEL" ]; then


### PR DESCRIPTION
## Summary
- Disables the **Direct Connections** toggle for all users during initial deployment
- Uses the built-in `ENABLE_DIRECT_CONNECTIONS` API setting instead of patching the UI
- Called in `do_first_start` via `POST /api/v1/configs/direct_connections`

## Test plan
- [ ] Fresh deploy: verify `{"ENABLE_DIRECT_CONNECTIONS": false}` returned from `GET /api/v1/configs/direct_connections`
- [ ] Verify regular users no longer see the Connections item in the user menu