### PR TITLE
MAIT-195: Update OpenAPI spec with API_KEY authorization support

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -15,8 +15,20 @@ paths:
           content:
             application/json:
               schema: {}
-  /api/v1/query/:
+  /:
+    get:
+      summary: Read Root
+      operationId: read_root__get
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+  /api/v1/query:
     post:
+      tags:
+      - Applications APIs
       summary: Query Endpoint
       description: Retrieve top-k chunks from vector store without LLM answer.
       operationId: query_endpoint_api_v1_query__post
@@ -39,9 +51,11 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
-  /api/v1/rephrase/:
+  /api/v1/rephrase:
     post:
-      summary: Rephrase Endpoint
+      tags:
+      - Applications APIs
+      summary: Query Endpoint
       description: Rephrase Node for by default 5 chunks using LLM.
       operationId: query_endpoint_api_v1_rephrase__post
       requestBody:
@@ -103,7 +117,7 @@ components:
         top_k:
           type: integer
           title: Top K
-          default: 5
+          default: 20
         metadata_filters:
           anyOf:
           - additionalProperties: true


### PR DESCRIPTION
## Summary
- Add root `GET /` endpoint to the OpenAPI spec
- Remove trailing slashes from `/api/v1/query` and `/api/v1/rephrase` paths
- Add `Applications APIs` tag to query and rephrase endpoints
- Update default `top_k` from 5 to 20