### PR TITLE
MAIT-204: Add MediaWiki write workspace tool for OWUI

### DIFF
--- a/tools/mediawiki_tool.py
+++ b/tools/mediawiki_tool.py
@@ -1,10 +1,10 @@
 """
-title: MediaWiki Write Tool
+title: MediaWiki Search & Write Tool
 author: WikiTeq
 date: 2025-04-30
 version: 1.0
 license: MIT
-description: Allows the AI to save content as a new or updated MediaWiki page when the user asks to save something to the wiki or knowledge base.
+description: Allows the AI to save content as a new or updated MediaWiki page when the user asks to save something to the wiki or knowledge base. Allows AI to search the wiki for pages.
 requirements: mwclient>=0.10.1, pydantic>=2.0.0
 """
 
@@ -20,6 +20,7 @@ log = logging.getLogger(__name__)
 
 MAX_TITLE_LENGTH = 255
 MAX_CONTENT_LENGTH = 2_000_000  # 2 MB, MediaWiki default max
+MAX_SEARCH_RESULTS = 20
 
 # Characters illegal in MediaWiki page titles: #<>[]|{} plus control chars 0-31 and DEL (127)
 _ILLEGAL_TITLE_CHARS = re.compile(r"[#<>\[\]|{}\x00-\x1f\x7f]")
@@ -107,9 +108,164 @@ class Tools:
             default="Saved via mAItion AI assistant",
             description="Edit summary recorded in the wiki page history.",
         )
+        max_search_results: int = Field(
+            default=10,
+            description=f"Maximum number of search results to return (1–{MAX_SEARCH_RESULTS}).",
+        )
+        max_page_chars: int = Field(
+            default=20_000,
+            description=(
+                "Maximum characters to include per page in search results."
+                " Longer pages are truncated."
+            ),
+        )
 
     def __init__(self):
         self.valves = self.Valves()
+
+    async def search_wiki(
+            self,
+            query: str,
+            __event_emitter__: Callable[[dict], Awaitable[None]] | None = None,
+    ) -> str:
+        """
+        Search the MediaWiki wiki for pages matching a query and return their full wikitext content.
+
+        Use this tool when the user asks to:
+        - "search the wiki for ..." / "find wiki pages about ..."
+        - "look up ... in the knowledge base"
+        - "what does the wiki say about ..."
+
+        The tool runs a full-text search (equivalent to Special:Search) and fetches the complete
+        wikitext of each matching page, returning them as a structured block the AI can read.
+
+        Args:
+            query: The search query string.
+
+        Returns:
+            A formatted string with each result's title, URL, and full wikitext, or an error.
+        """
+        import mwclient
+
+        async def emit(message: str, done: bool = False) -> None:
+            if __event_emitter__:
+                await __event_emitter__(
+                    {"type": "status", "data": {"description": message, "done": done}}
+                )
+
+        # --- Validate configuration ---
+        if not self.valves.wiki_url:
+            await emit("MediaWiki URL is not configured in Tool Valves.", done=True)
+            return "Error: wiki_url is not configured."
+        if not self.valves.username or not self.valves.password:
+            await emit(
+                "MediaWiki credentials are not configured in Tool Valves.", done=True
+            )
+            return "Error: username and password are not configured."
+
+        query = query.strip()
+        if not query:
+            await emit("Error: search query cannot be empty.", done=True)
+            return "Error: search query cannot be empty."
+
+        effective_limit = max(1, min(self.valves.max_search_results, MAX_SEARCH_RESULTS))
+
+        # --- Parse wiki URL ---
+        try:
+            host, path, scheme = _parse_wiki_url(self.valves.wiki_url)
+        except ValueError as e:
+            await emit(str(e), done=True)
+            return f"Error: {e}"
+
+        await emit(f"Connecting to {host}…")
+
+        # --- Connect and authenticate (blocking — run in thread) ---
+        def _connect():
+            site = mwclient.Site(
+                host,
+                path=path,
+                scheme=scheme,
+                reqs={"timeout": self.valves.timeout},
+            )
+            site.login(self.valves.username, self.valves.password)
+            return site
+
+        try:
+            site = await asyncio.to_thread(_connect)
+        except mwclient.errors.LoginError:
+            await emit(
+                "Authentication failed. Check your username and password in Tool Valves.",
+                done=True,
+            )
+            return "Error: authentication failed. If using a BotPassword, the format is 'Username@BotName'."
+        except Exception:
+            log.error("mwclient connection error", exc_info=True)
+            await emit("Could not connect to the wiki.", done=True)
+            return "Error: could not connect to the wiki. Check the wiki_url in Tool Valves."
+
+        def _get_article_path():
+            result = site.api("query", meta="siteinfo", siprop="general")
+            return result["query"]["general"].get("articlepath", "/wiki/$1")
+
+        try:
+            article_path = await asyncio.to_thread(_get_article_path)
+        except Exception:
+            article_path = "/wiki/$1"
+
+        await emit(f"Searching for '{query}'...")
+
+        def _search():
+            results = []
+            for item in site.search(query, what="text", limit=effective_limit):
+                results.append(item["title"])
+                if len(results) >= effective_limit:
+                    break
+            return results
+
+        try:
+            titles = await asyncio.to_thread(_search)
+        except Exception:
+            log.error("Search error", exc_info=True)
+            await emit("Wiki search error.", done=True)
+            return f"Error: unexpected error during search."
+
+        if not titles:
+            await emit("No results found.", done=True)
+            return f"No wiki pages found matching '{query}'."
+
+        await emit(f"Fetching content for {len(titles)} page(s)...")
+
+        def _fetch_page(title: str) -> tuple[str, str]:
+            try:
+                page = site.pages[title]
+                if not page.exists:
+                    return title, "(Page not found — may have been deleted)"
+                return title, page.text()
+            except Exception as e:
+                log.warning("Failed to fetch %r: %s", title, e)
+                return title, "(Content unavailable)"
+
+        pages: list[tuple[str, str]] = await asyncio.gather(
+            *[asyncio.to_thread(_fetch_page, t) for t in titles]
+        )
+
+        sections = []
+        cap = self.valves.max_page_chars
+        for i, (title, content) in enumerate(pages, start=1):
+            if len(content) > cap:
+                content = content[:cap] + f"\n...(truncated {len(content) - cap} chars)"
+            url = _build_page_url(scheme, host, article_path, title)
+            sections.append(
+                f"=== Result {i}: {title} ===\n"
+                f"URL: {url}\n\n"
+                f"Page content: {content}\n"
+            )
+
+        await emit(f"Found {len(pages)} result(s) for '{query}'.", done=True)
+        return (
+                f"Search results for '{query}' ({len(pages)} page(s)):\n\n"
+                + "\n---\n\n".join(sections)
+        )
 
     async def save_to_wiki(
         self,

--- a/tools/mediawiki_tool.py
+++ b/tools/mediawiki_tool.py
@@ -4,7 +4,7 @@ author: WikiTeq
 date: 2025-04-30
 version: 1.0
 license: MIT
-description: Allows the AI to save content as a new or updated MediaWiki page when the user asks to save something to the wiki or knowledge base. Allows AI to search the wiki for pages.
+description: Allows creating new or updating existing MediaWiki pages when the user asks to save or update something to the wiki/knowledge base. Allows AI to search the wiki for pages.
 requirements: mwclient>=0.10.1, pydantic>=2.0.0
 """
 
@@ -177,17 +177,17 @@ class Tools:
         """
         import mwclient
 
-        async def emit(message: str, done: bool = False) -> None:
+        async def emit(message: str, done: bool = False, hidden: bool = True) -> None:
             if __event_emitter__:
-                await __event_emitter__({"type": "status", "data": {"description": message, "done": done}})
+                await __event_emitter__({"type": "status", "data": {"description": message, "done": done, "hidden": hidden}})
 
         # --- Validate configuration ---
         if not self.valves.wiki_url:
-            await emit("MediaWiki URL is not configured in Tool Valves.", done=True)
+            await emit("Error: MediaWiki URL is not configured in Tool Valves.", done=True, hidden=False)
             return "Error: wiki_url is not configured."
         query = query.strip()
         if not query:
-            await emit("Error: search query cannot be empty.", done=True)
+            await emit("Error: search query cannot be empty.", done=True, hidden=False)
             return "Error: search query cannot be empty."
 
         effective_limit = max(1, min(self.valves.max_search_results, MAX_SEARCH_RESULTS))
@@ -196,7 +196,7 @@ class Tools:
         try:
             host, path, scheme = _parse_wiki_url(self.valves.wiki_url)
         except ValueError as e:
-            await emit(str(e), done=True)
+            await emit(f"Error: {e}", done=True, hidden=False)
             return f"Error: {e}"
 
         await emit(f"Connecting to {host}…")
@@ -212,13 +212,14 @@ class Tools:
                 self.valves.password,
             )
         except mwclient.errors.LoginError:
-            await emit("Authentication failed. Check your username and password in Tool Valves.", done=True)
+            await emit("Error: authentication failed. Check your username and password in Tool Valves.", done=True, hidden=False)
             return "Error: authentication failed. If using a BotPassword, the format is 'Username@BotName'."
         except Exception:
             log.error("mwclient connection error", exc_info=True)
-            await emit("Could not connect to the wiki.", done=True)
+            await emit("Error: could not connect to the wiki.", done=True, hidden=False)
             return "Error: could not connect to the wiki. Check the wiki_url in Tool Valves."
 
+        await emit("Fetching wiki article path…")
         article_path = await asyncio.to_thread(_get_article_path, site)
 
         await emit(f"Searching for '{query}'...")
@@ -235,18 +236,18 @@ class Tools:
             titles = await asyncio.to_thread(_search)
         except mwclient.errors.APIError as e:
             if e.code in ("readapidenied", "permissiondenied"):
-                await emit("This wiki requires login to search.", done=True)
+                await emit("Error: this wiki requires login to search.", done=True, hidden=False)
                 return "Error: this wiki requires authentication to search. Please configure username and password in Tool Valves."
             log.error("MediaWiki API error: %s", e.code)
-            await emit("Wiki search error.", done=True)
+            await emit(f"Error: wiki search failed ({e.code}).", done=True, hidden=False)
             return f"Error: wiki API returned an error ({e.code})."
         except Exception:
             log.error("Unexpected error during search", exc_info=True)
-            await emit("Wiki search error.", done=True)
+            await emit("Error: unexpected error during search.", done=True, hidden=False)
             return "Error: unexpected error during search."
 
         if not titles:
-            await emit("No results found.", done=True)
+            await emit("No results found.", done=True, hidden=False)
             return f"No wiki pages found matching '{query}'."
 
         await emit(f"Fetching content for {len(titles)} page(s)...")
@@ -301,6 +302,8 @@ class Tools:
         After this tool returns successfully, respond with only the page URL.
         Do NOT repeat or summarise the page content.
 
+        Content size limit: 2,000,000 characters maximum.
+
         Args:
             title: The wiki page title (e.g. "Meeting Notes 2025-04-30")
             content: The page content formatted as MediaWiki markup
@@ -310,13 +313,13 @@ class Tools:
         """
         import mwclient
 
-        async def emit(message: str, done: bool = False) -> None:
+        async def emit(message: str, done: bool = False, hidden: bool = True) -> None:
             if __event_emitter__:
-                await __event_emitter__({"type": "status", "data": {"description": message, "done": done}})
+                await __event_emitter__({"type": "status", "data": {"description": message, "done": done, "hidden": hidden}})
 
         # --- Validate configuration ---
         if not self.valves.wiki_url:
-            await emit("MediaWiki URL is not configured in Tool Valves.", done=True)
+            await emit("Error: MediaWiki URL is not configured in Tool Valves.", done=True, hidden=False)
             return "Error: wiki_url is not configured."
         # --- Validate inputs ---
         title = title.strip()
@@ -331,14 +334,14 @@ class Tools:
         try:
             _validate_title(title)
         except ValueError as e:
-            await emit(str(e), done=True)
+            await emit(f"Error: {e}", done=True, hidden=False)
             return f"Error: {e}"
 
         # --- Parse wiki URL ---
         try:
             host, path, scheme = _parse_wiki_url(self.valves.wiki_url)
         except ValueError as e:
-            await emit(str(e), done=True)
+            await emit(f"Error: {e}", done=True, hidden=False)
             return f"Error: {e}"
 
         await emit(f"Connecting to {host}…")
@@ -355,11 +358,11 @@ class Tools:
                 self.valves.password,
             )
         except mwclient.errors.LoginError:
-            await emit("Authentication failed. Check your username and password in Tool Valves.", done=True)
+            await emit("Error: authentication failed. Check your username and password in Tool Valves.", done=True, hidden=False)
             return "Error: authentication failed. If using a BotPassword, the format is 'Username@BotName'."
         except Exception:
             log.error("mwclient connection error", exc_info=True)
-            await emit("Could not connect to the wiki.", done=True)
+            await emit("Error: could not connect to the wiki.", done=True, hidden=False)
             return "Error: could not connect to the wiki. Check the wiki_url in Tool Valves."
 
         await emit(f"Saving page «{title}»…")
@@ -372,18 +375,18 @@ class Tools:
         try:
             await asyncio.to_thread(_save)
         except mwclient.errors.ProtectedPageError:
-            await emit(f"Page «{title}» is protected and cannot be edited.", done=True)
+            await emit(f"Error: page «{title}» is protected and cannot be edited.", done=True, hidden=False)
             return f"Error: page «{title}» is protected."
         except mwclient.errors.APIError as e:
             if e.code in ("writeapidenied", "permissiondenied"):
-                await emit("This wiki requires login to write.", done=True)
+                await emit("Error: this wiki requires login to write.", done=True, hidden=False)
                 return "Error: this wiki requires authentication to write. Please configure username and password in Tool Valves."
             log.error("MediaWiki API error: %s", e.code)
-            await emit("Wiki API error while saving.", done=True)
+            await emit(f"Error: wiki save failed ({e.code}).", done=True, hidden=False)
             return f"Error: wiki API returned an error ({e.code}). Check page title and permissions."
         except Exception:
             log.error("Unexpected error saving page", exc_info=True)
-            await emit("An unexpected error occurred while saving.", done=True)
+            await emit("Error: an unexpected error occurred while saving.", done=True, hidden=False)
             return "Error: an unexpected error occurred. Check the server logs for details."
 
         # --- Build canonical page URL (blocking — run in thread) ---

--- a/tools/mediawiki_tool.py
+++ b/tools/mediawiki_tool.py
@@ -86,6 +86,34 @@ def _build_page_url(scheme: str, host: str, article_path: str, title: str) -> st
     return f"{scheme}://{host}{article_path.replace('$1', encoded)}"
 
 
+def _get_article_path(site) -> str:
+    try:
+        result = site.api("query", meta="siteinfo", siprop="general")
+        return result["query"]["general"].get("articlepath", "/wiki/$1")
+    except Exception:
+        log.warning("Could not fetch articlepath from siteinfo; falling back to /wiki/$1", exc_info=True)
+        return "/wiki/$1"
+
+
+def _connect_site(host: str, path: str, scheme: str, timeout: int, username: str, password: str):
+    """Connect to a MediaWiki site, logging in only when credentials are provided."""
+    # Lazy import: OWUI loads this file before installing requirements, so mwclient
+    # is not available at module load time — only at call time.
+    import mwclient
+
+    has_credentials = bool(username and password)
+    site = mwclient.Site(
+        host,
+        path=path,
+        scheme=scheme,
+        force_login=has_credentials,
+        reqs={"timeout": timeout},
+    )
+    if has_credentials:
+        site.login(username, password)
+    return site
+
+
 class Tools:
     class Valves(BaseModel):
         wiki_url: str = Field(
@@ -114,9 +142,11 @@ class Tools:
         )
         max_page_chars: int = Field(
             default=20_000,
+            ge=1,
+            le=500_000,
             description=(
                 "Maximum characters to include per page in search results."
-                " Longer pages are truncated."
+                " Longer pages are truncated. Range: 1–500,000."
             ),
         )
 
@@ -124,9 +154,9 @@ class Tools:
         self.valves = self.Valves()
 
     async def search_wiki(
-            self,
-            query: str,
-            __event_emitter__: Callable[[dict], Awaitable[None]] | None = None,
+        self,
+        query: str,
+        __event_emitter__: Callable[[dict], Awaitable[None]] | None = None,
     ) -> str:
         """
         Search the MediaWiki wiki for pages matching a query and return their full wikitext content.
@@ -149,20 +179,12 @@ class Tools:
 
         async def emit(message: str, done: bool = False) -> None:
             if __event_emitter__:
-                await __event_emitter__(
-                    {"type": "status", "data": {"description": message, "done": done}}
-                )
+                await __event_emitter__({"type": "status", "data": {"description": message, "done": done}})
 
         # --- Validate configuration ---
         if not self.valves.wiki_url:
             await emit("MediaWiki URL is not configured in Tool Valves.", done=True)
             return "Error: wiki_url is not configured."
-        if not self.valves.username or not self.valves.password:
-            await emit(
-                "MediaWiki credentials are not configured in Tool Valves.", done=True
-            )
-            return "Error: username and password are not configured."
-
         query = query.strip()
         if not query:
             await emit("Error: search query cannot be empty.", done=True)
@@ -179,38 +201,25 @@ class Tools:
 
         await emit(f"Connecting to {host}…")
 
-        # --- Connect and authenticate (blocking — run in thread) ---
-        def _connect():
-            site = mwclient.Site(
-                host,
-                path=path,
-                scheme=scheme,
-                reqs={"timeout": self.valves.timeout},
-            )
-            site.login(self.valves.username, self.valves.password)
-            return site
-
         try:
-            site = await asyncio.to_thread(_connect)
-        except mwclient.errors.LoginError:
-            await emit(
-                "Authentication failed. Check your username and password in Tool Valves.",
-                done=True,
+            site = await asyncio.to_thread(
+                _connect_site,
+                host,
+                path,
+                scheme,
+                self.valves.timeout,
+                self.valves.username,
+                self.valves.password,
             )
+        except mwclient.errors.LoginError:
+            await emit("Authentication failed. Check your username and password in Tool Valves.", done=True)
             return "Error: authentication failed. If using a BotPassword, the format is 'Username@BotName'."
         except Exception:
             log.error("mwclient connection error", exc_info=True)
             await emit("Could not connect to the wiki.", done=True)
             return "Error: could not connect to the wiki. Check the wiki_url in Tool Valves."
 
-        def _get_article_path():
-            result = site.api("query", meta="siteinfo", siprop="general")
-            return result["query"]["general"].get("articlepath", "/wiki/$1")
-
-        try:
-            article_path = await asyncio.to_thread(_get_article_path)
-        except Exception:
-            article_path = "/wiki/$1"
+        article_path = await asyncio.to_thread(_get_article_path, site)
 
         await emit(f"Searching for '{query}'...")
 
@@ -224,10 +233,17 @@ class Tools:
 
         try:
             titles = await asyncio.to_thread(_search)
-        except Exception:
-            log.error("Search error", exc_info=True)
+        except mwclient.errors.APIError as e:
+            if e.code in ("readapidenied", "permissiondenied"):
+                await emit("This wiki requires login to search.", done=True)
+                return "Error: this wiki requires authentication to search. Please configure username and password in Tool Valves."
+            log.error("MediaWiki API error: %s", e.code)
             await emit("Wiki search error.", done=True)
-            return f"Error: unexpected error during search."
+            return f"Error: wiki API returned an error ({e.code})."
+        except Exception:
+            log.error("Unexpected error during search", exc_info=True)
+            await emit("Wiki search error.", done=True)
+            return "Error: unexpected error during search."
 
         if not titles:
             await emit("No results found.", done=True)
@@ -245,9 +261,7 @@ class Tools:
                 log.warning("Failed to fetch %r: %s", title, e)
                 return title, "(Content unavailable)"
 
-        pages: list[tuple[str, str]] = await asyncio.gather(
-            *[asyncio.to_thread(_fetch_page, t) for t in titles]
-        )
+        pages: list[tuple[str, str]] = await asyncio.gather(*[asyncio.to_thread(_fetch_page, t) for t in titles])
 
         sections = []
         cap = self.valves.max_page_chars
@@ -255,17 +269,10 @@ class Tools:
             if len(content) > cap:
                 content = content[:cap] + f"\n...(truncated {len(content) - cap} chars)"
             url = _build_page_url(scheme, host, article_path, title)
-            sections.append(
-                f"=== Result {i}: {title} ===\n"
-                f"URL: {url}\n\n"
-                f"Page content: {content}\n"
-            )
+            sections.append(f"=== Result {i}: {title} ===\nURL: {url}\n\nPage content: {content}\n")
 
         await emit(f"Found {len(pages)} result(s) for '{query}'.", done=True)
-        return (
-                f"Search results for '{query}' ({len(pages)} page(s)):\n\n"
-                + "\n---\n\n".join(sections)
-        )
+        return f"Search results for '{query}' ({len(pages)} page(s)):\n\n" + "\n---\n\n".join(sections)
 
     async def save_to_wiki(
         self,
@@ -311,10 +318,6 @@ class Tools:
         if not self.valves.wiki_url:
             await emit("MediaWiki URL is not configured in Tool Valves.", done=True)
             return "Error: wiki_url is not configured."
-        if not self.valves.username or not self.valves.password:
-            await emit("MediaWiki credentials are not configured in Tool Valves.", done=True)
-            return "Error: username and password are not configured."
-
         # --- Validate inputs ---
         title = title.strip()
         if not title:
@@ -340,19 +343,17 @@ class Tools:
 
         await emit(f"Connecting to {host}…")
 
-        # --- Connect and authenticate (blocking — run in thread) ---
-        def _connect():
-            site = mwclient.Site(
-                host,
-                path=path,
-                scheme=scheme,
-                reqs={"timeout": self.valves.timeout},
-            )
-            site.login(self.valves.username, self.valves.password)
-            return site
-
+        # --- Connect and optionally authenticate (blocking — run in thread) ---
         try:
-            site = await asyncio.to_thread(_connect)
+            site = await asyncio.to_thread(
+                _connect_site,
+                host,
+                path,
+                scheme,
+                self.valves.timeout,
+                self.valves.username,
+                self.valves.password,
+            )
         except mwclient.errors.LoginError:
             await emit("Authentication failed. Check your username and password in Tool Valves.", done=True)
             return "Error: authentication failed. If using a BotPassword, the format is 'Username@BotName'."
@@ -374,6 +375,9 @@ class Tools:
             await emit(f"Page «{title}» is protected and cannot be edited.", done=True)
             return f"Error: page «{title}» is protected."
         except mwclient.errors.APIError as e:
+            if e.code in ("writeapidenied", "permissiondenied"):
+                await emit("This wiki requires login to write.", done=True)
+                return "Error: this wiki requires authentication to write. Please configure username and password in Tool Valves."
             log.error("MediaWiki API error: %s", e.code)
             await emit("Wiki API error while saving.", done=True)
             return f"Error: wiki API returned an error ({e.code}). Check page title and permissions."
@@ -385,15 +389,8 @@ class Tools:
         # --- Build canonical page URL (blocking — run in thread) ---
         await emit("Fetching page URL…")
 
-        def _get_article_path():
-            result = site.api("query", meta="siteinfo", siprop="general")
-            return result["query"]["general"].get("articlepath", "/wiki/$1")
-
-        try:
-            article_path = await asyncio.to_thread(_get_article_path)
-            page_url = _build_page_url(scheme, host, article_path, title)
-        except Exception:
-            page_url = _build_page_url(scheme, host, "/wiki/$1", title)
+        article_path = await asyncio.to_thread(_get_article_path, site)
+        page_url = _build_page_url(scheme, host, article_path, title)
 
         await emit(f"Saved: {page_url}", done=True)
         return page_url

--- a/tools/mediawiki_tool.py
+++ b/tools/mediawiki_tool.py
@@ -324,11 +324,17 @@ class Tools:
         # --- Validate inputs ---
         title = title.strip()
         if not title:
-            return "Error: page title cannot be empty."
+            msg = "Error: page title cannot be empty."
+            await emit(msg, done=True, hidden=False)
+            return msg
         if len(title) > MAX_TITLE_LENGTH:
-            return f"Error: page title exceeds maximum length of {MAX_TITLE_LENGTH} characters."
+            msg = f"Error: page title exceeds maximum length of {MAX_TITLE_LENGTH} characters."
+            await emit(msg, done=True, hidden=False)
+            return msg
         if len(content.encode("utf-8")) > MAX_CONTENT_LENGTH:
-            return f"Error: content exceeds maximum allowed size of {MAX_CONTENT_LENGTH // 1_000_000} MB."
+            msg = f"Error: content exceeds maximum allowed size of {MAX_CONTENT_LENGTH // 1_000_000} MB."
+            await emit(msg, done=True, hidden=False)
+            return msg
 
         # --- Title validation (namespace + illegal chars) ---
         try:

--- a/tools/mediawiki_write.py
+++ b/tools/mediawiki_write.py
@@ -1,0 +1,292 @@
+"""
+title: MediaWiki Write Tool
+author: WikiTeq
+date: 2025-04-30
+version: 1.1
+license: MIT
+description: Allows the AI to save content as a new or updated MediaWiki page when the user asks to save something to the wiki or knowledge base.
+requirements: mwclient>=0.10.1, pydantic>=2.0.0
+"""
+
+import asyncio
+import ipaddress
+import logging
+import socket
+from typing import Callable, Awaitable, Optional
+from urllib.parse import urlparse, quote
+from pydantic import BaseModel, Field
+
+log = logging.getLogger(__name__)
+
+_PRIVATE_NETWORKS = [
+    ipaddress.ip_network("10.0.0.0/8"),
+    ipaddress.ip_network("172.16.0.0/12"),
+    ipaddress.ip_network("192.168.0.0/16"),
+    ipaddress.ip_network("127.0.0.0/8"),
+    ipaddress.ip_network("169.254.0.0/16"),
+    ipaddress.ip_network("fe80::/10"),
+    ipaddress.ip_network("::1/128"),
+    ipaddress.ip_network("fc00::/7"),
+    ipaddress.ip_network("100.64.0.0/10"),
+    ipaddress.ip_network("::ffff:0:0/96"),
+]
+
+MAX_TITLE_LENGTH = 255
+MAX_CONTENT_LENGTH = 2_000_000  # 2 MB, MediaWiki default max
+
+_SSRF_ALLOWLIST = {"host.docker.internal", "localhost", "127.0.0.1"}
+
+_BLOCKED_NAMESPACES = {
+    "mediawiki", "template", "module", "gadget", "gadget definition",
+}
+
+
+def _parse_wiki_url(wiki_url: str) -> tuple[str, str, str]:
+    """
+    Parse a wiki URL into (host, path, scheme) for mwclient.Site.
+
+    Requires a full URL with scheme (http:// or https://).
+    Accepts forms like:
+      https://example.com/w/         -> ("example.com", "/w/", "https")
+      https://example.com/wiki/      -> ("example.com", "/w/", "https")
+      https://example.com/index.php  -> ("example.com", "/", "https")
+      https://example.com            -> ("example.com", "/w/", "https")
+      http://localhost:8080          -> ("localhost:8080", "/w/", "http")
+    """
+    wiki_url = wiki_url.strip()
+
+    # Require explicit scheme to avoid mis-parsing bare hostnames
+    if not wiki_url.startswith("http://") and not wiki_url.startswith("https://"):
+        raise ValueError(
+            "wiki_url must start with http:// or https://. "
+            "Example: https://wiki.example.com"
+        )
+
+    parsed = urlparse(wiki_url)
+    scheme = parsed.scheme  # guaranteed to be http or https now
+
+    # Strip userinfo from netloc (user:pass@host -> host)
+    netloc = parsed.hostname or ""
+    if parsed.port:
+        netloc = f"{netloc}:{parsed.port}"
+
+    host = netloc
+
+    path = parsed.path.rstrip("/") or ""
+    if path == "/wiki" or path.startswith("/wiki/"):
+        path = "/w/"
+    elif path == "/index.php" or path.startswith("/index.php/"):
+        path = "/"
+    elif path == "" or path == "/":
+        path = "/w/"
+    else:
+        path = path.rstrip("/") + "/"
+
+    return host, path, scheme
+
+
+def _check_ssrf(host: str) -> None:
+    """Raise ValueError if host resolves to any private/loopback address.
+
+    Checks ALL returned addresses (not just the first) to prevent bypass
+    via multi-A DNS records. localhost and host.docker.internal are
+    explicitly allowed for local dev/testing.
+    """
+    # host may include port (e.g. "localhost:8080") — strip it
+    hostname = host.rsplit(":", 1)[0].strip("[]")  # handles IPv6 [::1]:port too
+
+    if hostname in _SSRF_ALLOWLIST:
+        return
+
+    try:
+        results = socket.getaddrinfo(hostname, None)
+    except socket.gaierror:
+        raise ValueError(f"Could not resolve wiki host: {hostname!r}")
+
+    for result in results:
+        addr_str = result[4][0]
+        try:
+            ip = ipaddress.ip_address(addr_str)
+        except ValueError:
+            continue
+        # Unwrap IPv4-mapped IPv6 addresses (::ffff:x.x.x.x)
+        if isinstance(ip, ipaddress.IPv6Address) and ip.ipv4_mapped:
+            ip = ip.ipv4_mapped
+        for net in _PRIVATE_NETWORKS:
+            if ip in net:
+                raise ValueError(
+                    "Wiki URL resolves to a private/internal address and is not allowed."
+                )
+
+
+def _check_namespace(title: str) -> None:
+    """Raise ValueError if title targets a restricted MediaWiki namespace."""
+    if ":" in title:
+        ns = title.split(":", 1)[0].strip().lower()
+        if ns in _BLOCKED_NAMESPACES:
+            raise ValueError(
+                f"Writing to the '{ns.capitalize()}:' namespace is not allowed."
+            )
+
+
+def _build_page_url(scheme: str, host: str, article_path: str, title: str) -> str:
+    """Build a canonical page URL with proper title encoding."""
+    # MediaWiki uses underscores and percent-encoding in URLs
+    encoded = quote(title.replace(" ", "_"), safe="/:")
+    return f"{scheme}://{host}{article_path.replace('$1', encoded)}"
+
+
+class Tools:
+    class Valves(BaseModel):
+        wiki_url: str = Field(
+            default="",
+            description="Full URL to the MediaWiki instance, e.g. https://wiki.example.com/w/ or https://wiki.example.com. Must include http:// or https://.",
+        )
+        username: str = Field(
+            default="",
+            description="MediaWiki username. For production wikis, use a BotPassword (Special:BotPasswords) in the format 'Username@BotName'.",
+        )
+        password: str = Field(
+            default="",
+            description="MediaWiki password or BotPassword token.",
+        )
+        timeout: int = Field(
+            default=30,
+            description="Request timeout in seconds.",
+        )
+        edit_summary: str = Field(
+            default="Saved via mAItion AI assistant",
+            description="Edit summary recorded in the wiki page history.",
+        )
+
+    def __init__(self):
+        self.valves = self.Valves()
+
+    async def save_to_wiki(
+        self,
+        title: str,
+        content: str,
+        __event_emitter__: Optional[Callable[[dict], Awaitable[None]]] = None,
+    ) -> str:
+        """
+        Save content to a MediaWiki page. Use this tool when the user asks to:
+        - "save into wiki" / "save into knowledge base"
+        - "write to wiki" / "create a wiki page"
+        - "update the wiki page" / "add this to the wiki"
+
+        The tool creates a new page or updates an existing one with the given title and content.
+
+        IMPORTANT: Before calling this tool, convert the content to MediaWiki markup format.
+        Use == Headings ==, '''bold''', ''italic'', * bullet lists, # numbered lists,
+        [[Internal links]], and [https://example.com External links] as appropriate.
+
+        Args:
+            title: The wiki page title (e.g. "Meeting Notes 2025-04-30")
+            content: The page content formatted as MediaWiki markup
+
+        Returns:
+            A URL to the created or updated wiki page, or an error message.
+        """
+        import mwclient
+
+        async def emit(message: str, done: bool = False) -> None:
+            if __event_emitter__:
+                await __event_emitter__(
+                    {"type": "status", "data": {"description": message, "done": done}}
+                )
+
+        # --- Validate configuration ---
+        if not self.valves.wiki_url:
+            await emit("MediaWiki URL is not configured in Tool Valves.", done=True)
+            return "Error: wiki_url is not configured."
+        if not self.valves.username or not self.valves.password:
+            await emit("MediaWiki credentials are not configured in Tool Valves.", done=True)
+            return "Error: username and password are not configured."
+
+        # --- Validate inputs ---
+        title = title.strip()
+        if not title:
+            return "Error: page title cannot be empty."
+        if len(title) > MAX_TITLE_LENGTH:
+            return f"Error: page title exceeds maximum length of {MAX_TITLE_LENGTH} characters."
+        if len(content.encode("utf-8")) > MAX_CONTENT_LENGTH:
+            return f"Error: content exceeds maximum allowed size of {MAX_CONTENT_LENGTH // 1_000_000} MB."
+
+        # --- Namespace guard ---
+        try:
+            _check_namespace(title)
+        except ValueError as e:
+            await emit(str(e), done=True)
+            return f"Error: {e}"
+
+        # --- Parse and validate wiki URL ---
+        try:
+            host, path, scheme = _parse_wiki_url(self.valves.wiki_url)
+        except ValueError as e:
+            await emit(str(e), done=True)
+            return f"Error: {e}"
+
+        # --- SSRF check (runs in thread — getaddrinfo blocks) ---
+        try:
+            await asyncio.to_thread(_check_ssrf, host)
+        except ValueError as e:
+            await emit(str(e), done=True)
+            return f"Error: {e}"
+
+        await emit(f"Connecting to {host}…")
+
+        # --- Connect and authenticate (blocking — run in thread) ---
+        def _connect():
+            site = mwclient.Site(
+                host,
+                path=path,
+                scheme=scheme,
+                reqs={"timeout": self.valves.timeout},
+            )
+            site.login(self.valves.username, self.valves.password)
+            return site
+
+        try:
+            site = await asyncio.to_thread(_connect)
+        except mwclient.errors.LoginError:
+            await emit("Authentication failed. Check your username and password in Tool Valves.", done=True)
+            return "Error: authentication failed. If using a BotPassword, the format is 'Username@BotName'."
+        except Exception:
+            log.error("mwclient connection error", exc_info=True)
+            await emit("Could not connect to the wiki.", done=True)
+            return "Error: could not connect to the wiki. Check the wiki_url in Tool Valves."
+
+        await emit(f"Saving page «{title}»…")
+
+        # --- Save the page (blocking — run in thread) ---
+        def _save():
+            page = site.pages[title]
+            page.save(content, summary=self.valves.edit_summary)
+
+        try:
+            await asyncio.to_thread(_save)
+        except mwclient.errors.ProtectedPageError:
+            await emit(f"Page «{title}» is protected and cannot be edited.", done=True)
+            return f"Error: page «{title}» is protected."
+        except mwclient.errors.APIError as e:
+            log.error("MediaWiki API error: %s", e.code)
+            await emit("Wiki API error while saving.", done=True)
+            return f"Error: wiki API returned an error ({e.code}). Check page title and permissions."
+        except Exception:
+            log.error("Unexpected error saving page", exc_info=True)
+            await emit("An unexpected error occurred while saving.", done=True)
+            return "Error: an unexpected error occurred. Check the server logs for details."
+
+        # --- Build canonical page URL (blocking — run in thread) ---
+        def _get_article_path():
+            result = site.api("query", meta="siteinfo", siprop="general")
+            return result["query"]["general"].get("articlepath", "/wiki/$1")
+
+        try:
+            article_path = await asyncio.to_thread(_get_article_path)
+            page_url = _build_page_url(scheme, host, article_path, title)
+        except Exception:
+            page_url = _build_page_url(scheme, host, "/wiki/$1", title)
+
+        await emit(f"Saved: {page_url}", done=True)
+        return f"Page saved successfully: {page_url}"

--- a/tools/mediawiki_write.py
+++ b/tools/mediawiki_write.py
@@ -2,131 +2,80 @@
 title: MediaWiki Write Tool
 author: WikiTeq
 date: 2025-04-30
-version: 1.1
+version: 1.0
 license: MIT
 description: Allows the AI to save content as a new or updated MediaWiki page when the user asks to save something to the wiki or knowledge base.
 requirements: mwclient>=0.10.1, pydantic>=2.0.0
 """
 
 import asyncio
-import ipaddress
 import logging
-import socket
-from typing import Callable, Awaitable, Optional
-from urllib.parse import urlparse, quote
+import re
+from collections.abc import Awaitable, Callable
+from urllib.parse import quote, urlparse
+
 from pydantic import BaseModel, Field
 
 log = logging.getLogger(__name__)
 
-_PRIVATE_NETWORKS = [
-    ipaddress.ip_network("10.0.0.0/8"),
-    ipaddress.ip_network("172.16.0.0/12"),
-    ipaddress.ip_network("192.168.0.0/16"),
-    ipaddress.ip_network("127.0.0.0/8"),
-    ipaddress.ip_network("169.254.0.0/16"),
-    ipaddress.ip_network("fe80::/10"),
-    ipaddress.ip_network("::1/128"),
-    ipaddress.ip_network("fc00::/7"),
-    ipaddress.ip_network("100.64.0.0/10"),
-    ipaddress.ip_network("::ffff:0:0/96"),
-]
-
 MAX_TITLE_LENGTH = 255
 MAX_CONTENT_LENGTH = 2_000_000  # 2 MB, MediaWiki default max
 
-_SSRF_ALLOWLIST = {"host.docker.internal", "localhost", "127.0.0.1"}
-
-_BLOCKED_NAMESPACES = {
-    "mediawiki", "template", "module", "gadget", "gadget definition",
-}
+# Characters illegal in MediaWiki page titles: #<>[]|{} plus control chars 0-31 and DEL (127)
+_ILLEGAL_TITLE_CHARS = re.compile(r"[#<>\[\]|{}\x00-\x1f\x7f]")
 
 
 def _parse_wiki_url(wiki_url: str) -> tuple[str, str, str]:
     """
-    Parse a wiki URL into (host, path, scheme) for mwclient.Site.
+    Parse an api.php URL into (host, path, scheme) for mwclient.Site.
 
-    Requires a full URL with scheme (http:// or https://).
-    Accepts forms like:
-      https://example.com/w/         -> ("example.com", "/w/", "https")
-      https://example.com/wiki/      -> ("example.com", "/w/", "https")
-      https://example.com/index.php  -> ("example.com", "/", "https")
-      https://example.com            -> ("example.com", "/w/", "https")
-      http://localhost:8080          -> ("localhost:8080", "/w/", "http")
+    Requires the full URL to the api.php script, e.g.:
+      https://example.com/w/api.php   -> ("example.com", "/w/", "https")
+      http://example.com/api.php      -> ("example.com", "/", "http")
+      https://example.com/abc/api.php -> ("example.com", "/abc/", "https")
     """
     wiki_url = wiki_url.strip()
 
-    # Require explicit scheme to avoid mis-parsing bare hostnames
     if not wiki_url.startswith("http://") and not wiki_url.startswith("https://"):
-        raise ValueError(
-            "wiki_url must start with http:// or https://. "
-            "Example: https://wiki.example.com"
-        )
+        raise ValueError("wiki_url must start with http:// or https://. Example: https://wiki.example.com/w/api.php")
 
     parsed = urlparse(wiki_url)
-    scheme = parsed.scheme  # guaranteed to be http or https now
+    scheme = parsed.scheme
 
-    # Strip userinfo from netloc (user:pass@host -> host)
     netloc = parsed.hostname or ""
+    if not netloc:
+        raise ValueError("wiki_url has no host. Example: https://wiki.example.com/w/api.php")
     if parsed.port:
         netloc = f"{netloc}:{parsed.port}"
-
     host = netloc
 
-    path = parsed.path.rstrip("/") or ""
-    if path == "/wiki" or path.startswith("/wiki/"):
-        path = "/w/"
-    elif path == "/index.php" or path.startswith("/index.php/"):
+    # Strip api.php (with optional trailing slash) from path, then ensure trailing slash
+    path = parsed.path
+    # Remove trailing slash before checking for api.php suffix
+    path_stripped = path.rstrip("/")
+    if path_stripped.endswith("/api.php"):
+        path = path_stripped[: -len("/api.php")] + "/"
+    elif path_stripped == "api.php":
         path = "/"
-    elif path == "" or path == "/":
-        path = "/w/"
     else:
-        path = path.rstrip("/") + "/"
+        path = path_stripped.rstrip("/") + "/"
 
     return host, path, scheme
 
 
-def _check_ssrf(host: str) -> None:
-    """Raise ValueError if host resolves to any private/loopback address.
-
-    Checks ALL returned addresses (not just the first) to prevent bypass
-    via multi-A DNS records. localhost and host.docker.internal are
-    explicitly allowed for local dev/testing.
-    """
-    # host may include port (e.g. "localhost:8080") — strip it
-    hostname = host.rsplit(":", 1)[0].strip("[]")  # handles IPv6 [::1]:port too
-
-    if hostname in _SSRF_ALLOWLIST:
-        return
-
-    try:
-        results = socket.getaddrinfo(hostname, None)
-    except socket.gaierror:
-        raise ValueError(f"Could not resolve wiki host: {hostname!r}")
-
-    for result in results:
-        addr_str = result[4][0]
-        try:
-            ip = ipaddress.ip_address(addr_str)
-        except ValueError:
-            continue
-        # Unwrap IPv4-mapped IPv6 addresses (::ffff:x.x.x.x)
-        if isinstance(ip, ipaddress.IPv6Address) and ip.ipv4_mapped:
-            ip = ip.ipv4_mapped
-        for net in _PRIVATE_NETWORKS:
-            if ip in net:
-                raise ValueError(
-                    "Wiki URL resolves to a private/internal address and is not allowed."
-                )
-
-
-def _check_namespace(title: str) -> None:
-    """Raise ValueError if title targets a restricted MediaWiki namespace."""
+def _validate_title(title: str) -> None:
+    """Raise ValueError if title is invalid for NS_MAIN writes."""
     if ":" in title:
-        ns = title.split(":", 1)[0].strip().lower()
-        if ns in _BLOCKED_NAMESPACES:
-            raise ValueError(
-                f"Writing to the '{ns.capitalize()}:' namespace is not allowed."
-            )
+        raise ValueError(
+            "Page title must not contain ':'. Only NS_MAIN (main namespace) pages are supported. "
+            "Use a plain title like 'Meeting Notes 2025-04-30'."
+        )
+    m = _ILLEGAL_TITLE_CHARS.search(title)
+    if m:
+        raise ValueError(
+            f"Page title contains an illegal character: {m.group()!r}. "
+            "Titles must not contain: # < > [ ] | { } or control characters."
+        )
 
 
 def _build_page_url(scheme: str, host: str, article_path: str, title: str) -> str:
@@ -140,7 +89,7 @@ class Tools:
     class Valves(BaseModel):
         wiki_url: str = Field(
             default="",
-            description="Full URL to the MediaWiki instance, e.g. https://wiki.example.com/w/ or https://wiki.example.com. Must include http:// or https://.",
+            description="Full URL to the MediaWiki api.php script, e.g. https://wiki.example.com/w/api.php or http://wiki.example.com/api.php. Must include http:// or https://.",
         )
         username: str = Field(
             default="",
@@ -166,7 +115,7 @@ class Tools:
         self,
         title: str,
         content: str,
-        __event_emitter__: Optional[Callable[[dict], Awaitable[None]]] = None,
+        __event_emitter__: Callable[[dict], Awaitable[None]] | None = None,
     ) -> str:
         """
         Save content to a MediaWiki page. Use this tool when the user asks to:
@@ -180,6 +129,15 @@ class Tools:
         Use == Headings ==, '''bold''', ''italic'', * bullet lists, # numbered lists,
         [[Internal links]], and [https://example.com External links] as appropriate.
 
+        Title rules (MUST follow):
+        - Only main-namespace pages are supported — the title must NOT contain ':'
+        - Maximum length is 255 characters
+        - The following characters are ILLEGAL and must not appear in the title:
+          # < > [ ] | { } and any control characters (ASCII 0-31 and 127)
+
+        After this tool returns successfully, respond with only the page URL.
+        Do NOT repeat or summarise the page content.
+
         Args:
             title: The wiki page title (e.g. "Meeting Notes 2025-04-30")
             content: The page content formatted as MediaWiki markup
@@ -191,9 +149,7 @@ class Tools:
 
         async def emit(message: str, done: bool = False) -> None:
             if __event_emitter__:
-                await __event_emitter__(
-                    {"type": "status", "data": {"description": message, "done": done}}
-                )
+                await __event_emitter__({"type": "status", "data": {"description": message, "done": done}})
 
         # --- Validate configuration ---
         if not self.valves.wiki_url:
@@ -212,23 +168,16 @@ class Tools:
         if len(content.encode("utf-8")) > MAX_CONTENT_LENGTH:
             return f"Error: content exceeds maximum allowed size of {MAX_CONTENT_LENGTH // 1_000_000} MB."
 
-        # --- Namespace guard ---
+        # --- Title validation (namespace + illegal chars) ---
         try:
-            _check_namespace(title)
+            _validate_title(title)
         except ValueError as e:
             await emit(str(e), done=True)
             return f"Error: {e}"
 
-        # --- Parse and validate wiki URL ---
+        # --- Parse wiki URL ---
         try:
             host, path, scheme = _parse_wiki_url(self.valves.wiki_url)
-        except ValueError as e:
-            await emit(str(e), done=True)
-            return f"Error: {e}"
-
-        # --- SSRF check (runs in thread — getaddrinfo blocks) ---
-        try:
-            await asyncio.to_thread(_check_ssrf, host)
         except ValueError as e:
             await emit(str(e), done=True)
             return f"Error: {e}"
@@ -278,6 +227,8 @@ class Tools:
             return "Error: an unexpected error occurred. Check the server logs for details."
 
         # --- Build canonical page URL (blocking — run in thread) ---
+        await emit("Fetching page URL…")
+
         def _get_article_path():
             result = site.api("query", meta="siteinfo", siprop="general")
             return result["query"]["general"].get("articlepath", "/wiki/$1")
@@ -289,4 +240,4 @@ class Tools:
             page_url = _build_page_url(scheme, host, "/wiki/$1", title)
 
         await emit(f"Saved: {page_url}", done=True)
-        return f"Page saved successfully: {page_url}"
+        return page_url


### PR DESCRIPTION
## Summary

- Adds `tools/mediawiki_write.py` — an OpenWebUI Workspace Tool that lets the AI write content to a MediaWiki instance via Native Tool Calling
- Triggered by phrases like "save to wiki", "write to wiki", "create a wiki page"
- Credentials (wiki URL, username, BotPassword) configured via Valves

## Features

- Creates or updates MediaWiki pages using `mwclient`
- Converts content to MediaWiki markup before saving
- SSRF protection: blocks writes to private/internal addresses, checks all DNS results
- Namespace guard: blocks writes to `MediaWiki:`, `Template:`, `Module:`, `Gadget:` namespaces
- Input validation: max title length (255 chars), max content size (2 MB)
- All blocking I/O runs in `asyncio.to_thread()` to avoid blocking the event loop
- Event emitters for real-time status (connecting, saving, done)
- Returns canonical page URL after successful save