### PR TITLE
MAIT-62: Switch to forked maition-web-ui image

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -2,7 +2,7 @@ services:
 
   # OWUI front-end
   openwebui:
-    image: ghcr.io/wikiteq/maition-web-ui:latest
+    image: ghcr.io/wikiteq/maition-web-ui:git-5a77709
     ports:
       - "${HTTP_WEB_PORT:-3000}:8080"
     depends_on:

--- a/compose.yaml
+++ b/compose.yaml
@@ -2,7 +2,7 @@ services:
 
   # OWUI front-end
   openwebui:
-    image: ghcr.io/wikiteq/maition-web-ui:git-5a77709
+    image: ghcr.io/wikiteq/maition-web-ui:git-4a85c3a
     ports:
       - "${HTTP_WEB_PORT:-3000}:8080"
     depends_on:

--- a/compose.yaml
+++ b/compose.yaml
@@ -2,7 +2,7 @@ services:
 
   # OWUI front-end
   openwebui:
-    image: ghcr.io/open-webui/open-webui:0.6.5
+    image: ghcr.io/wikiteq/maition-web-ui:latest
     ports:
       - "${HTTP_WEB_PORT:-3000}:8080"
     depends_on:


### PR DESCRIPTION
## Summary
- Replaces the official `ghcr.io/open-webui/open-webui:0.6.5` image with our forked `ghcr.io/wikiteq/maition-web-ui:latest`
- The fork is based on OWUI v0.6.5 and built via CI in [wikiteq/maition-web-ui](https://github.com/wikiteq/maition-web-ui)
- No functional changes — the forked image is a drop-in replacement

## Test plan
- [ ] `docker compose up -d` starts successfully
- [ ] OpenWebUI is accessible and behaves the same as before
- [ ] RAG filter function works correctly with the new image