### PR TITLE
MAIT-210: Conditionally install & configure MediaWiki Tool on first boot

### DIFF
--- a/.env.openwebui.example
+++ b/.env.openwebui.example
@@ -53,3 +53,10 @@ ENABLE_OLLAMA_API=False
 # the URL of the ROAT API, keep default
 ROAT_API_URL=http://api:8000
 ROAT_API_KEY=12345
+
+# MediaWiki Tool (optional): set TOOL_MEDIAWIKI_ENABLED=true to auto-install the
+# MediaWiki Search & Write Tool on first boot. MEDIAWIKI_API_URL is required when enabled.
+#TOOL_MEDIAWIKI_ENABLED=true
+#MEDIAWIKI_API_URL=https://wiki.example.com/w/api.php
+#MEDIAWIKI_USERNAME=
+#MEDIAWIKI_PASSWORD=

--- a/compose.yaml
+++ b/compose.yaml
@@ -18,6 +18,7 @@ services:
       - open-webui-cache:/root/.cache
       - ./tools/roat_retrieval.py:/etc/roat_retrieval.py
       - ./tools/roat_retrieval.json:/etc/roat_retrieval.json
+      - ./tools/mediawiki_tool.py:/etc/mediawiki_tool.py
       - ./helpers/entrypoint.sh:/custom-entrypoint.sh
       - ./helpers/healthz.py:/etc/healthz.py
       - ./patches:/etc/patches

--- a/compose.yaml
+++ b/compose.yaml
@@ -19,6 +19,7 @@ services:
       - ./tools/roat_retrieval.py:/etc/roat_retrieval.py
       - ./tools/roat_retrieval.json:/etc/roat_retrieval.json
       - ./tools/mediawiki_tool.py:/etc/mediawiki_tool.py
+      - ./tools/mediawiki_tool.json:/etc/mediawiki_tool.json
       - ./helpers/entrypoint.sh:/custom-entrypoint.sh
       - ./helpers/healthz.py:/etc/healthz.py
       - ./patches:/etc/patches

--- a/helpers/entrypoint.sh
+++ b/helpers/entrypoint.sh
@@ -210,7 +210,47 @@ do_first_start() {
       -H "Content-Type: application/json" \
       --data-raw "{\"suggestions\":[]}"
 
+    install_mediawiki_tool
+
     touch /app/backend/data/.first_start
+}
+
+install_mediawiki_tool() {
+    if [ "$TOOL_MEDIAWIKI_ENABLED" != "true" ]; then
+        return
+    fi
+
+    if [ -z "$MEDIAWIKI_API_URL" ]; then
+        echo "[Custom entrypoint] ERROR: TOOL_MEDIAWIKI_ENABLED=true but MEDIAWIKI_API_URL is not set. Skipping MediaWiki Tool install." >&2
+        return 1
+    fi
+
+    echo ""
+    echo "[Custom entrypoint] Installing MediaWiki Tool..."
+
+    TOOL_CODE=$(jq -Rs . < "/etc/mediawiki_tool.py")
+
+    CREATE_RESPONSE=$(curl -s -X POST "http://localhost:8080/api/v1/tools/create" \
+      -H "Authorization: Bearer ${API_KEY}" \
+      -H "Content-Type: application/json" \
+      --data-raw "{\"id\":\"mediawiki\",\"name\":\"MediaWiki Search & Write Tool\",\"content\":${TOOL_CODE},\"meta\":{\"description\":\"Search and write MediaWiki pages\"}}")
+
+    TOOL_ID=$(echo "${CREATE_RESPONSE}" | jq -r '.id // empty')
+    if [ -z "$TOOL_ID" ]; then
+        echo "[Custom entrypoint] WARNING: MediaWiki Tool install failed"
+        echo "${CREATE_RESPONSE}"
+        return
+    fi
+
+    echo "[Custom entrypoint] MediaWiki Tool created with id: ${TOOL_ID}"
+
+    echo ""
+    echo "[Custom entrypoint] Configuring MediaWiki Tool valves..."
+    curl -s -X POST "http://localhost:8080/api/v1/tools/id/${TOOL_ID}/valves/update" \
+      -H "Authorization: Bearer ${API_KEY}" \
+      -H "Content-Type: application/json" \
+      --data-raw "{\"wiki_url\":\"${MEDIAWIKI_API_URL}\",\"username\":\"${MEDIAWIKI_USERNAME:-}\",\"password\":\"${MEDIAWIKI_PASSWORD:-}\"}"
+
 }
 
 start_healthz_server

--- a/helpers/entrypoint.sh
+++ b/helpers/entrypoint.sh
@@ -229,11 +229,12 @@ install_mediawiki_tool() {
     echo "[Custom entrypoint] Installing MediaWiki Tool..."
 
     TOOL_CODE=$(jq -Rs . < "/etc/mediawiki_tool.py")
+    DATA_RAW=$(jq --argjson content "${TOOL_CODE}" '.content=$content' /etc/mediawiki_tool.json)
 
     CREATE_RESPONSE=$(curl -s -X POST "http://localhost:8080/api/v1/tools/create" \
       -H "Authorization: Bearer ${API_KEY}" \
       -H "Content-Type: application/json" \
-      --data-raw "{\"id\":\"mediawiki\",\"name\":\"MediaWiki Search & Write Tool\",\"content\":${TOOL_CODE},\"meta\":{\"description\":\"Search and write MediaWiki pages\"}}")
+      --data-raw "${DATA_RAW}")
 
     TOOL_ID=$(echo "${CREATE_RESPONSE}" | jq -r '.id // empty')
     if [ -z "$TOOL_ID" ]; then

--- a/helpers/entrypoint.sh
+++ b/helpers/entrypoint.sh
@@ -9,6 +9,11 @@ set -e
 : "${HEALTHZ_PORT:?missing HEALTHZ_PORT}"
 : "${HEALTHZ_READY_FILE:?missing HEALTHZ_READY_FILE}"
 
+if [ "$TOOL_MEDIAWIKI_ENABLED" = "true" ] && [ -z "$MEDIAWIKI_API_URL" ]; then
+    echo "[Custom entrypoint] ERROR: TOOL_MEDIAWIKI_ENABLED=true but MEDIAWIKI_API_URL is not set." >&2
+    exit 1
+fi
+
 start_healthz_server() {
     # poor mans healthz server
     echo "[Custom entrypoint] Starting :$HEALTHZ_PORT/healthz endpoint.."
@@ -220,11 +225,6 @@ install_mediawiki_tool() {
         return
     fi
 
-    if [ -z "$MEDIAWIKI_API_URL" ]; then
-        echo "[Custom entrypoint] ERROR: TOOL_MEDIAWIKI_ENABLED=true but MEDIAWIKI_API_URL is not set. Skipping MediaWiki Tool install." >&2
-        return 1
-    fi
-
     echo ""
     echo "[Custom entrypoint] Installing MediaWiki Tool..."
 
@@ -247,10 +247,15 @@ install_mediawiki_tool() {
 
     echo ""
     echo "[Custom entrypoint] Configuring MediaWiki Tool valves..."
+    VALVES_JSON=$(jq -n \
+      --arg wiki "${MEDIAWIKI_API_URL}" \
+      --arg user "${MEDIAWIKI_USERNAME:-}" \
+      --arg pass "${MEDIAWIKI_PASSWORD:-}" \
+      '{wiki_url:$wiki,username:$user,password:$pass}')
     curl -s -X POST "http://localhost:8080/api/v1/tools/id/${TOOL_ID}/valves/update" \
       -H "Authorization: Bearer ${API_KEY}" \
       -H "Content-Type: application/json" \
-      --data-raw "{\"wiki_url\":\"${MEDIAWIKI_API_URL}\",\"username\":\"${MEDIAWIKI_USERNAME:-}\",\"password\":\"${MEDIAWIKI_PASSWORD:-}\"}"
+      --data-raw "${VALVES_JSON}"
 
 }
 

--- a/helpers/entrypoint.sh
+++ b/helpers/entrypoint.sh
@@ -9,11 +9,6 @@ set -e
 : "${HEALTHZ_PORT:?missing HEALTHZ_PORT}"
 : "${HEALTHZ_READY_FILE:?missing HEALTHZ_READY_FILE}"
 
-if [ "$TOOL_MEDIAWIKI_ENABLED" = "true" ] && [ -z "$MEDIAWIKI_API_URL" ]; then
-    echo "[Custom entrypoint] ERROR: TOOL_MEDIAWIKI_ENABLED=true but MEDIAWIKI_API_URL is not set." >&2
-    exit 1
-fi
-
 start_healthz_server() {
     # poor mans healthz server
     echo "[Custom entrypoint] Starting :$HEALTHZ_PORT/healthz endpoint.."
@@ -225,6 +220,11 @@ install_mediawiki_tool() {
         return
     fi
 
+    if [ -z "$MEDIAWIKI_API_URL" ]; then
+        echo "[Custom entrypoint] WARNING: TOOL_MEDIAWIKI_ENABLED=true but MEDIAWIKI_API_URL is not set. Skipping MediaWiki Tool install." >&2
+        return
+    fi
+
     echo ""
     echo "[Custom entrypoint] Installing MediaWiki Tool..."
 
@@ -252,6 +252,7 @@ install_mediawiki_tool() {
       --arg user "${MEDIAWIKI_USERNAME:-}" \
       --arg pass "${MEDIAWIKI_PASSWORD:-}" \
       '{wiki_url:$wiki,username:$user,password:$pass}')
+
     curl -s -X POST "http://localhost:8080/api/v1/tools/id/${TOOL_ID}/valves/update" \
       -H "Authorization: Bearer ${API_KEY}" \
       -H "Content-Type: application/json" \

--- a/tools/mediawiki_tool.json
+++ b/tools/mediawiki_tool.json
@@ -1,0 +1,9 @@
+{
+	"id": "mediawiki",
+	"name": "MediaWiki Search & Write Tool",
+	"content": "",
+	"meta": {
+		"description": "Search and write MediaWiki pages",
+		"manifest": {}
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `install_mediawiki_tool()` to `helpers/entrypoint.sh`, called from `do_first_start()` and gated on `TOOL_MEDIAWIKI_ENABLED=true`
- Uses `MEDIAWIKI_API_URL` / `MEDIAWIKI_USERNAME` / `MEDIAWIKI_PASSWORD` — matching the kustomize deployment ENVs exactly, no remapping needed
- Fails fast with a clear error if `TOOL_MEDIAWIKI_ENABLED=true` but `MEDIAWIKI_API_URL` is not set
- Adds `tools/mediawiki_tool.json` template (consistent with `roat_retrieval.json` pattern)
- Mounts both `mediawiki_tool.py` and `mediawiki_tool.json` into the container via `compose.yaml`
- Documents all new ENVs in `.env.openwebui.example`