### PR TITLE
MAIT-195: Remove trailing slashes from ROAT API endpoint URLs in entrypoint

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -87,7 +87,7 @@ services:
 
   # rag-of-all-trades API
   api:
-    image: ghcr.io/wikiteq/rag-of-all-trades:f1d1428
+    image: ghcr.io/wikiteq/rag-of-all-trades:084bd29
     extra_hosts:
       - "host.docker.internal:host-gateway"
     depends_on:
@@ -111,7 +111,7 @@ services:
 
   # rag-of-all-trades WORKER
   celery_worker:
-    image: ghcr.io/wikiteq/rag-of-all-trades:f1d1428
+    image: ghcr.io/wikiteq/rag-of-all-trades:084bd29
     extra_hosts:
       - "host.docker.internal:host-gateway"
     depends_on:
@@ -137,7 +137,7 @@ services:
 
   # rag-of-all-trades BEAT
   celery_beat:
-    image: ghcr.io/wikiteq/rag-of-all-trades:f1d1428
+    image: ghcr.io/wikiteq/rag-of-all-trades:084bd29
     depends_on:
       postgres:
         condition: service_healthy

--- a/helpers/entrypoint.sh
+++ b/helpers/entrypoint.sh
@@ -109,7 +109,7 @@ do_first_start() {
     # curl -s -X POST "http://localhost:8080/api/v1/functions/id/ragofalltrades/valves/update" \
     #   -H "Authorization: Bearer ${API_KEY}" \
     #   -H "Content-Type: application/json" \
-    #   --data-raw "{\"pipelines\":[\"*\"],\"priority\":null,\"enabled\":true,\"rag_service_url\":\"$ROAT_API_URL/api/v1/query/\",\"rag_service_api_key\":\"$ROAT_API_KEY\",\"rag_service_timeout\":null,\"top_k\":null,\"inject_context\":null,\"context_template\":null}"
+    #   --data-raw "{\"pipelines\":[\"*\"],\"priority\":null,\"enabled\":true,\"rag_service_url\":\"$ROAT_API_URL/api/v1/query\",\"rag_service_api_key\":\"$ROAT_API_KEY\",\"rag_service_timeout\":null,\"top_k\":null,\"inject_context\":null,\"context_template\":null}"
     #
     # echo ""
     # echo "[Custom entrypoint] Enabling the function"
@@ -140,7 +140,7 @@ do_first_start() {
     curl -s -X POST "http://localhost:8080/api/v1/tools/id/roat_retrieval/valves/update" \
       -H "Authorization: Bearer ${API_KEY}" \
       -H "Content-Type: application/json" \
-      --data-raw "{\"rag_service_url\":\"$ROAT_API_URL/api/v1/query/\",\"rag_service_api_key\":\"$ROAT_API_KEY\"}"
+      --data-raw "{\"rag_service_url\":\"$ROAT_API_URL/api/v1/query\",\"rag_service_api_key\":\"$ROAT_API_KEY\"}"
 
     echo ""
     echo "[Custom entrypoint] Disabling Direct Connections for regular users"

--- a/helpers/entrypoint.sh
+++ b/helpers/entrypoint.sh
@@ -140,7 +140,8 @@ do_first_start() {
     curl -s -X POST "http://localhost:8080/api/v1/tools/id/roat_retrieval/valves/update" \
       -H "Authorization: Bearer ${API_KEY}" \
       -H "Content-Type: application/json" \
-      --data-raw "{\"rag_service_url\":\"$ROAT_API_URL/api/v1/query\",\"rag_service_api_key\":\"$ROAT_API_KEY\"}"
+      --data-raw "$(jq -n --arg url "$ROAT_API_URL/api/v1/query" --arg key "$ROAT_API_KEY" \
+        '{rag_service_url:$url,rag_service_api_key:$key}')"
 
     echo ""
     echo "[Custom entrypoint] Disabling Direct Connections for regular users"


### PR DESCRIPTION
## Summary

- Removes trailing slash from `rag_service_url` in the ROAT tool valve configuration (`/api/v1/query/` → `/api/v1/query`)
- Updates the commented-out filter function reference for consistency

## Context

The canonical ROAT API endpoints no longer use trailing slashes. This aligns the entrypoint bootstrap configuration with the updated URL convention.