### PR TITLE
MAIT-163: Add Wiki.js connector config and documentation

### DIFF
--- a/.env.rag.example
+++ b/.env.rag.example
@@ -106,5 +106,5 @@ S3_ACCOUNT1_SCHEDULES=
 
 # WIKI.JS CONNECTORS (optional):
 #WIKIJS1_BASE_URL=https://wiki.example.com
-#WIKIJS1_API_TOKEN=your-api-token   # must have read:source scope
+#WIKIJS1_API_TOKEN=your-api-token   # must have read:pages and read:source scopes
 #WIKIJS1_SCHEDULES=3600

--- a/.env.rag.example
+++ b/.env.rag.example
@@ -103,3 +103,8 @@ S3_ACCOUNT1_SCHEDULES=
 #PIPEDRIVE1_SCHEDULES=3600
 #PIPEDRIVE2_API_TOKEN=your-second-pipedrive-api-token
 #PIPEDRIVE2_SCHEDULES=3600
+
+# WIKI.JS CONNECTORS (optional):
+#WIKIJS1_BASE_URL=https://wiki.example.com
+#WIKIJS1_API_TOKEN=your-api-token   # must have read:source scope
+#WIKIJS1_SCHEDULES=3600

--- a/README.md
+++ b/README.md
@@ -351,7 +351,13 @@ PIPEDRIVE2_SCHEDULES=3600
 ### Wiki.js Connector
 
 The Wiki.js connector ingests pages from a [Wiki.js](https://js.wiki) v2 instance via the GraphQL API.
-The API token must have the **read:source** permission scope to retrieve page content.
+Both `markdown` and `html` content types are handled; HTML is automatically converted to Markdown.
+Metadata collected per page includes: page_id, path, locale, title, url, updated_at, tags, is_published.
+
+The API token requires two permission scopes:
+
+- `read:pages` — required for page discovery and metadata
+- `read:source` — required for page content; without it the content field is returned empty with no error
 
 ```yaml
 # config.yaml
@@ -361,7 +367,7 @@ sources:
     name: "wikijs1"
     config:
       base_url: "${WIKIJS1_BASE_URL}"
-      api_token: "${WIKIJS1_API_TOKEN}"   # must have read:source scope
+      api_token: "${WIKIJS1_API_TOKEN}"   # must have read:pages and read:source scopes
       schedules: "${WIKIJS1_SCHEDULES}"
       #paths:                             # optional; ingest only pages under these path prefixes
       #  - "/engineering"

--- a/README.md
+++ b/README.md
@@ -348,6 +348,37 @@ PIPEDRIVE2_API_TOKEN=your-second-pipedrive-api-token
 PIPEDRIVE2_SCHEDULES=3600
 ```
 
+### Wiki.js Connector
+
+The Wiki.js connector ingests pages from a [Wiki.js](https://js.wiki) v2 instance via the GraphQL API.
+The API token must have the **read:source** permission scope to retrieve page content.
+
+```yaml
+# config.yaml
+
+sources:
+  - type: "wikijs"
+    name: "wikijs1"
+    config:
+      base_url: "${WIKIJS1_BASE_URL}"
+      api_token: "${WIKIJS1_API_TOKEN}"   # must have read:source scope
+      schedules: "${WIKIJS1_SCHEDULES}"
+      #paths:                             # optional; ingest only pages under these path prefixes
+      #  - "/engineering"
+      #  - "/product"
+      #tags: "public"                     # optional; server-side tag filter (comma-separated)
+      #locale: "en"                       # optional; server-side locale filter
+      #include_unpublished: false         # optional, default false
+```
+
+```dotenv
+# .env.rag
+
+WIKIJS1_BASE_URL=https://wiki.example.com
+WIKIJS1_API_TOKEN=your-api-token
+WIKIJS1_SCHEDULES=3600
+```
+
 ## Embeddings and Inference
 
 ### Embeddings support

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ interact with your knowledge with ease!
 * S3 (any AWS compatible Object Storage including AWS, Contabo, B2, Cloudflare R2, OVH, etc)
 * MediaWiki (all versions supported, both private and public wiki)
 * SerpAPI
+* Wiki.js
 
 ## 🌐 Extra connectors
 

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -105,6 +105,20 @@ sources:
   #    api_token: "${PIPEDRIVE2_API_TOKEN}"
   #    schedules: "${PIPEDRIVE2_SCHEDULES}"
 
+  # Wiki.js connector (API token must have read:source scope)
+  #- type: "wikijs"
+  #  name: "wikijs1"
+  #  config:
+  #    base_url: "${WIKIJS1_BASE_URL}"
+  #    api_token: "${WIKIJS1_API_TOKEN}"
+  #    schedules: "${WIKIJS1_SCHEDULES}"
+  #    #paths:                             # optional; ingest only pages under these path prefixes
+  #    #  - "/engineering"
+  #    #  - "/product"
+  #    #tags: "public"                     # optional; server-side tag filter (comma-separated)
+  #    #locale: "en"                       # optional; server-side locale filter
+  #    #include_unpublished: false         # optional, default false
+
 embedding:
   # can be `local` or `openrouter`/`openai`
   provider: local

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -105,7 +105,7 @@ sources:
   #    api_token: "${PIPEDRIVE2_API_TOKEN}"
   #    schedules: "${PIPEDRIVE2_SCHEDULES}"
 
-  # Wiki.js connector (API token must have read:source scope)
+  # Wiki.js connector (API token must have read:pages and read:source scopes)
   #- type: "wikijs"
   #  name: "wikijs1"
   #  config:


### PR DESCRIPTION
## Summary

- Adds `### Wiki.js Connector` section to `README.md` with `config.yaml` and `.env.rag` examples
- Adds commented Wiki.js connector block to `config.yaml.example`
- Adds `WIKIJS1_*` env vars to `.env.rag.example`

## Notes

Companion to WikiTeq/rag-of-all-trades#60 — connector implementation PR.