### PR TITLE
SK-4: Show inline videos in AI chat when sources contain video metadata

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -20,6 +20,8 @@ services:
       - ./tools/roat_retrieval.json:/etc/roat_retrieval.json
       - ./tools/mediawiki_tool.py:/etc/mediawiki_tool.py
       - ./tools/mediawiki_tool.json:/etc/mediawiki_tool.json
+      - ./functions/video_inject.py:/etc/video_inject.py
+      - ./functions/video_inject.json:/etc/video_inject.json
       - ./models/wikiteqcenturion.json:/etc/wikiteqcenturion.json:ro
       - ./helpers/entrypoint.sh:/custom-entrypoint.sh
       - ./helpers/healthz.py:/etc/healthz.py

--- a/functions/video_inject.json
+++ b/functions/video_inject.json
@@ -3,7 +3,7 @@
   "name": "Video Inject Filter",
   "type": "filter",
   "meta": {
-    "description": "Reads VIDEO markers from tool messages and prepends an inline video player to the assistant response."
+    "description": "Reads VIDEO markers from tool messages and appends an inline video player after the assistant response."
   },
   "content": ""
 }

--- a/functions/video_inject.json
+++ b/functions/video_inject.json
@@ -1,0 +1,9 @@
+{
+  "id": "video_inject",
+  "name": "Video Inject Filter",
+  "type": "filter",
+  "meta": {
+    "description": "Reads VIDEO markers from tool messages and prepends an inline video player to the assistant response."
+  },
+  "content": ""
+}

--- a/functions/video_inject.py
+++ b/functions/video_inject.py
@@ -4,13 +4,13 @@ author: WikiTeq
 date: 2025-05-20
 version: 1.0
 license: MIT
-description: Reads <!--VIDEO:url--> markers from tool messages and appends an inline <video> player after the assistant response.
+description: Reads VIDEO markers from tool messages and appends an inline <video> player after the assistant response.
 """
 
 import logging
 import re
+from html import escape as html_escape
 from html import unescape
-from urllib.parse import quote as url_quote
 
 from pydantic import BaseModel
 
@@ -29,8 +29,8 @@ class Filter:
         log.info("video_inject outlet called, %d messages", len(messages))
 
         video_url = None
+        marker_re = re.compile(r"<!--VIDEO:(https://[^\s>]+)-->")
         for msg in reversed(messages):
-            role = msg.get("role")
             content = msg.get("content", "")
             if isinstance(content, list):
                 content = " ".join(
@@ -39,18 +39,43 @@ class Filter:
                 )
             if not isinstance(content, str):
                 continue
-            log.debug("video_inject role=%s content_len=%d", role, len(content))
-            m = re.search(r"<!--VIDEO:(https://[^\s>]+)-->", unescape(content))
+            m = marker_re.search(unescape(content))
             if m:
                 video_url = m.group(1)
-                log.info("video_inject: found marker in role=%s", role)
+                log.info("video_inject: found marker in role=%s", msg.get("role"))
                 break
 
         if not video_url:
             log.info("video_inject: no video marker found")
             return body
 
-        safe_url = url_quote(video_url, safe=":/?=&%#@!$,;~")
+        log.info("video_inject: injecting player for %s", video_url[:80])
+
+        # Strip markers in all encoded forms from all messages.
+        # 1. Raw:          <!--VIDEO:https://...-->
+        # 2. HTML-escaped: &lt;!--VIDEO:https://...--&gt;  (inside <details result="...">)
+        # 3. JSON+HTML:    <!--VIDEO:https://...->  (JSON-encoded in result attr)
+        strip_patterns = [
+            re.compile(r"<!--VIDEO:https://[^\s>]+-->"),
+            re.compile(r"&lt;!--VIDEO:https://[^\s&]+--&gt;"),
+            re.compile(r"\\u003c!--VIDEO:https://[^\s\\]+--\\u003e"),
+        ]
+
+        def strip_markers(text: str) -> str:
+            for p in strip_patterns:
+                text = p.sub("", text)
+            return text
+
+        for msg in messages:
+            content = msg.get("content")
+            if isinstance(content, str):
+                msg["content"] = strip_markers(content)
+            elif isinstance(content, list):
+                for part in content:
+                    if isinstance(part, dict) and isinstance(part.get("text"), str):
+                        part["text"] = strip_markers(part["text"])
+
+        safe_url = html_escape(video_url, quote=True)
         ext = video_url.rsplit(".", 1)[-1].split("?")[0].lower()
         mime_types = {"mp4": "video/mp4", "webm": "video/webm", "ogg": "video/ogg", "mov": "video/quicktime"}
         mime = mime_types.get(ext, "video/mp4")

--- a/functions/video_inject.py
+++ b/functions/video_inject.py
@@ -29,7 +29,7 @@ class Filter:
         log.info("video_inject outlet called, %d messages", len(messages))
 
         video_url = None
-        for msg in messages:
+        for msg in reversed(messages):
             role = msg.get("role")
             content = msg.get("content", "")
             if isinstance(content, list):

--- a/functions/video_inject.py
+++ b/functions/video_inject.py
@@ -1,0 +1,65 @@
+"""
+title: Video Inject Filter
+author: WikiTeq
+date: 2025-05-20
+version: 1.0
+license: MIT
+description: Reads <!--VIDEO:url--> markers from tool messages and appends an inline <video> player after the assistant response.
+"""
+
+import logging
+import re
+from html import unescape
+from urllib.parse import quote as url_quote
+
+from pydantic import BaseModel
+
+log = logging.getLogger(__name__)
+
+
+class Filter:
+    class Valves(BaseModel):
+        pass
+
+    def __init__(self):
+        self.valves = self.Valves()
+
+    async def outlet(self, body: dict, __user__=None, __event_emitter__=None) -> dict:
+        messages = body.get("messages", [])
+        log.info("video_inject outlet called, %d messages", len(messages))
+
+        video_url = None
+        for msg in messages:
+            role = msg.get("role")
+            content = msg.get("content", "")
+            if isinstance(content, list):
+                content = " ".join(
+                    part.get("text", "") if isinstance(part, dict) else str(part)
+                    for part in content
+                )
+            if not isinstance(content, str):
+                continue
+            log.info("video_inject role=%s content=%s", role, content[:300])
+            m = re.search(r"<!--VIDEO:(https://[^\s>]+)-->", unescape(content))
+            if m:
+                video_url = m.group(1)
+                log.info("video_inject: found marker in role=%s", role)
+                break
+
+        if not video_url:
+            log.info("video_inject: no video marker found")
+            return body
+
+        safe_url = url_quote(video_url, safe=":/?=&%#@!$,;~")
+        ext = video_url.rsplit(".", 1)[-1].split("?")[0].lower()
+        mime_types = {"mp4": "video/mp4", "webm": "video/webm", "ogg": "video/ogg", "mov": "video/quicktime"}
+        mime = mime_types.get(ext, "video/mp4")
+        video_block = f'<video controls style="max-width:100%">\n<source src="{safe_url}" type="{mime}">\n</video>'
+
+        for msg in reversed(messages):
+            if msg.get("role") == "assistant" and isinstance(msg.get("content"), str):
+                msg["content"] = f"{msg['content']}\n\n{video_block}"
+                log.info("video_inject: appended player for %s", video_url[:80])
+                break
+
+        return body

--- a/functions/video_inject.py
+++ b/functions/video_inject.py
@@ -39,7 +39,7 @@ class Filter:
                 )
             if not isinstance(content, str):
                 continue
-            log.info("video_inject role=%s content=%s", role, content[:300])
+            log.debug("video_inject role=%s content_len=%d", role, len(content))
             m = re.search(r"<!--VIDEO:(https://[^\s>]+)-->", unescape(content))
             if m:
                 video_url = m.group(1)

--- a/helpers/entrypoint.sh
+++ b/helpers/entrypoint.sh
@@ -300,9 +300,9 @@ install_video_inject_filter() {
 
     FILTER_ID=$(echo "${CREATE_RESPONSE}" | jq -r '.id // empty')
     if [ -z "$FILTER_ID" ]; then
-        echo "[Custom entrypoint] WARNING: Video Inject Filter install failed"
-        echo "${CREATE_RESPONSE}"
-        return
+        echo "[Custom entrypoint] ERROR: Video Inject Filter install failed" >&2
+        echo "${CREATE_RESPONSE}" >&2
+        exit 1
     fi
 
     echo "[Custom entrypoint] Video Inject Filter created with id: ${FILTER_ID}"

--- a/helpers/entrypoint.sh
+++ b/helpers/entrypoint.sh
@@ -293,7 +293,7 @@ install_video_inject_filter() {
     FILTER_CODE=$(jq -Rs . < "/etc/video_inject.py")
     DATA_RAW=$(jq --argjson content "${FILTER_CODE}" '.content=$content' /etc/video_inject.json)
 
-    CREATE_RESPONSE=$(curl -s -X POST "http://localhost:8080/api/v1/functions/create" \
+    CREATE_RESPONSE=$(curl -fsS -X POST "http://localhost:8080/api/v1/functions/create" \
       -H "Authorization: Bearer ${API_KEY}" \
       -H "Content-Type: application/json" \
       --data-raw "${DATA_RAW}")
@@ -309,13 +309,13 @@ install_video_inject_filter() {
 
     echo ""
     echo "[Custom entrypoint] Enabling Video Inject Filter..."
-    curl -s -X POST "http://localhost:8080/api/v1/functions/id/${FILTER_ID}/toggle" \
+    curl -fsS -X POST "http://localhost:8080/api/v1/functions/id/${FILTER_ID}/toggle" \
       -H "Authorization: Bearer ${API_KEY}" \
       -H "Content-Type: application/json"
 
     echo ""
     echo "[Custom entrypoint] Enabling Video Inject Filter globally..."
-    curl -s -X POST "http://localhost:8080/api/v1/functions/id/${FILTER_ID}/toggle/global" \
+    curl -fsS -X POST "http://localhost:8080/api/v1/functions/id/${FILTER_ID}/toggle/global" \
       -H "Authorization: Bearer ${API_KEY}" \
       -H "Content-Type: application/json"
 }

--- a/helpers/entrypoint.sh
+++ b/helpers/entrypoint.sh
@@ -236,6 +236,7 @@ do_first_start() {
       --data-raw "{\"suggestions\":[]}"
 
     install_mediawiki_tool
+    install_video_inject_filter
 
     touch /app/backend/data/.first_start
 }
@@ -283,6 +284,40 @@ install_mediawiki_tool() {
       -H "Content-Type: application/json" \
       --data-raw "${VALVES_JSON}"
 
+}
+
+install_video_inject_filter() {
+    echo ""
+    echo "[Custom entrypoint] Installing Video Inject Filter..."
+
+    FILTER_CODE=$(jq -Rs . < "/etc/video_inject.py")
+    DATA_RAW=$(jq --argjson content "${FILTER_CODE}" '.content=$content' /etc/video_inject.json)
+
+    CREATE_RESPONSE=$(curl -s -X POST "http://localhost:8080/api/v1/functions/create" \
+      -H "Authorization: Bearer ${API_KEY}" \
+      -H "Content-Type: application/json" \
+      --data-raw "${DATA_RAW}")
+
+    FILTER_ID=$(echo "${CREATE_RESPONSE}" | jq -r '.id // empty')
+    if [ -z "$FILTER_ID" ]; then
+        echo "[Custom entrypoint] WARNING: Video Inject Filter install failed"
+        echo "${CREATE_RESPONSE}"
+        return
+    fi
+
+    echo "[Custom entrypoint] Video Inject Filter created with id: ${FILTER_ID}"
+
+    echo ""
+    echo "[Custom entrypoint] Enabling Video Inject Filter..."
+    curl -s -X POST "http://localhost:8080/api/v1/functions/id/${FILTER_ID}/toggle" \
+      -H "Authorization: Bearer ${API_KEY}" \
+      -H "Content-Type: application/json"
+
+    echo ""
+    echo "[Custom entrypoint] Enabling Video Inject Filter globally..."
+    curl -s -X POST "http://localhost:8080/api/v1/functions/id/${FILTER_ID}/toggle/global" \
+      -H "Authorization: Bearer ${API_KEY}" \
+      -H "Content-Type: application/json"
 }
 
 start_healthz_server

--- a/tools/roat_retrieval.py
+++ b/tools/roat_retrieval.py
@@ -31,8 +31,8 @@ def _get_filename_from_extras(extras: dict) -> str | None:
     return extras.get("key") or extras.get("filename") or extras.get("name") or None
 
 
-def _find_video_url(references: list) -> tuple[str | None, str | None]:
-    """Return (video_url, source_name) from the highest-scored ref with extras.video_url."""
+def _find_video_url(references: list, field: str = "video_url") -> tuple[str | None, str | None]:
+    """Return (video_url, source_name) from the highest-scored ref with extras.<field>."""
 
     def score_key(ref):
         try:
@@ -44,7 +44,7 @@ def _find_video_url(references: list) -> tuple[str | None, str | None]:
         extras = ref.get("extras") or {}
         if not isinstance(extras, dict):
             continue
-        url = extras.get("video_url", "")
+        url = extras.get(field, "")
         if url and isinstance(url, str) and url.startswith("https://"):
             return url, ref.get("title") or ref.get("source_name") or "Source"
     return None, None
@@ -147,6 +147,10 @@ class Tools:
             default=0,
             description="Maximum characters for the document preview in source citations (0 = unlimited).",
         )
+        video_metadata_field: str = Field(
+            default="video_url",
+            description="Metadata field name in retrieved sources that contains the video URL.",
+        )
 
     def __init__(self):
         self.valves = self.Valves()
@@ -212,7 +216,7 @@ class Tools:
         log.info("Returning context with %d sources (%d chars)", len(sources), len(context))
 
         references = rag_result.get("references", []) or []
-        video_url, _ = _find_video_url(references)
+        video_url, _ = _find_video_url(references, field=self.valves.video_metadata_field)
         if video_url:
             log.info("Embedding video marker for %s", video_url[:80])
             return f"<!--VIDEO:{video_url}-->{context}"

--- a/tools/roat_retrieval.py
+++ b/tools/roat_retrieval.py
@@ -215,5 +215,5 @@ class Tools:
         video_url, _ = _find_video_url(references)
         if video_url:
             log.info("Embedding video marker for %s", video_url[:80])
-            return f"<!--VIDEO:{video_url}-->\n\n{context}"
+            return f"<!--VIDEO:{video_url}-->{context}"
         return context

--- a/tools/roat_retrieval.py
+++ b/tools/roat_retrieval.py
@@ -31,6 +31,25 @@ def _get_filename_from_extras(extras: dict) -> str | None:
     return extras.get("key") or extras.get("filename") or extras.get("name") or None
 
 
+def _find_video_url(references: list) -> tuple[str | None, str | None]:
+    """Return (video_url, source_name) from the highest-scored ref with extras.video_url."""
+
+    def score_key(ref):
+        try:
+            return float(ref.get("score") or 0)
+        except (TypeError, ValueError):
+            return 0.0
+
+    for ref in sorted(references, key=score_key, reverse=True):
+        extras = ref.get("extras") or {}
+        if not isinstance(extras, dict):
+            continue
+        url = extras.get("video_url", "")
+        if url and isinstance(url, str) and url.startswith("https://"):
+            return url, ref.get("title") or ref.get("source_name") or "Source"
+    return None, None
+
+
 def _call_rag_service(url: str, api_key: str, timeout: int, top_k: int, query: str) -> dict:
     payload = {"query": query, "top_k": top_k, "metadata_filters": {}}
     headers = {"Content-Type": "application/json"}
@@ -191,4 +210,10 @@ class Tools:
 
         await emit(f"Found {len(sources)} relevant source(s).", done=True)
         log.info("Returning context with %d sources (%d chars)", len(sources), len(context))
+
+        references = rag_result.get("references", []) or []
+        video_url, _ = _find_video_url(references)
+        if video_url:
+            log.info("Embedding video marker for %s", video_url[:80])
+            return f"<!--VIDEO:{video_url}-->\n\n{context}"
         return context


### PR DESCRIPTION
## Summary

- Adds `_find_video_url()` to `roat_retrieval.py` to detect `extras.video_url` in retrieved references and embed a `<!--VIDEO:url-->` marker in the tool result
- Adds a new `video_inject` Filter (`functions/video_inject.py`) whose `outlet` extracts the marker and appends an inline `<video>` block after the assistant response
- Mounts filter files into the container via `compose.yaml`
- Installs and globally enables the `video_inject` filter on first boot via `entrypoint.sh`

## How it works

```
search_knowledge_base() retrieves refs with extras.video_url
  → embeds <!--VIDEO:url--> in tool result
  → video_inject filter outlet extracts marker
  → appends <video> block after assistant answer
  → OWUI markdown renderer shows inline player
```

## What's needed for production

The ROAT connector (MediaWiki or any other) must populate `video_url` in document metadata at ingestion time. Tested manually by patching `data_embeddings.metadata_` directly in the DB — see SK-4 Jira comment for the SQL.

## Test plan

- [ ] On a fresh stack (`docker compose down -v && docker compose up -d`), confirm `video_inject` filter is installed and globally enabled automatically
- [ ] Patch a DB record with `video_url` in `_node_content.metadata` and ask a question that retrieves it — inline player should appear after the answer
- [ ] Ask a question where no retrieved source has `video_url` — no video block, citations only