### PR TITLE
MAIT-226: Improve ROAT tool description to reduce LLM hesitation

### DIFF
--- a/tools/roat_retrieval.json
+++ b/tools/roat_retrieval.json
@@ -3,7 +3,7 @@
 	"name": "Knowledge Base Search",
 	"content": "",
 	"meta": {
-		"description": "Searches the RAG-of-All-Trades knowledge base and returns relevant context.",
+		"description": "Searches the organizational knowledge base for internal documents, company processes, and domain-specific information. Use for questions about internal or organization-specific topics; skip for general knowledge questions.",
 		"manifest": {}
 	}
 }

--- a/tools/roat_retrieval.py
+++ b/tools/roat_retrieval.py
@@ -138,15 +138,26 @@ class Tools:
         __event_emitter__: Callable[[dict], Awaitable[None]] | None = None,
     ) -> str:
         """
-        Use this tool to answer questions about this system, its data, processes,
-        or any domain-specific topics. Prefer retrieved knowledge over general
-        training knowledge when the topic may be covered in the knowledge base.
+        Search the organizational knowledge base to answer questions about company
+        data, internal processes, documentation, or domain-specific topics that may
+        not be in the model's training data.
+
+        ALWAYS call this tool when the user asks about:
+        - Internal documents, wikis, or knowledge articles
+        - Company processes, policies, or procedures
+        - Project-specific data, tickets, or reports
+        - Topics specific to this organization that general training data would not cover
+
+        Do NOT call this tool for general knowledge questions (math, programming
+        syntax, public facts) that do not require internal documents.
 
         Args:
-            query: A concise search query derived from the user's question
+            query: A concise, keyword-rich search query derived from the user's question.
+                   Use specific nouns and avoid filler words.
 
         Returns:
-            Retrieved document chunks and their metadata from the knowledge base, or a message indicating nothing was found.
+            Retrieved document chunks with source metadata, or a message indicating
+            nothing relevant was found.
         """
 
         async def emit(description: str, done: bool = False) -> None:


### PR DESCRIPTION
## Summary

Improves the `search_knowledge_base` tool description in `tools/roat_retrieval.py` and the companion metadata in `tools/roat_retrieval.json` so the LLM is more confident when to call the ROAT knowledge base tool.

**Problem:** The AI was hesitant to call the tool because the docstring used vague trigger language ("may be covered"), giving the model no clear signal.

**Changes:**
- Rewrote the `search_knowledge_base` Python docstring with explicit `ALWAYS call` / `Do NOT call` conditions
- Improved `query` arg guidance: "keyword-rich, specific nouns, avoid filler words"
- Aligned `tools/roat_retrieval.json` meta description with the Python guard logic (adds skip-for-general-knowledge clause)
- Tightened the catch-all trigger bullet to be scope-bounded ("topics specific to this organization") rather than open-ended ("any topic where up-to-date information is needed")