### PR TITLE
MAIT-237: Add Caddy as caching HTTPS reverse proxy via compose overlay

### DIFF
--- a/.env.openwebui.example
+++ b/.env.openwebui.example
@@ -1,12 +1,5 @@
-# ──────────────────────────────────────────────────────────────────────────────
-# Caddy HTTPS profile (optional)
-# Enable with: docker compose --profile caddy up -d
-# Requirements:
-#   - DOMAIN must be an A/AAAA record pointing to this server
-#   - Ports 80 and 443 must be publicly reachable (for LetsEncrypt HTTP-01 challenge)
-#   - When using Caddy, set HTTP_WEB_PORT=127.0.0.1:3000 below to prevent
-#     unintended cleartext access on port 3000
-# ──────────────────────────────────────────────────────────────────────────────
+# Caddy HTTPS profile (optional) — see README for setup details
+#COMPOSE_PROFILES=caddy
 #DOMAIN=maition.example.com
 #ACME_EMAIL=admin@example.com
 #WEBUI_URL=https://maition.example.com

--- a/.env.openwebui.example
+++ b/.env.openwebui.example
@@ -9,6 +9,7 @@
 # ──────────────────────────────────────────────────────────────────────────────
 #DOMAIN=maition.example.com
 #ACME_EMAIL=admin@example.com
+#WEBUI_URL=https://maition.example.com
 
 # replace with your domain if deploying in production
 # for dev always include port number if not 80

--- a/.env.openwebui.example
+++ b/.env.openwebui.example
@@ -1,5 +1,6 @@
-# Caddy HTTPS profile (optional) — see README for setup details
-#COMPOSE_PROFILES=caddy
+# Caddy HTTPS reverse proxy (optional) — see README for setup details
+# To enable: docker compose -f compose.yaml -f compose.caddy.yaml up -d
+# Or set in shell: export COMPOSE_FILE=compose.yaml:compose.caddy.yaml
 #DOMAIN=maition.example.com
 #ACME_EMAIL=admin@example.com
 #WEBUI_URL=https://maition.example.com
@@ -7,8 +8,7 @@
 # replace with your domain if deploying in production
 # for dev always include port number if not 80
 WEBUI_URL=http://localhost:3000
-# on what port to listed on the host
-# When using the caddy profile, change to 127.0.0.1:3000 to bind loopback only
+# on what port to listen on the host
 HTTP_WEB_PORT=3000
 # replace with your key, generate via `openssl rand -hex 32`
 #WEBUI_SECRET_KEY=

--- a/.env.openwebui.example
+++ b/.env.openwebui.example
@@ -1,9 +1,12 @@
 # Caddy HTTPS reverse proxy (optional) — see README for setup details
-# To enable: docker compose -f compose.yaml -f compose.caddy.yaml up -d
-# Or set in shell: export COMPOSE_FILE=compose.yaml:compose.caddy.yaml
+# To enable: export COMPOSE_FILE=compose.yaml:compose.caddy.yaml
+# Or pass explicitly: docker compose -f compose.yaml -f compose.caddy.yaml up -d
 #DOMAIN=maition.example.com
 #ACME_EMAIL=admin@example.com
 #WEBUI_URL=https://maition.example.com
+# optional: publish Caddy on different host ports (defaults to 80/443)
+#CADDY_HTTP_PORT=80
+#CADDY_HTTPS_PORT=443
 
 # replace with your domain if deploying in production
 # for dev always include port number if not 80

--- a/.env.openwebui.example
+++ b/.env.openwebui.example
@@ -1,7 +1,20 @@
+# ──────────────────────────────────────────────────────────────────────────────
+# Caddy HTTPS profile (optional)
+# Enable with: docker compose --profile caddy up -d
+# Requirements:
+#   - DOMAIN must be an A/AAAA record pointing to this server
+#   - Ports 80 and 443 must be publicly reachable (for LetsEncrypt HTTP-01 challenge)
+#   - When using Caddy, set HTTP_WEB_PORT=127.0.0.1:3000 below to prevent
+#     unintended cleartext access on port 3000
+# ──────────────────────────────────────────────────────────────────────────────
+#DOMAIN=maition.example.com
+#ACME_EMAIL=admin@example.com
+
 # replace with your domain if deploying in production
 # for dev always include port number if not 80
 WEBUI_URL=http://localhost:3000
 # on what port to listed on the host
+# When using the caddy profile, change to 127.0.0.1:3000 to bind loopback only
 HTTP_WEB_PORT=3000
 # replace with your key, generate via `openssl rand -hex 32`
 #WEBUI_SECRET_KEY=

--- a/Caddyfile
+++ b/Caddyfile
@@ -1,9 +1,49 @@
 {
 	email {$ACME_EMAIL}
+	order cache before rewrite
+	cache {
+		ttl 8766h
+		default_cache_control public, max-age=31536000
+		mode bypass
+		redis {
+			url redis-caddy:6379
+		}
+	}
 }
 
 {$DOMAIN} {
-	reverse_proxy openwebui:8080
+	@static {
+		path *.jpg *.jpeg *.png *.webp *.gif *.ico *.svg
+		path *.css *.js *.woff *.woff2 *.ttf *.map
+	}
+
+	@manifest {
+		path /manifest.json
+	}
+
+	handle @static {
+		cache
+		reverse_proxy openwebui:8080 {
+			header_down -Cache-Control
+			header_down -Set-Cookie
+			header_down +Cache-Control "public, max-age=31536000, immutable"
+		}
+	}
+
+	handle @manifest {
+		cache
+		reverse_proxy openwebui:8080 {
+			header_down -Cache-Control
+			header_down -Set-Cookie
+			header_down Cache-Control "public, max-age=86400"
+		}
+	}
+
+	handle {
+		reverse_proxy openwebui:8080 {
+			flush_interval -1
+		}
+	}
 
 	header {
 		Strict-Transport-Security "max-age=31536000; includeSubDomains"
@@ -18,16 +58,17 @@
 
 # ──────────────────────────────────────────────────────────────────────────────
 # DNS-01 challenge (for environments where port 80 is not publicly reachable,
-# e.g. behind NAT, corporate firewall, or Cloudflare proxy):
+# e.g. behind NAT or Cloudflare proxy):
 #
-# DNS-01 requires a custom Caddy build with a DNS provider module (xcaddy).
-# See: https://caddyserver.com/docs/automatic-https#dns-challenge
+# The included image (melonsmasher/caddy-cloudflare-cache:2) already bundles
+# the caddy-dns/cloudflare module. To use DNS-01, replace the site block with:
 #
-# Example for Cloudflare (after building with caddy-dns/cloudflare module):
 #   {$DOMAIN} {
 #     tls {
 #       dns cloudflare {$CLOUDFLARE_API_TOKEN}
 #     }
-#     reverse_proxy openwebui:8080
+#     # ... rest of the handles unchanged
 #   }
+#
+# Set CLOUDFLARE_API_TOKEN in your .env file.
 # ──────────────────────────────────────────────────────────────────────────────

--- a/Caddyfile
+++ b/Caddyfile
@@ -1,0 +1,33 @@
+{
+	email {$ACME_EMAIL}
+}
+
+{$DOMAIN} {
+	reverse_proxy openwebui:8080
+
+	header {
+		Strict-Transport-Security "max-age=31536000; includeSubDomains"
+		X-Content-Type-Options nosniff
+		X-Frame-Options SAMEORIGIN
+	}
+
+	log {
+		output stdout
+	}
+}
+
+# ──────────────────────────────────────────────────────────────────────────────
+# DNS-01 challenge (for environments where port 80 is not publicly reachable,
+# e.g. behind NAT, corporate firewall, or Cloudflare proxy):
+#
+# DNS-01 requires a custom Caddy build with a DNS provider module (xcaddy).
+# See: https://caddyserver.com/docs/automatic-https#dns-challenge
+#
+# Example for Cloudflare (after building with caddy-dns/cloudflare module):
+#   {$DOMAIN} {
+#     tls {
+#       dns cloudflare {$CLOUDFLARE_API_TOKEN}
+#     }
+#     reverse_proxy openwebui:8080
+#   }
+# ──────────────────────────────────────────────────────────────────────────────

--- a/Caddyfile
+++ b/Caddyfile
@@ -44,31 +44,4 @@
 			flush_interval -1
 		}
 	}
-
-	header {
-		Strict-Transport-Security "max-age=31536000; includeSubDomains"
-		X-Content-Type-Options nosniff
-		X-Frame-Options SAMEORIGIN
-	}
-
-	log {
-		output stdout
-	}
 }
-
-# ──────────────────────────────────────────────────────────────────────────────
-# DNS-01 challenge (for environments where port 80 is not publicly reachable,
-# e.g. behind NAT or Cloudflare proxy):
-#
-# The included image (melonsmasher/caddy-cloudflare-cache:2) already bundles
-# the caddy-dns/cloudflare module. To use DNS-01, replace the site block with:
-#
-#   {$DOMAIN} {
-#     tls {
-#       dns cloudflare {$CLOUDFLARE_API_TOKEN}
-#     }
-#     # ... rest of the handles unchanged
-#   }
-#
-# Set CLOUDFLARE_API_TOKEN in your .env file.
-# ──────────────────────────────────────────────────────────────────────────────

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ mAItion serves all traffic — including static assets — through Open WebUI's 
 ### Requirements
 
 - A public domain (A/AAAA record pointing to your server)
-- Ports **80** and **443** open and publicly reachable (required for the LetsEncrypt HTTP-01 challenge)
+- Ports **80** and **443** open and publicly reachable (required for the LetsEncrypt HTTP-01 challenge). Set `CADDY_HTTP_PORT` / `CADDY_HTTPS_PORT` in `.env` if you need to publish Caddy on different host ports.
 
 ### Setup
 
@@ -138,26 +138,27 @@ mAItion serves all traffic — including static assets — through Open WebUI's 
    WEBUI_URL=https://maition.example.com
    ```
 
-2. Start the stack with the Caddy overlay — it clears OpenWebUI's host port binding so only Caddy is externally reachable:
+   Setting `DOMAIN` to an `http://` URL (e.g. `DOMAIN=http://localhost`) bypasses TLS termination entirely — Caddy will serve the app on plain HTTP. Use this only for local testing.
 
-   ```bash
-   docker compose -f compose.yaml -f compose.caddy.yaml up -d
-   ```
-
-   Or set the environment variable once so plain `docker compose` picks it up:
+2. Start the stack with the Caddy overlay by setting `COMPOSE_FILE` so plain `docker compose` picks it up automatically:
 
    ```bash
    export COMPOSE_FILE=compose.yaml:compose.caddy.yaml
    docker compose up -d
    ```
 
-   Caddy will automatically obtain and renew a TLS certificate. HTTP requests are redirected to HTTPS automatically.
+   Or pass the overlay explicitly with `-f`:
+
+   ```bash
+   docker compose -f compose.yaml -f compose.caddy.yaml up -d
+   ```
+
+   Either way, the overlay clears OpenWebUI's host port binding so only Caddy is externally reachable. Caddy will automatically obtain and renew a TLS certificate, and HTTP requests are redirected to HTTPS automatically.
 
 ### Troubleshooting
 
 - **Certificate not issued** — check that ports 80 and 443 are reachable from the public internet and your DNS record is pointing to this server. Run `docker compose logs caddy` to see the ACME challenge output.
-- **Port 80/443 already in use** — another reverse proxy (Traefik, Nginx, etc.) is likely running on the host. Either stop it or change Caddy to use different ports.
-- **Behind NAT or Cloudflare proxy** — HTTP-01 challenge may not work. DNS-01 is the alternative; the included Caddy image (`melonsmasher/caddy-cloudflare-cache:2`) already bundles the Cloudflare DNS module. Add `dns cloudflare {$CLOUDFLARE_API_TOKEN}` inside a `tls` block in your `Caddyfile` and set `CLOUDFLARE_API_TOKEN` in `.env`.
+- **Port 80/443 already in use** — another reverse proxy (Traefik, Nginx, etc.) is likely running on the host. Either stop it, or set `CADDY_HTTP_PORT`/`CADDY_HTTPS_PORT` in `.env` to publish Caddy on different host ports — note that LetsEncrypt's HTTP-01 challenge and normal HTTPS access require the public internet to reach ports 80/443, so this only works if you also forward those public ports to your chosen ones, or you're not relying on public TLS (e.g. local testing).
 - **Testing before going live** — avoid LetsEncrypt rate limits by temporarily setting `acme_ca` to the staging endpoint in the Caddyfile global block, then switch to production for your final deployment.
 
 ### Certificate persistence

--- a/README.md
+++ b/README.md
@@ -119,6 +119,50 @@ Two components handle RAG service communication:
 - **Knowledge Base Search tool** (`tools/roat_retrieval.py`) — a Workspace Tool that lets the LLM decide when to query ROAT. Requires a model with native function calling support. Both are automatically provisioned on first boot.
 - **Web Search Tool** (`tools/web_search.py`) — an optional Workspace Tool that lets the LLM search the web via the Tavily API. Enable with `TOOL_WEB_SEARCH_ENABLED=True` in `.env`, then either set `TOOL_WEB_SEARCH_API_KEY` to auto-configure the key on install, or set the `tavily_api_key` valve manually from Workspace → Tools.
 
+## HTTPS with Caddy
+
+mAItion serves all traffic — including static assets — through Open WebUI's Uvicorn server. For production deployments, adding Caddy as a caching reverse proxy provides automatic TLS certificate issuance via LetsEncrypt and speeds up static asset delivery.
+
+### Requirements
+
+- A public domain (A/AAAA record pointing to your server)
+- Ports **80** and **443** open and publicly reachable (required for the LetsEncrypt HTTP-01 challenge)
+
+### Setup
+
+1. Add the following to your `.env` file:
+
+   ```bash
+   DOMAIN=maition.example.com
+   ACME_EMAIL=admin@example.com
+   ```
+
+2. When using Caddy, bind OpenWebUI's plain HTTP port to loopback only to prevent unintended cleartext access:
+
+   ```bash
+   # in .env
+   HTTP_WEB_PORT=127.0.0.1:3000
+   ```
+
+3. Start the stack with the `caddy` profile:
+
+   ```bash
+   docker compose --profile caddy up -d
+   ```
+
+   Caddy will automatically obtain and renew a TLS certificate. HTTP requests are redirected to HTTPS automatically.
+
+### Troubleshooting
+
+- **Certificate not issued** — check that ports 80 and 443 are reachable from the public internet and your DNS record is pointing to this server. Run `docker compose logs caddy` to see the ACME challenge output.
+- **Port 80/443 already in use** — another reverse proxy (Traefik, Nginx, etc.) is likely running on the host. Either stop it or change Caddy to use different ports.
+- **Behind NAT or Cloudflare proxy** — HTTP-01 challenge may not work. DNS-01 is the alternative but requires a custom Caddy build with a DNS provider module. See the comments in `Caddyfile` for details.
+- **Testing before going live** — avoid LetsEncrypt rate limits by temporarily setting `acme_ca` to the staging endpoint in the Caddyfile global block, then switch to production for your final deployment.
+
+### Certificate persistence
+
+TLS certificates are stored in the `caddy_data` Docker volume. They survive `docker compose down` but are removed by `docker compose down -v`. Do not use `-v` if you want to preserve certificates.
+
 ## Connectors configuration
 
 The service supports multiple data sources, including multiple data sources of the same type, each with its own

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ Two components handle RAG service communication:
 
 ## HTTPS with Caddy
 
-mAItion serves all traffic — including static assets — through Open WebUI's Uvicorn server. For production deployments, adding Caddy as a caching reverse proxy provides automatic TLS certificate issuance via LetsEncrypt and speeds up static asset delivery. The `caddy` profile also starts a dedicated `redis-caddy` sidecar that Caddy uses as a cache backend: static assets (images, CSS, JS, fonts) are cached for one year with immutable headers, and `manifest.json` is cached for 24 hours. Dynamic chat and API requests bypass the cache entirely and are streamed directly to the browser.
+mAItion serves all traffic — including static assets — through Open WebUI's Uvicorn server. For production deployments, adding Caddy as a caching reverse proxy provides automatic TLS certificate issuance via LetsEncrypt and speeds up static asset delivery. The `compose.caddy.yaml` overlay also starts a dedicated `redis-caddy` sidecar that Caddy uses as a cache backend: static assets (images, CSS, JS, fonts) are cached for one year with immutable headers, and `manifest.json` is cached for 24 hours. Dynamic chat and API requests bypass the cache entirely and are streamed directly to the browser.
 
 ### Requirements
 
@@ -138,17 +138,17 @@ mAItion serves all traffic — including static assets — through Open WebUI's 
    WEBUI_URL=https://maition.example.com
    ```
 
-2. When using Caddy, bind OpenWebUI's plain HTTP port to loopback only to prevent unintended cleartext access:
+2. Start the stack with the Caddy overlay — it clears OpenWebUI's host port binding so only Caddy is externally reachable:
 
    ```bash
-   # in .env
-   HTTP_WEB_PORT=127.0.0.1:3000
+   docker compose -f compose.yaml -f compose.caddy.yaml up -d
    ```
 
-3. Start the stack with the `caddy` profile:
+   Or set the environment variable once so plain `docker compose` picks it up:
 
    ```bash
-   docker compose --profile caddy up -d
+   export COMPOSE_FILE=compose.yaml:compose.caddy.yaml
+   docker compose up -d
    ```
 
    Caddy will automatically obtain and renew a TLS certificate. HTTP requests are redirected to HTTPS automatically.

--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ mAItion serves all traffic — including static assets — through Open WebUI's 
    ```bash
    DOMAIN=maition.example.com
    ACME_EMAIL=admin@example.com
+   WEBUI_URL=https://maition.example.com
    ```
 
 2. When using Caddy, bind OpenWebUI's plain HTTP port to loopback only to prevent unintended cleartext access:

--- a/README.md
+++ b/README.md
@@ -159,7 +159,6 @@ mAItion serves all traffic — including static assets — through Open WebUI's 
 
 - **Certificate not issued** — check that ports 80 and 443 are reachable from the public internet and your DNS record is pointing to this server. Run `docker compose logs caddy` to see the ACME challenge output.
 - **Port 80/443 already in use** — another reverse proxy (Traefik, Nginx, etc.) is likely running on the host. Either stop it, or set `CADDY_HTTP_PORT`/`CADDY_HTTPS_PORT` in `.env` to publish Caddy on different host ports — note that LetsEncrypt's HTTP-01 challenge and normal HTTPS access require the public internet to reach ports 80/443, so this only works if you also forward those public ports to your chosen ones, or you're not relying on public TLS (e.g. local testing).
-- **Testing before going live** — avoid LetsEncrypt rate limits by temporarily setting `acme_ca` to the staging endpoint in the Caddyfile global block, then switch to production for your final deployment.
 
 ### Certificate persistence
 

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ Two components handle RAG service communication:
 
 ## HTTPS with Caddy
 
-mAItion serves all traffic — including static assets — through Open WebUI's Uvicorn server. For production deployments, adding Caddy as a caching reverse proxy provides automatic TLS certificate issuance via LetsEncrypt and speeds up static asset delivery.
+mAItion serves all traffic — including static assets — through Open WebUI's Uvicorn server. For production deployments, adding Caddy as a caching reverse proxy provides automatic TLS certificate issuance via LetsEncrypt and speeds up static asset delivery. The `caddy` profile also starts a dedicated `redis-caddy` sidecar that Caddy uses as a cache backend: static assets (images, CSS, JS, fonts) are cached for one year with immutable headers, and `manifest.json` is cached for 24 hours. Dynamic chat and API requests bypass the cache entirely and are streamed directly to the browser.
 
 ### Requirements
 
@@ -157,7 +157,7 @@ mAItion serves all traffic — including static assets — through Open WebUI's 
 
 - **Certificate not issued** — check that ports 80 and 443 are reachable from the public internet and your DNS record is pointing to this server. Run `docker compose logs caddy` to see the ACME challenge output.
 - **Port 80/443 already in use** — another reverse proxy (Traefik, Nginx, etc.) is likely running on the host. Either stop it or change Caddy to use different ports.
-- **Behind NAT or Cloudflare proxy** — HTTP-01 challenge may not work. DNS-01 is the alternative but requires a custom Caddy build with a DNS provider module. See the comments in `Caddyfile` for details.
+- **Behind NAT or Cloudflare proxy** — HTTP-01 challenge may not work. DNS-01 is the alternative; the included Caddy image (`melonsmasher/caddy-cloudflare-cache:2`) already bundles the Cloudflare DNS module. Add `dns cloudflare {$CLOUDFLARE_API_TOKEN}` inside a `tls` block in your `Caddyfile` and set `CLOUDFLARE_API_TOKEN` in `.env`.
 - **Testing before going live** — avoid LetsEncrypt rate limits by temporarily setting `acme_ca` to the staging endpoint in the Caddyfile global block, then switch to production for your final deployment.
 
 ### Certificate persistence

--- a/compose.caddy.yaml
+++ b/compose.caddy.yaml
@@ -1,0 +1,42 @@
+services:
+
+  # When using Caddy, openwebui should only listen on loopback
+  openwebui:
+    ports: !reset []
+
+  # Caddy HTTPS reverse proxy with static-asset caching
+  caddy:
+    image: melonsmasher/caddy-cloudflare-cache:2
+    restart: unless-stopped
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - ./Caddyfile:/etc/caddy/Caddyfile:ro
+      - caddy_data:/data
+      - caddy_config:/config
+    environment:
+      - DOMAIN=${DOMAIN:?DOMAIN must be set in .env to use Caddy}
+      - ACME_EMAIL=${ACME_EMAIL:?ACME_EMAIL must be set in .env to use Caddy}
+    depends_on:
+      openwebui:
+        condition: service_healthy
+      redis-caddy:
+        condition: service_started
+
+  # Dedicated Redis for Caddy static-asset cache
+  redis-caddy:
+    image: redis:7.4.0-alpine3.20
+    command:
+      - redis-server
+      - --maxmemory
+      - 64mb
+      - --maxmemory-policy
+      - allkeys-lru
+    restart: unless-stopped
+    tmpfs:
+      - /data
+
+volumes:
+  caddy_data:
+  caddy_config:

--- a/compose.caddy.yaml
+++ b/compose.caddy.yaml
@@ -1,6 +1,6 @@
 services:
 
-  # When using Caddy, openwebui should only listen on loopback
+  # When using Caddy, drop OpenWebUI's host port binding so only Caddy is externally reachable
   openwebui:
     ports: !reset []
 
@@ -9,8 +9,8 @@ services:
     image: melonsmasher/caddy-cloudflare-cache:2
     restart: unless-stopped
     ports:
-      - "80:80"
-      - "443:443"
+      - "${CADDY_HTTP_PORT:-80}:80"
+      - "${CADDY_HTTPS_PORT:-443}:443"
     volumes:
       - ./Caddyfile:/etc/caddy/Caddyfile:ro
       - caddy_data:/data

--- a/compose.yaml
+++ b/compose.yaml
@@ -168,7 +168,7 @@ services:
 
   # caddy reverse proxy (optional, requires --profile caddy)
   caddy:
-    image: caddy:2-alpine
+    image: melonsmasher/caddy-cloudflare-cache:2
     profiles:
       - caddy
     restart: unless-stopped
@@ -185,6 +185,23 @@ services:
     depends_on:
       openwebui:
         condition: service_healthy
+      redis-caddy:
+        condition: service_started
+
+  # dedicated Redis for Caddy static-asset cache (optional, requires --profile caddy)
+  redis-caddy:
+    image: redis:7.4.0-alpine3.20
+    profiles:
+      - caddy
+    command:
+      - redis-server
+      - --maxmemory
+      - 64mb
+      - --maxmemory-policy
+      - allkeys-lru
+    restart: unless-stopped
+    tmpfs:
+      - /data
 
 volumes:
   open-webui:

--- a/compose.yaml
+++ b/compose.yaml
@@ -181,7 +181,7 @@ services:
       - caddy_config:/config
     environment:
       - DOMAIN=${DOMAIN:?DOMAIN must be set in .env to use the caddy profile}
-      - ACME_EMAIL=${ACME_EMAIL:-}
+      - ACME_EMAIL=${ACME_EMAIL:?ACME_EMAIL must be set in .env to use the caddy profile}
     depends_on:
       openwebui:
         condition: service_healthy

--- a/compose.yaml
+++ b/compose.yaml
@@ -82,6 +82,8 @@ services:
       retries: 10
       timeout: 5s
       start_period: 5s
+    ports:
+      - "5432:5432"
 
   # redis
   redis:
@@ -166,6 +168,26 @@ services:
       bash -c "celery -A celery_app beat --loglevel=info"
     restart: unless-stopped
 
+  # caddy reverse proxy (optional, requires --profile caddy)
+  caddy:
+    image: caddy:2-alpine
+    profiles:
+      - caddy
+    restart: unless-stopped
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - ./Caddyfile:/etc/caddy/Caddyfile:ro
+      - caddy_data:/data
+      - caddy_config:/config
+    environment:
+      - DOMAIN=${DOMAIN:?DOMAIN must be set in .env to use the caddy profile}
+      - ACME_EMAIL=${ACME_EMAIL:-}
+    depends_on:
+      openwebui:
+        condition: service_healthy
+
 volumes:
   open-webui:
   open-webui-cache:
@@ -173,3 +195,5 @@ volumes:
   postgres_data:
   redis_data:
   api-modesl-cache:
+  caddy_data:
+  caddy_config:

--- a/compose.yaml
+++ b/compose.yaml
@@ -82,8 +82,6 @@ services:
       retries: 10
       timeout: 5s
       start_period: 5s
-    ports:
-      - "5432:5432"
 
   # redis
   redis:

--- a/compose.yaml
+++ b/compose.yaml
@@ -166,43 +166,6 @@ services:
       bash -c "celery -A celery_app beat --loglevel=info"
     restart: unless-stopped
 
-  # caddy reverse proxy (optional, requires --profile caddy)
-  caddy:
-    image: melonsmasher/caddy-cloudflare-cache:2
-    profiles:
-      - caddy
-    restart: unless-stopped
-    ports:
-      - "80:80"
-      - "443:443"
-    volumes:
-      - ./Caddyfile:/etc/caddy/Caddyfile:ro
-      - caddy_data:/data
-      - caddy_config:/config
-    environment:
-      - DOMAIN=${DOMAIN:?DOMAIN must be set in .env to use the caddy profile}
-      - ACME_EMAIL=${ACME_EMAIL:?ACME_EMAIL must be set in .env to use the caddy profile}
-    depends_on:
-      openwebui:
-        condition: service_healthy
-      redis-caddy:
-        condition: service_started
-
-  # dedicated Redis for Caddy static-asset cache (optional, requires --profile caddy)
-  redis-caddy:
-    image: redis:7.4.0-alpine3.20
-    profiles:
-      - caddy
-    command:
-      - redis-server
-      - --maxmemory
-      - 64mb
-      - --maxmemory-policy
-      - allkeys-lru
-    restart: unless-stopped
-    tmpfs:
-      - /data
-
 volumes:
   open-webui:
   open-webui-cache:
@@ -210,5 +173,3 @@ volumes:
   postgres_data:
   redis_data:
   api-modesl-cache:
-  caddy_data:
-  caddy_config:

--- a/docs/configuration/caddy.mdx
+++ b/docs/configuration/caddy.mdx
@@ -1,0 +1,56 @@
+---
+title: "HTTPS with Caddy"
+description: "Run mAItion behind Caddy as a caching SSL-terminating reverse proxy with automatic LetsEncrypt certificates."
+keywords:
+  - mAItion
+  - Caddy
+  - HTTPS
+  - TLS
+  - reverse proxy
+  - LetsEncrypt
+---
+
+mAItion serves all traffic — including static assets — through Open WebUI's Uvicorn server. For production deployments, the optional `compose.caddy.yaml` overlay adds Caddy as a caching reverse proxy that handles automatic TLS certificate issuance via LetsEncrypt and speeds up static asset delivery.
+
+The overlay also starts a dedicated `redis-caddy` sidecar used as Caddy's cache backend: static assets (images, CSS, JS, fonts) are cached for one year with immutable headers, and `manifest.json` is cached for 24 hours. Dynamic chat and API requests bypass the cache entirely and are streamed directly to the browser.
+
+## Requirements
+
+- A public domain with an A/AAAA record pointing to your server
+- Ports **80** and **443** open and publicly reachable (required for the LetsEncrypt HTTP-01 challenge)
+
+## Setup
+
+1. Add the following to your `.env` file:
+
+   ```bash
+   DOMAIN=maition.example.com
+   ACME_EMAIL=admin@example.com
+   WEBUI_URL=https://maition.example.com
+   ```
+
+2. Start the stack with the Caddy overlay. It clears OpenWebUI's host port binding so only Caddy is externally reachable:
+
+   ```bash
+   docker compose -f compose.yaml -f compose.caddy.yaml up -d
+   ```
+
+   Or set `COMPOSE_FILE` once so plain `docker compose` picks it up automatically:
+
+   ```bash
+   export COMPOSE_FILE=compose.yaml:compose.caddy.yaml
+   docker compose up -d
+   ```
+
+   Caddy will automatically obtain and renew a TLS certificate. HTTP requests are redirected to HTTPS automatically.
+
+## Troubleshooting
+
+- **Certificate not issued** — check that ports 80 and 443 are reachable from the public internet and your DNS record points to this server. Run `docker compose logs caddy` to see the ACME challenge output.
+- **Port 80/443 already in use** — another reverse proxy (Traefik, Nginx, etc.) is likely running on the host. Either stop it or reconfigure Caddy to use different ports.
+- **Behind NAT or Cloudflare proxy** — HTTP-01 challenge may not work. DNS-01 is the alternative; the included Caddy image (`melonsmasher/caddy-cloudflare-cache:2`) already bundles the Cloudflare DNS module. Add `dns cloudflare {$CLOUDFLARE_API_TOKEN}` inside a `tls` block in your `Caddyfile` and set `CLOUDFLARE_API_TOKEN` in `.env`.
+- **Testing before going live** — avoid LetsEncrypt rate limits by temporarily setting `acme_ca` to the staging endpoint in the Caddyfile global block, then switch to production for your final deployment.
+
+## Certificate persistence
+
+TLS certificates are stored in the `caddy_data` Docker volume. They survive `docker compose down` but are removed by `docker compose down -v`. Do not use `-v` if you want to preserve your certificates.

--- a/docs/configuration/caddy.mdx
+++ b/docs/configuration/caddy.mdx
@@ -50,7 +50,6 @@ The overlay also starts a dedicated `redis-caddy` sidecar used as Caddy's cache 
 
 - **Certificate not issued** — check that ports 80 and 443 are reachable from the public internet and your DNS record points to this server. Run `docker compose logs caddy` to see the ACME challenge output.
 - **Port 80/443 already in use** — another reverse proxy (Traefik, Nginx, etc.) is likely running on the host. Either stop it, or set `CADDY_HTTP_PORT`/`CADDY_HTTPS_PORT` in `.env` to publish Caddy on different host ports — note that LetsEncrypt's HTTP-01 challenge and normal HTTPS access require the public internet to reach ports 80/443, so this only works if you also forward those public ports to your chosen ones, or you're not relying on public TLS (e.g. local testing).
-- **Testing before going live** — avoid LetsEncrypt rate limits by temporarily setting `acme_ca` to the staging endpoint in the Caddyfile global block, then switch to production for your final deployment.
 
 ## Certificate persistence
 

--- a/docs/configuration/caddy.mdx
+++ b/docs/configuration/caddy.mdx
@@ -17,7 +17,7 @@ The overlay also starts a dedicated `redis-caddy` sidecar used as Caddy's cache 
 ## Requirements
 
 - A public domain with an A/AAAA record pointing to your server
-- Ports **80** and **443** open and publicly reachable (required for the LetsEncrypt HTTP-01 challenge)
+- Ports **80** and **443** open and publicly reachable (required for the LetsEncrypt HTTP-01 challenge). Set `CADDY_HTTP_PORT` / `CADDY_HTTPS_PORT` in `.env` if you need to publish Caddy on different host ports.
 
 ## Setup
 
@@ -29,26 +29,27 @@ The overlay also starts a dedicated `redis-caddy` sidecar used as Caddy's cache 
    WEBUI_URL=https://maition.example.com
    ```
 
-2. Start the stack with the Caddy overlay. It clears OpenWebUI's host port binding so only Caddy is externally reachable:
+   Setting `DOMAIN` to an `http://` URL (e.g. `DOMAIN=http://localhost`) bypasses TLS termination entirely — Caddy will serve the app on plain HTTP. Use this only for local testing.
 
-   ```bash
-   docker compose -f compose.yaml -f compose.caddy.yaml up -d
-   ```
-
-   Or set `COMPOSE_FILE` once so plain `docker compose` picks it up automatically:
+2. Start the stack with the Caddy overlay by setting `COMPOSE_FILE` so plain `docker compose` picks it up automatically:
 
    ```bash
    export COMPOSE_FILE=compose.yaml:compose.caddy.yaml
    docker compose up -d
    ```
 
-   Caddy will automatically obtain and renew a TLS certificate. HTTP requests are redirected to HTTPS automatically.
+   Or pass the overlay explicitly with `-f`:
+
+   ```bash
+   docker compose -f compose.yaml -f compose.caddy.yaml up -d
+   ```
+
+   Either way, the overlay clears OpenWebUI's host port binding so only Caddy is externally reachable. Caddy will automatically obtain and renew a TLS certificate, and HTTP requests are redirected to HTTPS automatically.
 
 ## Troubleshooting
 
 - **Certificate not issued** — check that ports 80 and 443 are reachable from the public internet and your DNS record points to this server. Run `docker compose logs caddy` to see the ACME challenge output.
-- **Port 80/443 already in use** — another reverse proxy (Traefik, Nginx, etc.) is likely running on the host. Either stop it or reconfigure Caddy to use different ports.
-- **Behind NAT or Cloudflare proxy** — HTTP-01 challenge may not work. DNS-01 is the alternative; the included Caddy image (`melonsmasher/caddy-cloudflare-cache:2`) already bundles the Cloudflare DNS module. Add `dns cloudflare {$CLOUDFLARE_API_TOKEN}` inside a `tls` block in your `Caddyfile` and set `CLOUDFLARE_API_TOKEN` in `.env`.
+- **Port 80/443 already in use** — another reverse proxy (Traefik, Nginx, etc.) is likely running on the host. Either stop it, or set `CADDY_HTTP_PORT`/`CADDY_HTTPS_PORT` in `.env` to publish Caddy on different host ports — note that LetsEncrypt's HTTP-01 challenge and normal HTTPS access require the public internet to reach ports 80/443, so this only works if you also forward those public ports to your chosen ones, or you're not relying on public TLS (e.g. local testing).
 - **Testing before going live** — avoid LetsEncrypt rate limits by temporarily setting `acme_ca` to the staging endpoint in the Caddyfile global block, then switch to production for your final deployment.
 
 ## Certificate persistence

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -93,7 +93,8 @@
 							"configuration/frontend-env",
 							"configuration/backend-env",
 							"configuration/sso",
-							"configuration/workspace-models"
+							"configuration/workspace-models",
+							"configuration/caddy"
 						]
 					}
 				]


### PR DESCRIPTION
Adds Caddy as an optional SSL-terminating caching reverse proxy via a \`compose.caddy.yaml\` overlay, aligned with the k8s setup.

Enable with:
```bash
docker compose -f compose.yaml -f compose.caddy.yaml up -d
```

Or persistently:
```bash
export COMPOSE_FILE=compose.yaml:compose.caddy.yaml
```

**What's included:**
- `compose.caddy.yaml` — Caddy + dedicated \`redis-caddy\` sidecar (64MB LRU, tmpfs)
- `Caddyfile` — static asset caching (1-year TTL), manifest caching (24h), streaming pass-through for chat/API
- Custom image `melonsmasher/caddy-cloudflare-cache:2` (matches k8s)
- `.env.openwebui.example` — Caddy env vars hint (`DOMAIN`, `ACME_EMAIL`, `WEBUI_URL`)
- `README.md` — HTTPS with Caddy setup section
- `docs/configuration/caddy.mdx` — new docs page under Configuration