### PR TITLE
Update rag-of-all-trades image to 30c6315

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -91,7 +91,7 @@ services:
 
   # rag-of-all-trades API
   api:
-    image: ghcr.io/wikiteq/rag-of-all-trades:51b3e91
+    image: ghcr.io/wikiteq/rag-of-all-trades:30c6315
     extra_hosts:
       - "host.docker.internal:host-gateway"
     depends_on:
@@ -115,7 +115,7 @@ services:
 
   # rag-of-all-trades WORKER
   celery_worker:
-    image: ghcr.io/wikiteq/rag-of-all-trades:51b3e91
+    image: ghcr.io/wikiteq/rag-of-all-trades:30c6315
     extra_hosts:
       - "host.docker.internal:host-gateway"
     depends_on:
@@ -141,7 +141,7 @@ services:
 
   # rag-of-all-trades BEAT
   celery_beat:
-    image: ghcr.io/wikiteq/rag-of-all-trades:51b3e91
+    image: ghcr.io/wikiteq/rag-of-all-trades:30c6315
     depends_on:
       postgres:
         condition: service_healthy


### PR DESCRIPTION
## Summary
- Bumps `rag-of-all-trades` image tag to `30c6315` across all three services (`api`, `celery_worker`, `celery_beat`) in `compose.yaml`

[MAIT-227]

[MAIT-227]: https://wikiteq.atlassian.net/browse/MAIT-227?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ