### PR TITLE
SK-4: Gate video_inject filter install and marker embedding on FUNCTION_VIDEO_INJECT_ENABLED env

### DIFF
--- a/.env.openwebui.example
+++ b/.env.openwebui.example
@@ -62,3 +62,7 @@ ROAT_API_KEY=12345
 #MEDIAWIKI_API_URL=https://wiki.example.com/w/api.php
 #MEDIAWIKI_USERNAME=
 #MEDIAWIKI_PASSWORD=
+
+# Video Inject Filter (optional): set FUNCTION_VIDEO_INJECT_ENABLED=True to auto-install the
+# inline video player filter on first boot. Requires video_url metadata in retrieved sources.
+#FUNCTION_VIDEO_INJECT_ENABLED=True

--- a/helpers/entrypoint.sh
+++ b/helpers/entrypoint.sh
@@ -287,6 +287,10 @@ install_mediawiki_tool() {
 }
 
 install_video_inject_filter() {
+    if [ "$FUNCTION_VIDEO_INJECT_ENABLED" != "True" ]; then
+        return
+    fi
+
     echo ""
     echo "[Custom entrypoint] Installing Video Inject Filter..."
 

--- a/tools/roat_retrieval.py
+++ b/tools/roat_retrieval.py
@@ -10,6 +10,7 @@ requirements: requests
 
 import asyncio
 import logging
+import os
 import re
 from collections.abc import Awaitable, Callable
 
@@ -226,9 +227,10 @@ class Tools:
         await emit(f"Found {len(sources)} relevant source(s).", done=True)
         log.info("Returning context with %d sources (%d chars)", len(sources), len(context))
 
-        references = rag_result.get("references", []) or []
-        video_url, _ = _find_video_url(references, field=self.valves.video_metadata_field)
-        if video_url:
-            log.info("Embedding video marker for %s", video_url[:80])
-            return f"<!--VIDEO:{video_url}-->{context}"
+        if os.environ.get("FUNCTION_VIDEO_INJECT_ENABLED", "").lower() == "true":
+            references = rag_result.get("references", []) or []
+            video_url, _ = _find_video_url(references, field=self.valves.video_metadata_field)
+            if video_url:
+                log.info("Embedding video marker for %s", video_url[:80])
+                return f"<!--VIDEO:{video_url}-->{context}"
         return context

--- a/tools/roat_retrieval.py
+++ b/tools/roat_retrieval.py
@@ -227,7 +227,7 @@ class Tools:
         await emit(f"Found {len(sources)} relevant source(s).", done=True)
         log.info("Returning context with %d sources (%d chars)", len(sources), len(context))
 
-        if os.environ.get("FUNCTION_VIDEO_INJECT_ENABLED", "").lower() == "true":
+        if os.environ.get("FUNCTION_VIDEO_INJECT_ENABLED", "") == "True":
             references = rag_result.get("references", []) or []
             video_url, _ = _find_video_url(references, field=self.valves.video_metadata_field)
             if video_url:


### PR DESCRIPTION
## Summary

- `helpers/entrypoint.sh`: `install_video_inject_filter()` is now a no-op unless `FUNCTION_VIDEO_INJECT_ENABLED=True`, matching the pattern used by `TOOL_MEDIAWIKI_ENABLED`
- `tools/roat_retrieval.py`: `<!--VIDEO:...-->` marker is only embedded when `FUNCTION_VIDEO_INJECT_ENABLED=True` (read from env at call time via `os.environ`)
- `.env.openwebui.example`: documented the new flag with a comment