### PR TITLE
MAIT-299: Replace [Source] + Metadata format with XML document tags and YAML frontmatter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ config.yaml
 !.env.*.example
 model-cache/
 compose.override.yaml
+.gstack/

--- a/helpers/entrypoint.sh
+++ b/helpers/entrypoint.sh
@@ -346,6 +346,7 @@ pip install hf_xet
 # (ENABLE_PIP_INSTALL_FRONTMATTER_REQUIREMENTS) is disabled — it is incompatible
 # with multi-worker deployments and unreliable across container restarts.
 pip install "mwclient>=0.10.1"
+pip install "pyyaml>=6.0"
 
 start_app
 wait_for_app

--- a/tools/roat_retrieval.py
+++ b/tools/roat_retrieval.py
@@ -101,12 +101,18 @@ def _format_context_and_sources(rag_result: dict, max_document_preview_chars: in
         filename = _get_filename_from_extras(extras)
         source_name = ref.get("title") or ref.get("source_name") or filename or f"Source {i + 1}"
 
-        metadata_fields = {k: v for k, v in extras.items() if k not in _internal_fields}
-        metadata_fields["url"] = ref.get("url") or extras.get("url")
-        metadata_md = "\n".join(f"- *{k}*: {v}" for k, v in metadata_fields.items() if v is not None)
-        metadata_section = f"## Metadata\n\n{metadata_md}" if metadata_md else ""
+        metadata_fields = {"title": source_name}
+        metadata_fields.update({k: v for k, v in extras.items() if k not in _internal_fields and v is not None})
+        url = ref.get("url") or extras.get("url")
+        if url:
+            metadata_fields["url"] = url
+        frontmatter = "---\n" + "\n".join(f"{k}: {v}" for k, v in metadata_fields.items()) + "\n---"
 
-        context_parts.append(f"[Source: {source_name}]\n\n{metadata_section}\n\n{text}\n")
+        context_parts.append(
+            f'<document index="{i + 1}" score="{score:.2f}" format="markdown+frontmatter">\n'
+            f"{frontmatter}\n\n{text}\n"
+            f"</document>"
+        )
 
         source_obj = {
             "source": {"name": source_name},
@@ -132,7 +138,7 @@ def _format_context_and_sources(rag_result: dict, max_document_preview_chars: in
 
         sources.append(source_obj)
 
-    return "\n".join(context_parts), sources
+    return "\n\n".join(context_parts), sources
 
 
 class Tools:

--- a/tools/roat_retrieval.py
+++ b/tools/roat_retrieval.py
@@ -245,7 +245,30 @@ class Tools:
 
         Returns:
             Retrieved document chunks with source metadata, or a message indicating
-            nothing relevant was found.
+            nothing relevant was found. Response uses the following format to present
+            multiple documents found:
+
+            <document index="1" score="0.63" format="markdown+frontmatter">
+            ---
+            title: FileTitle.txt
+            source: source-data-connector-name
+            last_modified: '2026-06-17 13:43:31.051046'
+            ---
+
+            Content of the document or document chunk
+            </document>
+
+            <document index="2" score="0.55" format="markdown+frontmatter">
+            ---
+            title: AnotherFileTitle.txt
+            source: source-data-connector-name
+            last_modified: '2026-06-18 15:23:11.071035'
+            ---
+
+            Content of another document or document chunk
+            </document>
+
+            ...
         """
 
         async def emit(description: str, done: bool = False) -> None:

--- a/tools/roat_retrieval.py
+++ b/tools/roat_retrieval.py
@@ -21,6 +21,15 @@ from pydantic import BaseModel, Field
 log = logging.getLogger(__name__)
 log.setLevel(logging.INFO)
 
+_CLOSING_DOCUMENT_TAG_RE = re.compile(r"</document\s*>", re.IGNORECASE)
+_OPENING_DOCUMENT_TAG_RE = re.compile(r"<document\b", re.IGNORECASE)
+
+
+def _escape_document_tags(text: str) -> str:
+    text = _CLOSING_DOCUMENT_TAG_RE.sub(lambda m: "<\\/document>", text)
+    text = _OPENING_DOCUMENT_TAG_RE.sub(lambda m: "<\\document", text)
+    return text
+
 
 def _parse_raw_chunk(raw_text: str) -> dict:
     match = re.match(r"Score:\s*([\d.]+)\s*\|\s*Text:\s*(.*)", raw_text, re.DOTALL)
@@ -120,7 +129,7 @@ def _format_context_and_sources(rag_result: dict, max_document_preview_chars: in
             sort_keys=False,
         ).strip()
         frontmatter = f"---\n{frontmatter_body}\n---"
-        safe_text = text.replace("</document>", "<\\/document>")
+        safe_text = _escape_document_tags(text)
         context_parts.append(
             f'<document index="{i + 1}" score="{score:.2f}" format="markdown+frontmatter">\n'
             f"{frontmatter}\n\n{safe_text}\n"

--- a/tools/roat_retrieval.py
+++ b/tools/roat_retrieval.py
@@ -120,9 +120,10 @@ def _format_context_and_sources(rag_result: dict, max_document_preview_chars: in
             sort_keys=False,
         ).strip()
         frontmatter = f"---\n{frontmatter_body}\n---"
+        safe_text = text.replace("</document>", "<\\/document>")
         context_parts.append(
             f'<document index="{i + 1}" score="{score:.2f}" format="markdown+frontmatter">\n'
-            f"{frontmatter}\n\n<content>\n{text}\n</content>\n"
+            f"{frontmatter}\n\n{safe_text}\n"
             f"</document>"
         )
 

--- a/tools/roat_retrieval.py
+++ b/tools/roat_retrieval.py
@@ -5,7 +5,7 @@ date: 2025-05-01
 version: 1.0
 license: MIT
 description: Searches the RAG-of-All-Trades knowledge base and returns relevant context for the user's query.
-requirements: requests
+requirements: requests, pyyaml
 """
 
 import asyncio
@@ -14,6 +14,7 @@ import os
 import re
 from collections.abc import Awaitable, Callable
 
+import yaml
 import requests
 from pydantic import BaseModel, Field
 
@@ -102,15 +103,26 @@ def _format_context_and_sources(rag_result: dict, max_document_preview_chars: in
         source_name = ref.get("title") or ref.get("source_name") or filename or f"Source {i + 1}"
 
         metadata_fields = {"title": source_name}
-        metadata_fields.update({k: v for k, v in extras.items() if k not in _internal_fields and v is not None})
+        metadata_fields.update(
+            {
+                k: v
+                for k, v in extras.items()
+                if k not in _internal_fields and k != "url" and v is not None
+            }
+        )
         url = ref.get("url") or extras.get("url")
         if url:
             metadata_fields["url"] = url
-        frontmatter = "---\n" + "\n".join(f"{k}: {v}" for k, v in metadata_fields.items()) + "\n---"
-
+        frontmatter_body = yaml.safe_dump(
+            metadata_fields,
+            default_flow_style=False,
+            allow_unicode=True,
+            sort_keys=False,
+        ).strip()
+        frontmatter = f"---\n{frontmatter_body}\n---"
         context_parts.append(
             f'<document index="{i + 1}" score="{score:.2f}" format="markdown+frontmatter">\n'
-            f"{frontmatter}\n\n{text}\n"
+            f"{frontmatter}\n\n<content>\n{text}\n</content>\n"
             f"</document>"
         )
 


### PR DESCRIPTION
## Summary
- Replaces the old `[Source: <title>]` + `## Metadata` bullet list format with `<document>` XML wrapper tags and YAML frontmatter
- Frontmatter fields: `title` first, extras (minus internal fields) middle, `url` last
- Documents separated by `\n\n` for clean boundaries