### PR TITLE
MAIT-240: Allow model system prompt override/extension via ENV during bootstrapping

### DIFF
--- a/.env.openwebui.example
+++ b/.env.openwebui.example
@@ -40,6 +40,11 @@ OPENAI_API_KEY=sk-or-v1-xxxxxxxxx
 OPENAI_DEFAULT_MODEL=openai/gpt-4.1-nano
 # set to "True" to make the default model private and create a public Workspace model on first boot
 # CREATE_CUSTOM_WORKSPACE_MODEL=True
+# Model system prompt override/extension (optional, applies when CREATE_CUSTOM_WORKSPACE_MODEL=True):
+# - OWUI_MODEL_PROMPT fully replaces the bundled system prompt
+# - OWUI_MODEL_PROMPT_APPEND appends to the bundled (or overridden) system prompt, separated by a blank line
+#OWUI_MODEL_PROMPT=
+#OWUI_MODEL_PROMPT_APPEND=
 
 # system settings, see https://docs.openwebui.com/getting-started/env-configuration/ for a complete list
 ENV=dev

--- a/helpers/entrypoint.sh
+++ b/helpers/entrypoint.sh
@@ -187,6 +187,18 @@ do_first_start() {
                   '.[0].base_model_id = $base_model | .[0]' \
                   "/etc/wikiteqcenturion.json")
 
+                if [ -n "$OWUI_MODEL_PROMPT" ]; then
+                    WORKSPACE_MODEL_DATA=$(echo "${WORKSPACE_MODEL_DATA}" | jq \
+                      --arg prompt "$OWUI_MODEL_PROMPT" \
+                      '.params.system = $prompt')
+                fi
+
+                if [ -n "$OWUI_MODEL_PROMPT_APPEND" ]; then
+                    WORKSPACE_MODEL_DATA=$(echo "${WORKSPACE_MODEL_DATA}" | jq \
+                      --arg append "$OWUI_MODEL_PROMPT_APPEND" \
+                      '.params.system = (.params.system + "\n\n" + $append)')
+                fi
+
                 if [ "$TOOL_MEDIAWIKI_ENABLED" == "True" ]; then
                     WORKSPACE_MODEL_DATA=$(echo "${WORKSPACE_MODEL_DATA}" | jq \
                       '.meta.toolIds += ["mediawiki"]')


### PR DESCRIPTION
## Summary

- Adds `OWUI_MODEL_PROMPT` env var: when set, fully replaces the bundled `wikiteqcenturion` system prompt at first-boot bootstrapping time
- Adds `OWUI_MODEL_PROMPT_APPEND` env var: when set, appends custom instructions to the active system prompt (bundled or overridden), separated by a blank line
- Both vars are no-ops when `CREATE_CUSTOM_WORKSPACE_MODEL` is not `True`
- Documents both vars in `.env.openwebui.example`

## How it works

In `helpers/entrypoint.sh`, after `WORKSPACE_MODEL_DATA` is loaded from `wikiteqcenturion.json`, two `jq` mutations are applied (in order):
1. If `OWUI_MODEL_PROMPT` is set → `.params.system = $prompt`
2. If `OWUI_MODEL_PROMPT_APPEND` is set → `.params.system = (.params.system + "\n\n" + $append)`

## Test plan

- [x] Live tested: started stack with both vars set, verified model API returned the injected prompt + appended section
- [x] Verified combination order: replace runs before append
- [x] Verified neither var set = no change to bundled prompt behavior