### PR TITLE
Update rag-of-all-trades image to b345647

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -93,7 +93,7 @@ services:
 
   # rag-of-all-trades API
   api:
-    image: ghcr.io/wikiteq/rag-of-all-trades:ba94b0d
+    image: ghcr.io/wikiteq/rag-of-all-trades:b345647
     extra_hosts:
       - "host.docker.internal:host-gateway"
     depends_on:
@@ -117,7 +117,7 @@ services:
 
   # rag-of-all-trades WORKER
   celery_worker:
-    image: ghcr.io/wikiteq/rag-of-all-trades:ba94b0d
+    image: ghcr.io/wikiteq/rag-of-all-trades:b345647
     extra_hosts:
       - "host.docker.internal:host-gateway"
     depends_on:
@@ -143,7 +143,7 @@ services:
 
   # rag-of-all-trades BEAT
   celery_beat:
-    image: ghcr.io/wikiteq/rag-of-all-trades:ba94b0d
+    image: ghcr.io/wikiteq/rag-of-all-trades:b345647
     depends_on:
       postgres:
         condition: service_healthy


### PR DESCRIPTION
## Summary
- Bumps `rag-of-all-trades` image tag to `b345647` across all three services (`api`, `celery_worker`, `celery_beat`) in `compose.yaml`