### PR TITLE
Document enabled property for connector sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -470,6 +470,7 @@ sources: # holds the list of sources to ingest from (Connectors)
 
   - type: # type of the connector (s3, mediawiki, serpapi)
     name: # arbitrary name for the connector, will be stored in metadata
+    enabled: true # optional, set to false to skip this source entirely (default: true)
     config:
       # connector specific configuration
       schedules: "${S3_ACCOUNT1_SCHEDULES}"

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -1,6 +1,7 @@
 sources:
   - type: "s3"
     name: "account1"
+    enabled: true  # optional, applies to all connector types below; set false to skip this source entirely (default: true)
     config:
       endpoint: "${S3_ACCOUNT1_ENDPOINT}"
       access_key: "${S3_ACCOUNT1_ACCESS_KEY}"

--- a/docs/connectors/directory-connector.mdx
+++ b/docs/connectors/directory-connector.mdx
@@ -37,6 +37,7 @@ Use the same container path (e.g. `/data/docs`) as the `path` value in `config.y
 sources:
   - type: "directory"
     name: "local_docs"
+    enabled: true  # optional, default: true
     config:
       path: "/data/docs"            # required, path inside the container
       recursive: true               # optional, default true
@@ -52,6 +53,7 @@ sources:
 
 | Field | Required | Default | Description |
 |---|---|---|---|
+| `enabled` | no | `true` | Set to `false` to skip this source entirely |
 | `path` | yes | — | Absolute path to the directory inside the container |
 | `recursive` | no | `true` | Whether to recurse into subdirectories |
 | `required_exts` | no | — | Comma-separated file extensions to include (e.g. `txt,md,pdf`). All files are included when omitted. |

--- a/docs/connectors/jira-connector.mdx
+++ b/docs/connectors/jira-connector.mdx
@@ -42,6 +42,7 @@ Set these in `.env.rag`:
 sources:
   - type: "jira"
     name: "jira1"
+    enabled: true  # optional, default: true
     config:
       server_url: "${JIRA1_SERVER_URL}"
       auth_type: "basic"
@@ -75,6 +76,7 @@ sources:
 
 | Field | Required | Default | Description |
 |---|---|---|---|
+| `enabled` | no | `true` | Set to `false` to skip this source entirely |
 | `server_url` | yes | — | Base URL of your Jira instance |
 | `auth_type` | yes | — | `basic` or `token` |
 | `email` | when `auth_type=basic` | — | Jira account email |

--- a/docs/connectors/mediawiki-connector.mdx
+++ b/docs/connectors/mediawiki-connector.mdx
@@ -43,6 +43,7 @@ Set these in `.env.rag`:
 sources:
   - type: "mediawiki"
     name: "wiki1"
+    enabled: true  # optional, default: true
     config:
       host: "${MEDIAWIKI1_HOST}"
       path: "/w/"          # optional, default /w/
@@ -60,6 +61,7 @@ sources:
 
 | Field | Required | Default | Description |
 |---|---|---|---|
+| `enabled` | no | `true` | Set to `false` to skip this source entirely |
 | `host` | yes | — | Hostname of the MediaWiki instance (e.g. `en.wikipedia.org`) |
 | `path` | no | `/w/` | Path to the MediaWiki API root |
 | `scheme` | no | `https` | URL scheme (`http` or `https`) |

--- a/docs/connectors/pipedrive-connector.mdx
+++ b/docs/connectors/pipedrive-connector.mdx
@@ -30,6 +30,7 @@ Set these in `.env.rag`:
 sources:
   - type: "pipedrive"
     name: "pipedrive1"
+    enabled: true  # optional, default: true
     config:
       api_token: "${PIPEDRIVE1_API_TOKEN}"
       # Optional: which object types to load (default: all)
@@ -60,6 +61,7 @@ PIPEDRIVE1_SCHEDULES=3600
 
 | Field | Required | Default | Description |
 |---|---|---|---|
+| `enabled` | no | `true` | Set to `false` to skip this source entirely |
 | `api_token` | yes | — | Pipedrive API token |
 | `load_types` | no | all 10 types | List of entity types to ingest. Valid values: `activities`, `deals`, `notes`, `organizations`, `persons`, `products`, `projects`, `leads`, `tasks`, `mails` |
 | `max_items` | no | unlimited | Maximum number of records to fetch per entity type |

--- a/docs/connectors/s3-connector.mdx
+++ b/docs/connectors/s3-connector.mdx
@@ -34,6 +34,7 @@ Set these in `.env.rag`:
 sources:
   - type: "s3"
     name: "account1"
+    enabled: true  # optional, default: true
     config:
       endpoint: "${S3_ACCOUNT1_ENDPOINT}"
       access_key: "${S3_ACCOUNT1_ACCESS_KEY}"
@@ -48,6 +49,7 @@ sources:
 
 | Field | Required | Default | Description |
 |---|---|---|---|
+| `enabled` | no | `true` | Set to `false` to skip this source entirely |
 | `endpoint` | yes | — | S3 API endpoint URL |
 | `access_key` | yes | — | Access key ID |
 | `secret_key` | yes | — | Secret access key |

--- a/docs/connectors/serpapi-connector.mdx
+++ b/docs/connectors/serpapi-connector.mdx
@@ -30,6 +30,7 @@ Set these in `.env.rag`:
 sources:
   - type: "serpapi"
     name: "serp_ingestion1"
+    enabled: true  # optional, default: true
     config:
       api_key: "${SERPAPI1_KEY}"
       queries: "${SERPAPI1_QUERIES}"
@@ -40,6 +41,7 @@ sources:
 
 | Field | Required | Default | Description |
 |---|---|---|---|
+| `enabled` | no | `true` | Set to `false` to skip this source entirely |
 | `api_key` | yes | — | SerpAPI API key |
 | `queries` | yes | — | One query or comma-separated list of queries |
 | `schedules` | no | `3600` | Ingestion interval in seconds |

--- a/docs/connectors/web-connector.mdx
+++ b/docs/connectors/web-connector.mdx
@@ -41,6 +41,7 @@ sources:
   # URLs mode — scrape a fixed list of pages
   - type: "web"
     name: "web1"
+    enabled: true  # optional, default: true
     config:
       urls: "${WEB1_URLS}"
       html_to_text: true
@@ -73,6 +74,7 @@ WEB2_SCHEDULES=3600
 
 | Field | Required | Default | Description |
 |---|---|---|---|
+| `enabled` | no | `true` | Set to `false` to skip this source entirely |
 | `urls` | yes (URLs mode) | — | Comma-separated list of URLs to scrape |
 | `sitemap_url` | yes (sitemap mode) | — | URL of the `sitemap.xml` to parse |
 | `include_prefix` | no | — | Only ingest URLs with this path prefix (mutually exclusive with `exclude_prefix`) |


### PR DESCRIPTION
## Summary
- Documents the new `enabled` property (added in rag-of-all-trades PR #69) for all connector `sources` entries
- Adds `enabled` row to the Configuration Reference table in all 7 connector docs
- Adds `enabled: true` to each connector's `config.yaml` example, showing correct placement (sibling of `type`/`name`, not nested under `config`)
- Updates `config.yaml.example` and `README.md` reference section with the same

Related: MAIT-269