### PR TITLE
Update rag-of-all-trades image to 367bd7c

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -93,7 +93,7 @@ services:
 
   # rag-of-all-trades API
   api:
-    image: ghcr.io/wikiteq/rag-of-all-trades:b345647
+    image: ghcr.io/wikiteq/rag-of-all-trades:367bd7c
     extra_hosts:
       - "host.docker.internal:host-gateway"
     depends_on:
@@ -117,7 +117,7 @@ services:
 
   # rag-of-all-trades WORKER
   celery_worker:
-    image: ghcr.io/wikiteq/rag-of-all-trades:b345647
+    image: ghcr.io/wikiteq/rag-of-all-trades:367bd7c
     extra_hosts:
       - "host.docker.internal:host-gateway"
     depends_on:
@@ -143,7 +143,7 @@ services:
 
   # rag-of-all-trades BEAT
   celery_beat:
-    image: ghcr.io/wikiteq/rag-of-all-trades:b345647
+    image: ghcr.io/wikiteq/rag-of-all-trades:367bd7c
     depends_on:
       postgres:
         condition: service_healthy


### PR DESCRIPTION
## Summary
- Bumps `rag-of-all-trades` image tag to `367bd7c` across all three services (`api`, `celery_worker`, `celery_beat`) in `compose.yaml`