### PR TITLE
MAIT-307: Port OpenWebUI compression middleware (gzip/brotli/zstd)

### DIFF
--- a/helpers/entrypoint.sh
+++ b/helpers/entrypoint.sh
@@ -347,6 +347,13 @@ pip install hf_xet
 # with multi-worker deployments and unreliable across container restarts.
 pip install "mwclient>=0.10.1"
 
+# Compression support for the response compression middleware
+# (patches/compression.patch). zstandard is already a transitive OpenWebUI
+# dependency but pinned explicitly here so a future base-image bump can't
+# silently drop it; brotli is not present in the base image at all; gzip is
+# stdlib.
+pip install "brotli>=1.1.0" "zstandard>=0.23.0"
+
 start_app
 wait_for_app
 #copy_statics

--- a/helpers/entrypoint.sh
+++ b/helpers/entrypoint.sh
@@ -351,8 +351,9 @@ pip install "mwclient>=0.10.1"
 # (patches/compression.patch). zstandard is already a transitive OpenWebUI
 # dependency but pinned explicitly here so a future base-image bump can't
 # silently drop it; brotli is not present in the base image at all; gzip is
-# stdlib.
-pip install "brotli>=1.1.0" "zstandard>=0.23.0"
+# stdlib. Exact pins (not >=) so a new brotli/zstandard release can't
+# silently change compression behavior underneath the middleware.
+pip install "brotli==1.1.0" "zstandard==0.23.0"
 
 start_app
 wait_for_app

--- a/patches/compression.patch
+++ b/patches/compression.patch
@@ -1,0 +1,163 @@
+diff --git backend/open_webui/main.py backend/open_webui/main.py
+index 56ea17fa1..1111111 100644
+--- backend/open_webui/main.py
++++ backend/open_webui/main.py
+@@ -39,6 +39,10 @@
+ from fastapi.responses import JSONResponse, RedirectResponse
+ from fastapi.staticfiles import StaticFiles
+
++import brotli
++import gzip
++import zstandard
++
+ from starlette.exceptions import HTTPException as StarletteHTTPException
+ from starlette.middleware.base import BaseHTTPMiddleware
+ from starlette.middleware.sessions import SessionMiddleware
+@@ -859,6 +863,135 @@ class SPAStaticFiles(StaticFiles):
+
+ app.state.MODELS = {}
+
++# Smallest body worth spending CPU cycles compressing.
++RESPONSE_COMPRESSION_MIN_BYTES = 1024
++
++# Largest body worth buffering in memory to compress. Above this, skip
++# compression and pass the original streaming response through untouched —
++# bounds worst-case per-request memory for large exports/search results.
++RESPONSE_COMPRESSION_MAX_BYTES = 10 * 1024 * 1024
++
++# Only buffer+compress response types we know are single-shot bodies.
++# Deliberately excludes text/event-stream and other streaming content so
++# chat SSE responses are never buffered or delayed by this middleware.
++RESPONSE_COMPRESSION_MEDIA_TYPES = {
++    "application/json",
++    "text/plain",
++    "text/html",
++    "text/css",
++    "text/javascript",
++    "application/javascript",
++    "image/svg+xml",
++}
++
++# Preference order when a client's Accept-Encoding accepts more than one.
++# zstd gives the best ratio/speed tradeoff, brotli next, gzip as the
++# universally-supported fallback.
++RESPONSE_ENCODERS = {
++    "zstd": lambda data: zstandard.ZstdCompressor().compress(data),
++    "br": lambda data: brotli.compress(data),
++    "gzip": lambda data: gzip.compress(data),
++}
++
++
++def _negotiate_encoding(accept_encoding: str) -> str | None:
++    accepted = set()
++    for part in accept_encoding.split(","):
++        piece = part.strip()
++        if not piece:
++            continue
++        name, _, params = piece.partition(";")
++        name = name.strip().lower()
++        qvalue = 1.0
++        for param in params.split(";"):
++            key, _, value = param.strip().partition("=")
++            if key.strip().lower() == "q":
++                try:
++                    qvalue = float(value.strip())
++                except ValueError:
++                    qvalue = 1.0
++        if name and qvalue > 0:
++            accepted.add(name)
++    for candidate in RESPONSE_ENCODERS:
++        if candidate in accepted:
++            return candidate
++    return None
++
++
++class ResponseCompressionMiddleware(BaseHTTPMiddleware):
++    """0.6.5 sends every response uncompressed; negotiate a single best
++    encoding from Accept-Encoding and compress the body in one pass rather
++    than layering a separate middleware per algorithm."""
++
++    async def dispatch(self, request: Request, call_next):
++        response = await call_next(request)
++
++        # call_next() always hands back Starlette's internal
++        # _StreamingResponse, which never sets media_type — the real
++        # Content-Type only lives in the header at this point.
++        content_type = response.headers.get("content-type", "").split(";")[0].strip().lower()
++        encoding = _negotiate_encoding(request.headers.get("accept-encoding", ""))
++        if (
++            encoding is None
++            or content_type not in RESPONSE_COMPRESSION_MEDIA_TYPES
++            or "content-encoding" in response.headers
++        ):
++            return response
++
++        chunks = []
++        size = 0
++        too_large = False
++        async for chunk in response.body_iterator:
++            size += len(chunk)
++            if size > RESPONSE_COMPRESSION_MAX_BYTES:
++                too_large = True
++                break
++            chunks.append(chunk)
++
++        if too_large:
++            # Body exceeded the cap; nothing consumed it downstream, so
++            # replay what we already read followed by the rest of the
++            # stream, uncompressed, rather than holding it all in memory.
++            async def replay():
++                for chunk in chunks:
++                    yield chunk
++                async for chunk in response.body_iterator:
++                    yield chunk
++
++            return StreamingResponse(
++                replay(),
++                status_code=response.status_code,
++                headers=dict(response.headers),
++                media_type=content_type,
++            )
++
++        body = b"".join(chunks)
++
++        if len(body) < RESPONSE_COMPRESSION_MIN_BYTES:
++            return Response(
++                content=body,
++                status_code=response.status_code,
++                headers=dict(response.headers),
++                media_type=content_type,
++            )
++
++        compressed = RESPONSE_ENCODERS[encoding](body)
++        headers = dict(response.headers)
++        headers["content-encoding"] = encoding
++        headers["content-length"] = str(len(compressed))
++        existing_vary = headers.get("vary", "")
++        vary_values = [v.strip() for v in existing_vary.split(",") if v.strip()]
++        if "Accept-Encoding" not in vary_values:
++            vary_values.append("Accept-Encoding")
++        headers["vary"] = ", ".join(vary_values)
++
++        return Response(
++            content=compressed,
++            status_code=response.status_code,
++            headers=headers,
++            media_type=content_type,
++        )
++
+
+ class RedirectMiddleware(BaseHTTPMiddleware):
+     async def dispatch(self, request: Request, call_next):
+@@ -985,6 +1118,11 @@ if audit_level != AuditLevel.NONE:
+         excluded_paths=AUDIT_EXCLUDED_PATHS,
+         max_body_size=MAX_BODY_LOG_SIZE,
+     )
++
++# Registered last (wraps outermost) so it sees the response after
++# AuditLoggingMiddleware/CORSMiddleware have already read/annotated it —
++# audit logs capture the original body, not compressed bytes.
++app.add_middleware(ResponseCompressionMiddleware)
+ ##################################
+ #
+ # Chat Endpoints

--- a/patches/compression.patch
+++ b/patches/compression.patch
@@ -13,7 +13,7 @@ index 56ea17fa1..1111111 100644
  from starlette.exceptions import HTTPException as StarletteHTTPException
  from starlette.middleware.base import BaseHTTPMiddleware
  from starlette.middleware.sessions import SessionMiddleware
-@@ -859,6 +863,135 @@ class SPAStaticFiles(StaticFiles):
+@@ -859,6 +863,154 @@ class SPAStaticFiles(StaticFiles):
 
  app.state.MODELS = {}
 
@@ -49,7 +49,10 @@ index 56ea17fa1..1111111 100644
 +
 +
 +def _negotiate_encoding(accept_encoding: str) -> str | None:
-+    accepted = set()
++    # name -> client q-value (higher wins). "*" carries its own q-value and
++    # is applied as a fallback for any encoder not explicitly named.
++    qvalues: dict[str, float] = {}
++    wildcard_q: float | None = None
 +    for part in accept_encoding.split(","):
 +        piece = part.strip()
 +        if not piece:
@@ -64,12 +67,25 @@ index 56ea17fa1..1111111 100644
 +                    qvalue = float(value.strip())
 +                except ValueError:
 +                    qvalue = 1.0
-+        if name and qvalue > 0:
-+            accepted.add(name)
-+    for candidate in RESPONSE_ENCODERS:
-+        if candidate in accepted:
-+            return candidate
-+    return None
++        if name == "*":
++            wildcard_q = qvalue
++        elif name:
++            qvalues[name] = qvalue
++
++    # Fixed zstd > br > gzip preference is only a tie-breaker; the client's
++    # explicit q-value ranking always wins.
++    preference = {name: i for i, name in enumerate(RESPONSE_ENCODERS)}
++    best_name = None
++    best_key = None
++    for name in RESPONSE_ENCODERS:
++        q = qvalues.get(name, wildcard_q if wildcard_q is not None else 0.0)
++        if q <= 0:
++            continue
++        key = (q, -preference[name])
++        if best_key is None or key > best_key:
++            best_key = key
++            best_name = name
++    return best_name
 +
 +
 +class ResponseCompressionMiddleware(BaseHTTPMiddleware):
@@ -96,16 +112,19 @@ index 56ea17fa1..1111111 100644
 +        size = 0
 +        too_large = False
 +        async for chunk in response.body_iterator:
++            # Append before checking the cap — body_iterator has already
++            # handed us this chunk, so dropping it here would silently
++            # truncate the replayed response by one chunk.
++            chunks.append(chunk)
 +            size += len(chunk)
 +            if size > RESPONSE_COMPRESSION_MAX_BYTES:
 +                too_large = True
 +                break
-+            chunks.append(chunk)
 +
 +        if too_large:
-+            # Body exceeded the cap; nothing consumed it downstream, so
-+            # replay what we already read followed by the rest of the
-+            # stream, uncompressed, rather than holding it all in memory.
++            # Body exceeded the cap; replay everything read so far followed
++            # by the rest of the stream, uncompressed, rather than holding
++            # the whole thing in memory.
 +            async def replay():
 +                for chunk in chunks:
 +                    yield chunk
@@ -149,7 +168,7 @@ index 56ea17fa1..1111111 100644
 
  class RedirectMiddleware(BaseHTTPMiddleware):
      async def dispatch(self, request: Request, call_next):
-@@ -985,6 +1118,11 @@ if audit_level != AuditLevel.NONE:
+@@ -985,6 +1137,11 @@ if audit_level != AuditLevel.NONE:
          excluded_paths=AUDIT_EXCLUDED_PATHS,
          max_body_size=MAX_BODY_LOG_SIZE,
      )


### PR DESCRIPTION
## Summary
- OpenWebUI 0.6.5 sends every HTTP response uncompressed. Adds a custom `ResponseCompressionMiddleware` via a new `patches/compression.patch` supporting gzip, brotli, and zstd.
- Negotiates a single best encoding per request (zstd > brotli > gzip preference, RFC-correct `q`-value handling), compressed in one pass, limited to an explicit content-type allowlist that excludes `text/event-stream` so chat SSE streaming is never buffered or delayed.
- Adds a 10MB body-buffering cap (falls back to an uncompressed streaming passthrough above it) and registers the middleware after `AuditLoggingMiddleware`/CORS so audit logs still capture readable response bodies instead of compressed bytes.
- `helpers/entrypoint.sh` installs `brotli` (not in the base image) and explicitly pins `zstandard` (already a transitive dependency, now pinned defensively).