### PR TITLE
QLOUD-550: Surface real error details to the model in ROAT/Wiki tools

### DIFF
--- a/tools/mediawiki_tool.py
+++ b/tools/mediawiki_tool.py
@@ -189,7 +189,14 @@ class Tools:
         async def emit(message: str, done: bool = False, hidden: bool = True) -> None:
             if __event_emitter__:
                 await __event_emitter__(
-                    {"type": "status", "data": {"description": message, "done": done, "hidden": hidden}}
+                    {
+                        "type": "status",
+                        "data": {
+                            "description": message,
+                            "done": done,
+                            "hidden": hidden,
+                        },
+                    }
                 )
 
         # --- Validate configuration ---
@@ -231,7 +238,7 @@ class Tools:
             return "Error: authentication failed. If using a BotPassword, the format is 'Username@BotName'."
         except Exception as e:
             log.error("mwclient connection error", exc_info=True)
-            await emit(f"Error: could not connect to the wiki: {e}", done=True, hidden=False)
+            await emit("Error: could not connect to the wiki.", done=True, hidden=False)
             return (
                 f"Error: could not connect to the wiki. Check the wiki_url in Tool Valves. Details: {_truncate(str(e))}"
             )
@@ -260,7 +267,7 @@ class Tools:
             return f"Error: wiki API returned an error ({e.code})."
         except Exception as e:
             log.error("Unexpected error during search: %s", e, exc_info=True)
-            await emit(f"Error: unexpected error during search: {e}", done=True, hidden=False)
+            await emit("Error: unexpected error during search.", done=True, hidden=False)
             return f"Error: unexpected error during search. Details: {_truncate(str(e))}"
 
         if not titles:
@@ -347,7 +354,14 @@ class Tools:
         async def emit(message: str, done: bool = False, hidden: bool = True) -> None:
             if __event_emitter__:
                 await __event_emitter__(
-                    {"type": "status", "data": {"description": message, "done": done, "hidden": hidden}}
+                    {
+                        "type": "status",
+                        "data": {
+                            "description": message,
+                            "done": done,
+                            "hidden": hidden,
+                        },
+                    }
                 )
 
         # --- Validate configuration ---
@@ -405,7 +419,11 @@ class Tools:
             return "Error: authentication failed. If using a BotPassword, the format is 'Username@BotName'."
         except Exception as e:
             log.error("mwclient connection error", exc_info=True)
-            await emit(f"Error: could not connect to the wiki: {e}", done=True, hidden=False)
+            await emit(
+                "Error: could not connect to the wiki.",
+                done=True,
+                hidden=False,
+            )
             return (
                 f"Error: could not connect to the wiki. Check the wiki_url in Tool Valves. Details: {_truncate(str(e))}"
             )
@@ -431,7 +449,7 @@ class Tools:
             return f"Error: wiki API returned an error ({e.code}). Check page title and permissions."
         except Exception as e:
             log.error("Unexpected error saving page: %s", e, exc_info=True)
-            await emit(f"Error: unexpected error while saving: {e}", done=True, hidden=False)
+            await emit("Error: an unexpected error occurred while saving.", done=True, hidden=False)
             return f"Error: an unexpected error occurred while saving. Details: {_truncate(str(e))}"
 
         # --- Build canonical page URL (blocking — run in thread) ---

--- a/tools/mediawiki_tool.py
+++ b/tools/mediawiki_tool.py
@@ -230,13 +230,16 @@ class Tools:
                 self.valves.username,
                 self.valves.password,
             )
-        except mwclient.errors.LoginError:
+        except mwclient.errors.LoginError as e:
             await emit(
                 "Error: authentication failed. Check your username and password in Tool Valves.",
                 done=True,
                 hidden=False,
             )
-            return "Error: authentication failed. If using a BotPassword, the format is 'Username@BotName'."
+            return (
+                "Error: authentication failed. If using a BotPassword, the format is 'Username@BotName'. "
+                f"Details: {_truncate(str(e))}"
+            )
         except Exception as e:
             log.error("mwclient connection error", exc_info=True)
             await emit("Error: could not connect to the wiki.", done=True, hidden=False)
@@ -411,13 +414,16 @@ class Tools:
                 self.valves.username,
                 self.valves.password,
             )
-        except mwclient.errors.LoginError:
+        except mwclient.errors.LoginError as e:
             await emit(
                 "Error: authentication failed. Check your username and password in Tool Valves.",
                 done=True,
                 hidden=False,
             )
-            return "Error: authentication failed. If using a BotPassword, the format is 'Username@BotName'."
+            return (
+                "Error: authentication failed. If using a BotPassword, the format is 'Username@BotName'. "
+                f"Details: {_truncate(str(e))}"
+            )
         except Exception as e:
             log.error("mwclient connection error", exc_info=True)
             await emit(
@@ -429,7 +435,7 @@ class Tools:
                 f"Error: could not connect to the wiki. Check the wiki_url in Tool Valves. Details: {_truncate(str(e))}"
             )
 
-        await emit(f"Saving page «{title}»…")
+        await emit(f"Saving page '{title}'…")
 
         # --- Save the page (blocking — run in thread) ---
         def _save():
@@ -439,15 +445,18 @@ class Tools:
         try:
             await asyncio.to_thread(_save)
         except mwclient.errors.ProtectedPageError:
-            await emit(f"Error: page «{title}» is protected and cannot be edited.", done=True, hidden=False)
-            return f"Error: page «{title}» is protected."
+            await emit(f"Error: page '{title}' is protected and cannot be edited.", done=True, hidden=False)
+            return f"Error: page '{title}' is protected."
         except mwclient.errors.APIError as e:
             if e.code in ("writeapidenied", "permissiondenied"):
                 await emit("Error: this wiki requires login to write.", done=True, hidden=False)
                 return "Error: this wiki requires authentication to write. Please configure username and password in Tool Valves."
             log.error("MediaWiki API error: %s", e.code)
             await emit(f"Error: wiki save failed ({e.code}).", done=True, hidden=False)
-            return f"Error: wiki API returned an error ({e.code}). Check page title and permissions."
+            return (
+                f"Error: wiki API returned an error ({e.code}). Check page title and permissions. "
+                f"Details: {_truncate(str(e))}"
+            )
         except Exception as e:
             log.error("Unexpected error saving page: %s", e, exc_info=True)
             await emit("Error: an unexpected error occurred while saving.", done=True, hidden=False)

--- a/tools/mediawiki_tool.py
+++ b/tools/mediawiki_tool.py
@@ -28,7 +28,8 @@ def _truncate(text: str, limit: int = MAX_ERROR_DETAIL_CHARS) -> str:
     text = text.strip()
     if len(text) <= limit:
         return text
-    return text[:limit] + "... (truncated)"
+    suffix = "... (truncated)"
+    return text[: limit - len(suffix)] + suffix
 
 
 # Characters illegal in MediaWiki page titles: #<>[]|{} plus control chars 0-31 and DEL (127)

--- a/tools/mediawiki_tool.py
+++ b/tools/mediawiki_tool.py
@@ -21,6 +21,15 @@ log = logging.getLogger(__name__)
 MAX_TITLE_LENGTH = 255
 MAX_CONTENT_LENGTH = 2_000_000  # 2 MB, MediaWiki default max
 MAX_SEARCH_RESULTS = 20
+MAX_ERROR_DETAIL_CHARS = 500
+
+
+def _truncate(text: str, limit: int = MAX_ERROR_DETAIL_CHARS) -> str:
+    text = text.strip()
+    if len(text) <= limit:
+        return text
+    return text[:limit] + "... (truncated)"
+
 
 # Characters illegal in MediaWiki page titles: #<>[]|{} plus control chars 0-31 and DEL (127)
 _ILLEGAL_TITLE_CHARS = re.compile(r"[#<>\[\]|{}\x00-\x1f\x7f]")
@@ -179,7 +188,9 @@ class Tools:
 
         async def emit(message: str, done: bool = False, hidden: bool = True) -> None:
             if __event_emitter__:
-                await __event_emitter__({"type": "status", "data": {"description": message, "done": done, "hidden": hidden}})
+                await __event_emitter__(
+                    {"type": "status", "data": {"description": message, "done": done, "hidden": hidden}}
+                )
 
         # --- Validate configuration ---
         if not self.valves.wiki_url:
@@ -212,12 +223,18 @@ class Tools:
                 self.valves.password,
             )
         except mwclient.errors.LoginError:
-            await emit("Error: authentication failed. Check your username and password in Tool Valves.", done=True, hidden=False)
+            await emit(
+                "Error: authentication failed. Check your username and password in Tool Valves.",
+                done=True,
+                hidden=False,
+            )
             return "Error: authentication failed. If using a BotPassword, the format is 'Username@BotName'."
-        except Exception:
+        except Exception as e:
             log.error("mwclient connection error", exc_info=True)
-            await emit("Error: could not connect to the wiki.", done=True, hidden=False)
-            return "Error: could not connect to the wiki. Check the wiki_url in Tool Valves."
+            await emit(f"Error: could not connect to the wiki: {e}", done=True, hidden=False)
+            return (
+                f"Error: could not connect to the wiki. Check the wiki_url in Tool Valves. Details: {_truncate(str(e))}"
+            )
 
         await emit("Fetching wiki article path…")
         article_path = await asyncio.to_thread(_get_article_path, site)
@@ -241,10 +258,10 @@ class Tools:
             log.error("MediaWiki API error: %s", e.code)
             await emit(f"Error: wiki search failed ({e.code}).", done=True, hidden=False)
             return f"Error: wiki API returned an error ({e.code})."
-        except Exception:
-            log.error("Unexpected error during search", exc_info=True)
-            await emit("Error: unexpected error during search.", done=True, hidden=False)
-            return "Error: unexpected error during search."
+        except Exception as e:
+            log.error("Unexpected error during search: %s", e, exc_info=True)
+            await emit(f"Error: unexpected error during search: {e}", done=True, hidden=False)
+            return f"Error: unexpected error during search. Details: {_truncate(str(e))}"
 
         if not titles:
             await emit("No results found.", done=True, hidden=False)
@@ -329,7 +346,9 @@ class Tools:
 
         async def emit(message: str, done: bool = False, hidden: bool = True) -> None:
             if __event_emitter__:
-                await __event_emitter__({"type": "status", "data": {"description": message, "done": done, "hidden": hidden}})
+                await __event_emitter__(
+                    {"type": "status", "data": {"description": message, "done": done, "hidden": hidden}}
+                )
 
         # --- Validate configuration ---
         if not self.valves.wiki_url:
@@ -378,12 +397,18 @@ class Tools:
                 self.valves.password,
             )
         except mwclient.errors.LoginError:
-            await emit("Error: authentication failed. Check your username and password in Tool Valves.", done=True, hidden=False)
+            await emit(
+                "Error: authentication failed. Check your username and password in Tool Valves.",
+                done=True,
+                hidden=False,
+            )
             return "Error: authentication failed. If using a BotPassword, the format is 'Username@BotName'."
-        except Exception:
+        except Exception as e:
             log.error("mwclient connection error", exc_info=True)
-            await emit("Error: could not connect to the wiki.", done=True, hidden=False)
-            return "Error: could not connect to the wiki. Check the wiki_url in Tool Valves."
+            await emit(f"Error: could not connect to the wiki: {e}", done=True, hidden=False)
+            return (
+                f"Error: could not connect to the wiki. Check the wiki_url in Tool Valves. Details: {_truncate(str(e))}"
+            )
 
         await emit(f"Saving page «{title}»…")
 
@@ -404,10 +429,10 @@ class Tools:
             log.error("MediaWiki API error: %s", e.code)
             await emit(f"Error: wiki save failed ({e.code}).", done=True, hidden=False)
             return f"Error: wiki API returned an error ({e.code}). Check page title and permissions."
-        except Exception:
-            log.error("Unexpected error saving page", exc_info=True)
-            await emit("Error: an unexpected error occurred while saving.", done=True, hidden=False)
-            return "Error: an unexpected error occurred. Check the server logs for details."
+        except Exception as e:
+            log.error("Unexpected error saving page: %s", e, exc_info=True)
+            await emit(f"Error: unexpected error while saving: {e}", done=True, hidden=False)
+            return f"Error: an unexpected error occurred while saving. Details: {_truncate(str(e))}"
 
         # --- Build canonical page URL (blocking — run in thread) ---
         await emit("Fetching page URL…")

--- a/tools/roat_retrieval.py
+++ b/tools/roat_retrieval.py
@@ -38,7 +38,8 @@ def _truncate(text: str, limit: int = MAX_ERROR_DETAIL_CHARS) -> str:
     text = text.strip()
     if len(text) <= limit:
         return text
-    return text[:limit] + "... (truncated)"
+    suffix = "... (truncated)"
+    return text[: limit - len(suffix)] + suffix
 
 
 def _extract_http_error_detail(err: requests.HTTPError) -> str:

--- a/tools/roat_retrieval.py
+++ b/tools/roat_retrieval.py
@@ -14,8 +14,8 @@ import os
 import re
 from collections.abc import Awaitable, Callable
 
-import yaml
 import requests
+import yaml
 from pydantic import BaseModel, Field
 
 log = logging.getLogger(__name__)
@@ -29,6 +29,28 @@ def _escape_document_tags(text: str) -> str:
     text = _CLOSING_DOCUMENT_TAG_RE.sub(lambda m: "<\\/document>", text)
     text = _OPENING_DOCUMENT_TAG_RE.sub(lambda m: "<\\document", text)
     return text
+
+
+MAX_ERROR_DETAIL_CHARS = 500
+
+
+def _truncate(text: str, limit: int = MAX_ERROR_DETAIL_CHARS) -> str:
+    text = text.strip()
+    if len(text) <= limit:
+        return text
+    return text[:limit] + "... (truncated)"
+
+
+def _extract_http_error_detail(err: requests.HTTPError) -> str:
+    resp = err.response
+    if resp is None:
+        return _truncate(str(err))
+    try:
+        body = resp.json()
+        detail = body.get("detail", body) if isinstance(body, dict) else body
+        return _truncate(str(detail))
+    except ValueError:
+        return _truncate(resp.text)
 
 
 def _parse_raw_chunk(raw_text: str) -> dict:
@@ -113,11 +135,7 @@ def _format_context_and_sources(rag_result: dict, max_document_preview_chars: in
 
         metadata_fields = {"title": source_name}
         metadata_fields.update(
-            {
-                k: v
-                for k, v in extras.items()
-                if k not in _internal_fields and k != "url" and v is not None
-            }
+            {k: v for k, v in extras.items() if k not in _internal_fields and k != "url" and v is not None}
         )
         url = ref.get("url") or extras.get("url")
         if url:
@@ -299,13 +317,15 @@ class Tools:
                 metadata_filters,
             )
         except requests.HTTPError as e:
+            detail = _extract_http_error_detail(e)
             log.error("ROAT request failed: %s", e, exc_info=True)
             await emit("The knowledge base rejected this request.", done=True)
-            return "Error: the knowledge base rejected this request. Check the server logs for details."
+            status_code = e.response.status_code if e.response is not None else "unknown"
+            return f"Error: the knowledge base rejected this request ({status_code}). {detail}"
         except Exception as e:
             log.error("ROAT request failed: %s", e, exc_info=True)
             await emit("Failed to reach the knowledge base.", done=True)
-            return "Error: could not reach the knowledge base. Check the server logs for details."
+            return f"Error: could not reach the knowledge base. {_truncate(str(e))}"
 
         context, sources = _format_context_and_sources(rag_result, self.valves.max_document_preview_chars)
 


### PR DESCRIPTION
## Summary
- Generic `except` blocks in `tools/roat_retrieval.py` and `tools/mediawiki_tool.py` were returning canned error messages with no detail, preventing the model from self-correcting malformed requests (e.g. a 422 from ROAT).
- Now the real HTTP status/validation detail (ROAT) or exception text (both tools) is included in the returned message, truncated to 500 chars to avoid flooding the chat.
- Scope covers all 6 generic except-blocks across both files (not just the 3 lines cited in the ticket), since the omitted call sites had the identical bug.

Jira: https://wikiteq.atlassian.net/browse/QLOUD-550