### PR TITLE
MAIT-328: Make MediaWiki search tool emit sources

### DIFF
--- a/tools/mediawiki_tool.py
+++ b/tools/mediawiki_tool.py
@@ -265,12 +265,24 @@ class Tools:
         pages: list[tuple[str, str]] = await asyncio.gather(*[asyncio.to_thread(_fetch_page, t) for t in titles])
 
         sections = []
+        sources = []
         cap = self.valves.max_page_chars
         for i, (title, content) in enumerate(pages, start=1):
             if len(content) > cap:
                 content = content[:cap] + f"\n...(truncated {len(content) - cap} chars)"
             url = _build_page_url(scheme, host, article_path, title)
             sections.append(f"=== Result {i}: {title} ===\nURL: {url}\n\nPage content: {content}\n")
+            sources.append(
+                {
+                    "source": {"name": title, "url": url},
+                    "document": [content],
+                    "metadata": [{"source": title, "url": url}],
+                }
+            )
+
+        if __event_emitter__:
+            for src in sources:
+                await __event_emitter__({"type": "source", "data": src})
 
         await emit(f"Found {len(pages)} result(s) for '{query}'.", done=True)
         return f"Search results for '{query}' ({len(pages)} page(s)):\n\n" + "\n---\n\n".join(sections)

--- a/tools/mediawiki_tool.py
+++ b/tools/mediawiki_tool.py
@@ -267,18 +267,20 @@ class Tools:
         sections = []
         sources = []
         cap = self.valves.max_page_chars
+        _fetch_errors = {"(Page not found — may have been deleted)", "(Content unavailable)"}
         for i, (title, content) in enumerate(pages, start=1):
             if len(content) > cap:
                 content = content[:cap] + f"\n...(truncated {len(content) - cap} chars)"
             url = _build_page_url(scheme, host, article_path, title)
             sections.append(f"=== Result {i}: {title} ===\nURL: {url}\n\nPage content: {content}\n")
-            sources.append(
-                {
-                    "source": {"name": title, "url": url},
-                    "document": [content],
-                    "metadata": [{"source": title, "url": url}],
-                }
-            )
+            if content not in _fetch_errors:
+                sources.append(
+                    {
+                        "source": {"name": title, "url": url},
+                        "document": [content],
+                        "metadata": [{"source": title, "url": url}],
+                    }
+                )
 
         if __event_emitter__:
             for src in sources:


### PR DESCRIPTION
## Summary
- `search_wiki` in `tools/mediawiki_tool.py` now emits a `source` event per matched wiki page via `__event_emitter__`, mirroring the citation pattern already used by `tools/roat_retrieval.py`.
- Each source includes the page title, URL, and content; the existing formatted-string return value is unchanged.

## Test plan
- [x] Verified live in OpenWebUI chat against real Wikipedia: search queries now render a "References from ..." citation bar with correct page titles/URLs.
- [x] Confirmed the same tool without this change produces no citation bar (before/after comparison in the same chat).
- [x] Ran multiple distinct queries in one conversation to confirm citations update correctly each time, not just once.