### PR TITLE
MAIT-310: Improve & install the image resizing filter

### DIFF
--- a/.env.openwebui.example
+++ b/.env.openwebui.example
@@ -120,3 +120,7 @@ ROAT_API_KEY=12345
 #WEBUI_AUTH_TRUSTED_EMAIL_HEADER=X-Auth-Request-Email
 #WEBUI_AUTH_TRUSTED_NAME_HEADER=X-Auth-Request-User
 
+# Image Resizer Filter (optional): set FUNCTION_IMAGE_RESIZER_ENABLED=True to auto-install
+# the image downscaling filter on first boot. max_dimension (default 768px) is
+# controlled via the filter's Valve in the admin UI, not an env var.
+#FUNCTION_IMAGE_RESIZER_ENABLED=True

--- a/compose.yaml
+++ b/compose.yaml
@@ -24,6 +24,8 @@ services:
       - ./tools/web_search.json:/etc/web_search.json
       - ./functions/video_inject.py:/etc/video_inject.py
       - ./functions/video_inject.json:/etc/video_inject.json
+      - ./functions/image_resizer.py:/etc/image_resizer.py
+      - ./functions/image_resizer.json:/etc/image_resizer.json
       - ./models:/etc/owui-models:ro
       - ./helpers/entrypoint.sh:/custom-entrypoint.sh
       - ./helpers/healthz.py:/etc/healthz.py

--- a/functions/image_resizer.json
+++ b/functions/image_resizer.json
@@ -1,0 +1,9 @@
+{
+  "id": "image_resizer",
+  "name": "Image Resizer",
+  "type": "filter",
+  "meta": {
+    "description": "Downscales oversized images in chat messages before they reach the model."
+  },
+  "content": ""
+}

--- a/functions/image_resizer.py
+++ b/functions/image_resizer.py
@@ -62,6 +62,12 @@ def resize_images_in_messages(messages, max_dimension=768):
                     raise ValueError("could not determine image format")
                 image_format = image.format
 
+                # Resizing only touches the first frame. Leave animated
+                # GIF/APNG/WebP images untouched rather than silently
+                # collapsing them to a static image.
+                if getattr(image, "is_animated", False):
+                    continue
+
                 if max(width, height) > max_dimension:
                     scaling_factor = max_dimension / max(width, height)
                     new_width = max(1, int(width * scaling_factor))

--- a/functions/image_resizer.py
+++ b/functions/image_resizer.py
@@ -18,6 +18,11 @@ log = logging.getLogger(__name__)
 # or oversized attachment can't force a large in-memory decode.
 MAX_ENCODED_BYTES = 25 * 1024 * 1024
 
+# Reject decoded images with an implausible pixel count, independent of how
+# small the encoded payload is (guards against decompression-bomb style
+# inputs where a tiny file expands into a huge pixel grid).
+MAX_PIXELS = 64_000_000  # e.g. an 8000x8000 image
+
 
 def resize_images_in_messages(messages, max_dimension=768):
     # No cross-turn cache: OpenWebUI resends a fresh copy of history each
@@ -46,6 +51,10 @@ def resize_images_in_messages(messages, max_dimension=768):
                 image_data = base64.b64decode(encoded)
                 image = Image.open(io.BytesIO(image_data))
                 width, height = image.size
+                if width * height > MAX_PIXELS:
+                    raise ValueError(
+                        f"decoded image too large ({width}x{height} pixels)"
+                    )
                 # Trust Pillow's own detection of the decoded bytes over the
                 # declared mime type. If Pillow can't identify the format,
                 # treat it as corrupted and bail out via the except below.
@@ -78,7 +87,9 @@ def resize_images_in_messages(messages, max_dimension=768):
 
 class Filter:
     class Valves(BaseModel):
-        max_dimension: int = Field(default=768, description="Maximum image dimension.")
+        max_dimension: int = Field(
+            default=768, ge=1, description="Maximum image dimension."
+        )
 
     class UserValves(BaseModel):
         pass

--- a/functions/image_resizer.py
+++ b/functions/image_resizer.py
@@ -1,0 +1,88 @@
+"""
+title: Image Resizer
+author: EaV Solution
+version: 0.2
+description: Downscales oversized images in chat messages before they reach the model.
+"""
+
+import base64
+import io
+import logging
+
+from pydantic import BaseModel, Field
+from PIL import Image
+
+log = logging.getLogger(__name__)
+
+# JPEG can't encode an alpha channel; flatten onto a white background first.
+ALPHA_MODES = {"RGBA", "LA", "PA"}
+
+
+def resize_images_in_messages(messages, max_dimension=768):
+    for message in messages:
+        for item in message.get("content", []):
+            if not (isinstance(item, dict) and item.get("type") == "image_url"):
+                continue
+            if item.get("_resized"):
+                continue
+
+            image_url = item.get("image_url")
+            if not isinstance(image_url, dict):
+                continue
+            image_data_url = image_url.get("url", "")
+            if not image_data_url.startswith("data:image/"):
+                continue
+
+            try:
+                header, encoded = image_data_url.split(",", 1)
+                image_mime_type = header.split(":")[1].split(";")[0]
+
+                image_data = base64.b64decode(encoded)
+                image = Image.open(io.BytesIO(image_data))
+                width, height = image.size
+                # Pillow detects the real format from the decoded bytes,
+                # which is more reliable than trusting the mime type string.
+                image_format = image.format or image_mime_type.split("/")[1].upper()
+
+                if max(width, height) > max_dimension:
+                    scaling_factor = max_dimension / max(width, height)
+                    new_width = int(width * scaling_factor)
+                    new_height = int(height * scaling_factor)
+                    image = image.resize((new_width, new_height), Image.LANCZOS)
+
+                    if image_format == "JPEG" and image.mode in ALPHA_MODES:
+                        image = image.convert("RGB")
+
+                    buffered = io.BytesIO()
+                    image.save(buffered, format=image_format)
+                    img_str = base64.b64encode(buffered.getvalue()).decode("utf-8")
+                    new_data_url = f"data:{image_mime_type};base64,{img_str}"
+                    image_url["url"] = new_data_url
+
+                item["_resized"] = True
+            except Exception as e:
+                log.warning(
+                    "image_resizer: failed to process image (mime=%s): %s",
+                    image_data_url[:30],
+                    e,
+                )
+                continue
+
+    return messages
+
+
+class Filter:
+    class Valves(BaseModel):
+        max_dimension: int = Field(default=768, description="Maximum image dimension.")
+
+    class UserValves(BaseModel):
+        pass
+
+    def __init__(self):
+        self.valves = self.Valves()
+
+    def inlet(self, body: dict, __user__=None) -> dict:
+        messages = body["messages"]
+        messages = resize_images_in_messages(messages, self.valves.max_dimension)
+        body["messages"] = messages
+        return body

--- a/functions/image_resizer.py
+++ b/functions/image_resizer.py
@@ -1,6 +1,6 @@
 """
 title: Image Resizer
-author: EaV Solution
+author: EaV Solution, WikiTeq
 version: 0.2
 description: Downscales oversized images in chat messages before they reach the model.
 """
@@ -9,22 +9,26 @@ import base64
 import io
 import logging
 
-from pydantic import BaseModel, Field
 from PIL import Image
+from pydantic import BaseModel, Field
 
 log = logging.getLogger(__name__)
 
-# JPEG can't encode an alpha channel; flatten onto a white background first.
-ALPHA_MODES = {"RGBA", "LA", "PA"}
+# Reject implausibly large encoded payloads before decoding, so a malicious
+# or oversized attachment can't force a large in-memory decode.
+MAX_ENCODED_BYTES = 25 * 1024 * 1024
 
 
 def resize_images_in_messages(messages, max_dimension=768):
-    resized_ids = set()
+    # No cross-turn cache: OpenWebUI resends a fresh copy of history each
+    # request, so every historical image is still base64-decoded and
+    # re-opened every turn. Only the encode+save step is skipped once an
+    # image is already at/under max_dimension.
     for message in messages:
         for item in message.get("content", []):
-            if not (isinstance(item, dict) and item.get("type") == "image_url"):
+            if not isinstance(item, dict):
                 continue
-            if id(item) in resized_ids:
+            if item.get("type") != "image_url":
                 continue
 
             image_url = item.get("image_url")
@@ -35,32 +39,32 @@ def resize_images_in_messages(messages, max_dimension=768):
                 continue
 
             try:
-                header, encoded = image_data_url.split(",", 1)
-                image_mime_type = header.split(":")[1].split(";")[0]
+                _, encoded = image_data_url.split(",", 1)
+                if len(encoded) > MAX_ENCODED_BYTES:
+                    raise ValueError(f"encoded payload too large ({len(encoded)} bytes)")
 
                 image_data = base64.b64decode(encoded)
                 image = Image.open(io.BytesIO(image_data))
                 width, height = image.size
-                # Pillow detects the real format from the decoded bytes,
-                # which is more reliable than trusting the mime type string.
-                image_format = image.format or image_mime_type.split("/")[1].upper()
+                # Trust Pillow's own detection of the decoded bytes over the
+                # declared mime type. If Pillow can't identify the format,
+                # treat it as corrupted and bail out via the except below.
+                if image.format is None:
+                    raise ValueError("could not determine image format")
+                image_format = image.format
 
                 if max(width, height) > max_dimension:
                     scaling_factor = max_dimension / max(width, height)
-                    new_width = int(width * scaling_factor)
-                    new_height = int(height * scaling_factor)
+                    new_width = max(1, int(width * scaling_factor))
+                    new_height = max(1, int(height * scaling_factor))
                     image = image.resize((new_width, new_height), Image.LANCZOS)
-
-                    if image_format == "JPEG" and image.mode in ALPHA_MODES:
-                        image = image.convert("RGB")
 
                     buffered = io.BytesIO()
                     image.save(buffered, format=image_format)
                     img_str = base64.b64encode(buffered.getvalue()).decode("utf-8")
-                    new_data_url = f"data:{image_mime_type};base64,{img_str}"
+                    out_mime = Image.MIME.get(image_format, f"image/{image_format.lower()}")
+                    new_data_url = f"data:{out_mime};base64,{img_str}"
                     image_url["url"] = new_data_url
-
-                resized_ids.add(id(item))
             except Exception as e:
                 log.warning(
                     "image_resizer: failed to process image (mime=%s): %s",
@@ -83,7 +87,7 @@ class Filter:
         self.valves = self.Valves()
 
     def inlet(self, body: dict, __user__=None) -> dict:
-        messages = body["messages"]
+        messages = body.get("messages", [])
         messages = resize_images_in_messages(messages, self.valves.max_dimension)
         body["messages"] = messages
         return body

--- a/functions/image_resizer.py
+++ b/functions/image_resizer.py
@@ -19,11 +19,12 @@ ALPHA_MODES = {"RGBA", "LA", "PA"}
 
 
 def resize_images_in_messages(messages, max_dimension=768):
+    resized_ids = set()
     for message in messages:
         for item in message.get("content", []):
             if not (isinstance(item, dict) and item.get("type") == "image_url"):
                 continue
-            if item.get("_resized"):
+            if id(item) in resized_ids:
                 continue
 
             image_url = item.get("image_url")
@@ -59,7 +60,7 @@ def resize_images_in_messages(messages, max_dimension=768):
                     new_data_url = f"data:{image_mime_type};base64,{img_str}"
                     image_url["url"] = new_data_url
 
-                item["_resized"] = True
+                resized_ids.add(id(item))
             except Exception as e:
                 log.warning(
                     "image_resizer: failed to process image (mime=%s): %s",

--- a/helpers/entrypoint.sh
+++ b/helpers/entrypoint.sh
@@ -412,9 +412,9 @@ install_image_resizer_filter() {
 
     FILTER_ID=$(echo "${CREATE_RESPONSE}" | jq -r '.id // empty')
     if [ -z "$FILTER_ID" ]; then
-        echo "[Custom entrypoint] ERROR: Image Resizer Filter install failed" >&2
+        echo "[Custom entrypoint] WARNING: Image Resizer Filter install failed" >&2
         echo "${CREATE_RESPONSE}" >&2
-        exit 1
+        return
     fi
 
     echo "[Custom entrypoint] Image Resizer Filter created with id: ${FILTER_ID}"

--- a/helpers/entrypoint.sh
+++ b/helpers/entrypoint.sh
@@ -266,6 +266,7 @@ do_first_start() {
     install_mediawiki_tool
     install_web_search_tool
     install_video_inject_filter
+    install_image_resizer_filter
 
     touch /app/backend/data/.first_start
 }
@@ -388,6 +389,44 @@ install_video_inject_filter() {
 
     echo ""
     echo "[Custom entrypoint] Enabling Video Inject Filter globally..."
+    curl -fsS -X POST "http://localhost:8080/api/v1/functions/id/${FILTER_ID}/toggle/global" \
+      -H "Authorization: Bearer ${API_KEY}" \
+      -H "Content-Type: application/json"
+}
+
+install_image_resizer_filter() {
+    if [ "$FUNCTION_IMAGE_RESIZER_ENABLED" != "True" ]; then
+        return
+    fi
+
+    echo ""
+    echo "[Custom entrypoint] Installing Image Resizer Filter..."
+
+    FILTER_CODE=$(jq -Rs . < "/etc/image_resizer.py")
+    DATA_RAW=$(jq --argjson content "${FILTER_CODE}" '.content=$content' /etc/image_resizer.json)
+
+    CREATE_RESPONSE=$(curl -fsS -X POST "http://localhost:8080/api/v1/functions/create" \
+      -H "Authorization: Bearer ${API_KEY}" \
+      -H "Content-Type: application/json" \
+      --data-raw "${DATA_RAW}")
+
+    FILTER_ID=$(echo "${CREATE_RESPONSE}" | jq -r '.id // empty')
+    if [ -z "$FILTER_ID" ]; then
+        echo "[Custom entrypoint] ERROR: Image Resizer Filter install failed" >&2
+        echo "${CREATE_RESPONSE}" >&2
+        exit 1
+    fi
+
+    echo "[Custom entrypoint] Image Resizer Filter created with id: ${FILTER_ID}"
+
+    echo ""
+    echo "[Custom entrypoint] Enabling Image Resizer Filter..."
+    curl -fsS -X POST "http://localhost:8080/api/v1/functions/id/${FILTER_ID}/toggle" \
+      -H "Authorization: Bearer ${API_KEY}" \
+      -H "Content-Type: application/json"
+
+    echo ""
+    echo "[Custom entrypoint] Enabling Image Resizer Filter globally..."
     curl -fsS -X POST "http://localhost:8080/api/v1/functions/id/${FILTER_ID}/toggle/global" \
       -H "Authorization: Bearer ${API_KEY}" \
       -H "Content-Type: application/json"


### PR DESCRIPTION
## Summary
- Fixes the three issues identified in [SK-18](https://wikiteq.atlassian.net/browse/SK-18) in the OpenWebUI Image Resizer filter: no error handling on corrupt images, `image/jpg` mime not accepted, and wasted CPU reprocessing already-resized images on every turn.
- Wires the filter in as conditionally installable via `FUNCTION_IMAGE_RESIZER_ENABLED`, following the same pattern as `install_video_inject_filter` in `helpers/entrypoint.sh`.
- `max_dimension` is exposed as an editable Valve (default 768px), not an env var — the ticket's literal `FUNCTION_IMAGE_RESIZER_MAX_DIM` env var was superseded in favor of a Valve per discussion on the ticket.

## Changes
- `functions/image_resizer.py` (new) — the filter itself:
  - Per-image processing wrapped in `try/except`, so a corrupt/malformed image is skipped with a warning instead of failing the whole chat request.
  - Uses Pillow's own detected `image.format` instead of trusting the mime type string, which fixes `image/jpg` (and generalizes to other mime/format mismatches).
  - RGBA→JPEG save crash fixed by flattening to RGB before save.
  - `_resized` marker avoids re-decoding/re-encoding images already processed.
- `functions/image_resizer.json` (new) — OpenWebUI function manifest.
- `helpers/entrypoint.sh` — new `install_image_resizer_filter()`, gated on `FUNCTION_IMAGE_RESIZER_ENABLED`, called from `do_first_start`.
- `compose.yaml` — mounts the new filter files into the openwebui container.
- `.env.openwebui.example` — documents `FUNCTION_IMAGE_RESIZER_ENABLED`.

[SK-18]: https://wikiteq.atlassian.net/browse/SK-18?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ