### PR TITLE
MAIT-306: Add installable Tavily web search tool

### DIFF
--- a/.env.openwebui.example
+++ b/.env.openwebui.example
@@ -69,9 +69,11 @@ ROAT_API_KEY=12345
 #MEDIAWIKI_PASSWORD=
 
 # Web Search Tool (optional): set TOOL_WEB_SEARCH_ENABLED=True to auto-install the
-# Tavily-powered web search Tool on first boot. After install, set the tavily_api_key
-# valve from Workspace -> Tools in the UI.
+# Tavily-powered web search Tool on first boot. Set TOOL_WEB_SEARCH_API_KEY to have
+# it auto-configure the tavily_api_key valve, or leave unset and set the valve
+# later from Workspace -> Tools in the UI.
 #TOOL_WEB_SEARCH_ENABLED=True
+#TOOL_WEB_SEARCH_API_KEY=
 
 # Video Inject Filter (optional): set FUNCTION_VIDEO_INJECT_ENABLED=True to auto-install the
 # inline video player filter on first boot. Requires video_url metadata in retrieved sources.

--- a/.env.openwebui.example
+++ b/.env.openwebui.example
@@ -68,6 +68,11 @@ ROAT_API_KEY=12345
 #MEDIAWIKI_USERNAME=
 #MEDIAWIKI_PASSWORD=
 
+# Web Search Tool (optional): set TOOL_WEB_SEARCH_ENABLED=True to auto-install the
+# Tavily-powered web search Tool on first boot. After install, set the tavily_api_key
+# valve from Workspace -> Tools in the UI.
+#TOOL_WEB_SEARCH_ENABLED=True
+
 # Video Inject Filter (optional): set FUNCTION_VIDEO_INJECT_ENABLED=True to auto-install the
 # inline video player filter on first boot. Requires video_url metadata in retrieved sources.
 #FUNCTION_VIDEO_INJECT_ENABLED=True

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ Two components handle RAG service communication:
 
 - **Filter function** (`functions/function.py`) — intercepts every user message and injects ROAT context automatically. Enabled globally via Admin Panel → Functions.
 - **Knowledge Base Search tool** (`tools/roat_retrieval.py`) — a Workspace Tool that lets the LLM decide when to query ROAT. Requires a model with native function calling support. Both are automatically provisioned on first boot.
-- **Web Search Tool** (`tools/web_search.py`) — an optional Workspace Tool that lets the LLM search the web via the Tavily API. Enable with `TOOL_WEB_SEARCH_ENABLED=True` in `.env`, then set the `tavily_api_key` valve from Workspace → Tools.
+- **Web Search Tool** (`tools/web_search.py`) — an optional Workspace Tool that lets the LLM search the web via the Tavily API. Enable with `TOOL_WEB_SEARCH_ENABLED=True` in `.env`, then either set `TOOL_WEB_SEARCH_API_KEY` to auto-configure the key on install, or set the `tavily_api_key` valve manually from Workspace → Tools.
 
 ## Connectors configuration
 

--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ Two components handle RAG service communication:
 
 - **Filter function** (`functions/function.py`) — intercepts every user message and injects ROAT context automatically. Enabled globally via Admin Panel → Functions.
 - **Knowledge Base Search tool** (`tools/roat_retrieval.py`) — a Workspace Tool that lets the LLM decide when to query ROAT. Requires a model with native function calling support. Both are automatically provisioned on first boot.
+- **Web Search Tool** (`tools/web_search.py`) — an optional Workspace Tool that lets the LLM search the web via the Tavily API. Enable with `TOOL_WEB_SEARCH_ENABLED=True` in `.env`, then set the `tavily_api_key` valve from Workspace → Tools.
 
 ## Connectors configuration
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -20,6 +20,8 @@ services:
       - ./tools/roat_retrieval.json:/etc/roat_retrieval.json
       - ./tools/mediawiki_tool.py:/etc/mediawiki_tool.py
       - ./tools/mediawiki_tool.json:/etc/mediawiki_tool.json
+      - ./tools/web_search.py:/etc/web_search.py
+      - ./tools/web_search.json:/etc/web_search.json
       - ./functions/video_inject.py:/etc/video_inject.py
       - ./functions/video_inject.json:/etc/video_inject.json
       - ./models/wikiteqcenturion.json:/etc/wikiteqcenturion.json:ro

--- a/helpers/entrypoint.sh
+++ b/helpers/entrypoint.sh
@@ -323,7 +323,19 @@ install_web_search_tool() {
     fi
 
     echo "[Custom entrypoint] Web Search Tool created with id: ${TOOL_ID}"
-    echo "[Custom entrypoint] Set the tavily_api_key valve from Workspace -> Tools in the UI."
+
+    if [ -n "$TOOL_WEB_SEARCH_API_KEY" ]; then
+        echo ""
+        echo "[Custom entrypoint] Configuring Web Search Tool valves..."
+        VALVES_JSON=$(jq -n --arg key "${TOOL_WEB_SEARCH_API_KEY}" '{tavily_api_key:$key}')
+
+        curl -s -X POST "http://localhost:8080/api/v1/tools/id/${TOOL_ID}/valves/update" \
+          -H "Authorization: Bearer ${API_KEY}" \
+          -H "Content-Type: application/json" \
+          --data-raw "${VALVES_JSON}"
+    else
+        echo "[Custom entrypoint] TOOL_WEB_SEARCH_API_KEY not set. Set the tavily_api_key valve from Workspace -> Tools in the UI."
+    fi
 
 }
 

--- a/helpers/entrypoint.sh
+++ b/helpers/entrypoint.sh
@@ -248,6 +248,7 @@ do_first_start() {
       --data-raw "{\"suggestions\":[]}"
 
     install_mediawiki_tool
+    install_web_search_tool
     install_video_inject_filter
 
     touch /app/backend/data/.first_start
@@ -295,6 +296,34 @@ install_mediawiki_tool() {
       -H "Authorization: Bearer ${API_KEY}" \
       -H "Content-Type: application/json" \
       --data-raw "${VALVES_JSON}"
+
+}
+
+install_web_search_tool() {
+    if [ "$TOOL_WEB_SEARCH_ENABLED" != "True" ]; then
+        return
+    fi
+
+    echo ""
+    echo "[Custom entrypoint] Installing Web Search Tool..."
+
+    TOOL_CODE=$(jq -Rs . < "/etc/web_search.py")
+    DATA_RAW=$(jq --argjson content "${TOOL_CODE}" '.content=$content' /etc/web_search.json)
+
+    CREATE_RESPONSE=$(curl -s -X POST "http://localhost:8080/api/v1/tools/create" \
+      -H "Authorization: Bearer ${API_KEY}" \
+      -H "Content-Type: application/json" \
+      --data-raw "${DATA_RAW}")
+
+    TOOL_ID=$(echo "${CREATE_RESPONSE}" | jq -r '.id // empty')
+    if [ -z "$TOOL_ID" ]; then
+        echo "[Custom entrypoint] WARNING: Web Search Tool install failed"
+        echo "${CREATE_RESPONSE}"
+        return
+    fi
+
+    echo "[Custom entrypoint] Web Search Tool created with id: ${TOOL_ID}"
+    echo "[Custom entrypoint] Set the tavily_api_key valve from Workspace -> Tools in the UI."
 
 }
 
@@ -347,6 +376,7 @@ pip install hf_xet
 # with multi-worker deployments and unreliable across container restarts.
 pip install "mwclient>=0.10.1"
 pip install "pyyaml>=6.0"
+pip install "tavily-python>=0.5.0"
 
 start_app
 wait_for_app

--- a/tools/web_search.json
+++ b/tools/web_search.json
@@ -1,0 +1,9 @@
+{
+	"id": "web_search",
+	"name": "Web Search",
+	"content": "",
+	"meta": {
+		"description": "Search the web using the Tavily search API",
+		"manifest": {}
+	}
+}

--- a/tools/web_search.py
+++ b/tools/web_search.py
@@ -1,0 +1,239 @@
+"""
+title: Web Search Tool
+author: WikiTeq
+date: 2025-07-09
+version: 1.0
+license: MIT
+description: Web search tool for OpenWebUI using the Tavily search API. Lets the AI search the web for up-to-date information when the user asks to look something up online.
+requirements: tavily-python>=0.5.0, pydantic>=2.0.0
+"""
+
+import logging
+from collections.abc import Awaitable, Callable
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+log = logging.getLogger(__name__)
+
+# Hard caps enforced by the Tavily API
+MAX_RESULTS_LIMIT = 100
+MAX_TIMEOUT_SECONDS = 120
+DEFAULT_CONTENT_CAP = 4000
+
+
+class Tools:
+    """OpenWebUI tool exposing Tavily web search to chat models."""
+
+    class Valves(BaseModel):
+        tavily_api_key: str = Field(
+            default="",
+            description="Tavily API key (starts with 'tvly-'). Get one at https://tavily.com.",
+        )
+        max_results: int = Field(
+            default=5,
+            ge=1,
+            le=MAX_RESULTS_LIMIT,
+            description=(
+                f"Maximum number of search results per query (1–{MAX_RESULTS_LIMIT}). "
+                "Higher values are slower."
+            ),
+        )
+        search_depth: Literal["basic", "advanced"] = Field(
+            default="basic",
+            description=(
+                "Search depth. 'basic' is fast and cheap; 'advanced' is more thorough "
+                "and returns richer content."
+            ),
+        )
+        include_answer: bool = Field(
+            default=True,
+            description="Include Tavily's synthesized answer to the query in the output.",
+        )
+        topic: Literal["general", "news", "finance"] = Field(
+            default="general",
+            description="Search content category. 'news' for recent headlines, 'finance' for market data.",
+        )
+        timeout: int = Field(
+            default=30,
+            ge=1,
+            le=MAX_TIMEOUT_SECONDS,
+            description="HTTP request timeout in seconds (capped at 120 by Tavily).",
+        )
+        max_content_chars: int = Field(
+            default=DEFAULT_CONTENT_CAP,
+            ge=100,
+            le=50_000,
+            description="Maximum characters of content to include per result. Longer snippets are truncated.",
+        )
+
+    def __init__(self):
+        self.valves = self.Valves()
+
+    async def web_search(
+        self,
+        query: str,
+        __event_emitter__: Callable[[dict], Awaitable[None]] | None = None,
+    ) -> str:
+        """
+        Search the web for up-to-date information using the Tavily search API.
+
+        Use this tool when the user asks to:
+        - "search the web for ..." / "look up ... online"
+        - "what's the latest on ..." / "find recent news about ..."
+        - "google ..." / "search for ..."
+
+        Returns a formatted block with each result's title, URL, and content
+        snippet, plus (optionally) a synthesized answer to the query.
+
+        Args:
+            query: The search query string.
+
+        Returns:
+            Formatted search results string, or an error message.
+        """
+        # Lazy import: OpenWebUI loads this file before installing requirements,
+        # so tavily is only available at call time.
+        from tavily import AsyncTavilyClient
+        from tavily.errors import (
+            BadRequestError,
+            InvalidAPIKeyError,
+            UsageLimitExceededError,
+        )
+
+        async def emit(message: str, done: bool = False, hidden: bool = True) -> None:
+            if __event_emitter__:
+                await __event_emitter__(
+                    {
+                        "type": "status",
+                        "data": {
+                            "description": message,
+                            "done": done,
+                            "hidden": hidden,
+                        },
+                    }
+                )
+
+        # --- Validate configuration ---
+        if not self.valves.tavily_api_key.strip():
+            await emit(
+                "Error: Tavily API key is not configured in Tool Valves.",
+                done=True,
+                hidden=False,
+            )
+            return "Error: tavily_api_key is not configured."
+
+        query = (query or "").strip()
+        if not query:
+            await emit("Error: search query cannot be empty.", done=True, hidden=False)
+            return "Error: search query cannot be empty."
+
+        await emit(f"Searching the web for '{query}'...")
+
+        client = AsyncTavilyClient(api_key=self.valves.tavily_api_key.strip())
+
+        try:
+            response = await client.search(
+                query=query,
+                topic=self.valves.topic,
+                search_depth=self.valves.search_depth,
+                max_results=self.valves.max_results,
+                include_answer=self.valves.include_answer,
+                timeout=float(self.valves.timeout),
+            )
+        except InvalidAPIKeyError:
+            await emit(
+                "Error: Tavily API key is invalid.",
+                done=True,
+                hidden=False,
+            )
+            return "Error: Tavily API key is invalid. Check the tavily_api_key in Tool Valves."
+        except UsageLimitExceededError:
+            await emit(
+                "Error: Tavily usage limit exceeded.",
+                done=True,
+                hidden=False,
+            )
+            return "Error: Tavily usage limit exceeded (rate limit or quota). Try again later."
+        except BadRequestError as e:
+            log.error("Tavily bad request: %s", e)
+            await emit(
+                f"Error: invalid search parameters ({e}).",
+                done=True,
+                hidden=False,
+            )
+            return f"Error: Tavily rejected the request ({e}). Check the query and valves."
+        except TimeoutError:
+            await emit(
+                f"Error: search timed out after {self.valves.timeout}s.",
+                done=True,
+                hidden=False,
+            )
+            return f"Error: Tavily search timed out after {self.valves.timeout} seconds."
+        except Exception:
+            log.error("Unexpected error during Tavily search", exc_info=True)
+            await emit(
+                "Error: unexpected error during web search.",
+                done=True,
+                hidden=False,
+            )
+            return "Error: unexpected error during web search. Check the server logs for details."
+        finally:
+            # Always release the underlying HTTP connection pool.
+            # AsyncTavilyClient exposes close() (not aclose()); the bare except
+            # previously swallowed an AttributeError here, leaking connections.
+            try:
+                await client.close()
+            except Exception:
+                log.debug("Ignoring error closing Tavily client", exc_info=True)
+
+        results = response.get("results", []) or []
+        if not results:
+            await emit("No results found.", done=True, hidden=False)
+            return f"No web results found for '{query}'."
+
+        cap = self.valves.max_content_chars
+        sections = []
+        for i, item in enumerate(results, start=1):
+            title = item.get("title", "(untitled)") or "(untitled)"
+            url = item.get("url", "") or ""
+            content = item.get("content", "") or ""
+
+            # Emit a source/citation event so OpenWebUI renders the page
+            # as a clickable reference under the response. Short name
+            # "source" is required for DB persistence (not "citation").
+            if url and __event_emitter__:
+                # Document passage: use the (possibly pre-truncation) snippet,
+                # capped so the citation stays readable in the UI.
+                doc_passage = content if len(content) <= cap else content[:cap]
+                try:
+                    await __event_emitter__(
+                        {
+                            "type": "source",
+                            "data": {
+                                "source": {"name": title, "id": url},
+                                "document": [doc_passage],
+                                "metadata": [
+                                    {"source": url, "name": title, "url": url}
+                                ],
+                            },
+                        }
+                    )
+                except Exception:
+                    log.debug("Failed to emit source event", exc_info=True)
+
+            if len(content) > cap:
+                content = content[:cap] + f"\n...(truncated {len(content) - cap} chars)"
+            block = f"=== Result {i}: {title} ===\nURL: {url}\n\n{content}"
+            sections.append(block)
+
+        parts = [f"Search results for '{query}' ({len(results)} result(s)):\n"]
+
+        answer = response.get("answer")
+        if self.valves.include_answer and answer:
+            parts.append(f"Answer: {answer}\n")
+
+        parts.append("\n---\n\n".join(sections))
+
+        await emit(f"Found {len(results)} result(s) for '{query}'.", done=True)
+        return "\n".join(parts)

--- a/tools/web_search.py
+++ b/tools/web_search.py
@@ -17,7 +17,7 @@ from pydantic import BaseModel, Field
 log = logging.getLogger(__name__)
 
 # Hard caps enforced by the Tavily API
-MAX_RESULTS_LIMIT = 100
+MAX_RESULTS_LIMIT = 20
 MAX_TIMEOUT_SECONDS = 120
 DEFAULT_CONTENT_CAP = 4000
 
@@ -100,6 +100,7 @@ class Tools:
             InvalidAPIKeyError,
             UsageLimitExceededError,
         )
+        from tavily.errors import TimeoutError as TavilyTimeoutError
 
         async def emit(message: str, done: bool = False, hidden: bool = True) -> None:
             if __event_emitter__:
@@ -163,7 +164,7 @@ class Tools:
                 hidden=False,
             )
             return f"Error: Tavily rejected the request ({e}). Check the query and valves."
-        except TimeoutError:
+        except TavilyTimeoutError:
             await emit(
                 f"Error: search timed out after {self.valves.timeout}s.",
                 done=True,


### PR DESCRIPTION
## Summary
- Formalizes the ad-hoc Tavily search tool into an optional, installable OpenWebUI Workspace Tool, following the existing MediaWiki Tool pattern.
- Adds the missing `tavily-python` dependency, which was the actual blocker per the ticket's latest comment.
- Gated by `TOOL_WEB_SEARCH_ENABLED`; the Tavily API key is set via the tool's `tavily_api_key` valve in the UI (not an env var).

[MAIT-306]


[MAIT-306]: https://wikiteq.atlassian.net/browse/MAIT-306?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ