### PR TITLE
MAIT-331: Add get_sources tool and wire ROAT/MediaWiki source-state tracking

### DIFF
--- a/.env.openwebui.example
+++ b/.env.openwebui.example
@@ -82,6 +82,12 @@ ROAT_API_KEY=12345
 # inline video player filter on first boot. Requires video_url metadata in retrieved sources.
 #FUNCTION_VIDEO_INJECT_ENABLED=True
 
+# Get Sources Tool (optional): set TOOL_GET_SOURCES_ENABLED=True to auto-install the
+# Get Current Sources tool on first boot. Lets the model retrieve sources emitted
+# by other tools (roat_retrieval, mediawiki) during the current chat turn, for
+# more reliable inline citations.
+#TOOL_GET_SOURCES_ENABLED=True
+
 # ── SSO / OAuth2 ──────────────────────────────────────────────────────────────
 # Single Sign-On is configured via environment variables and is disabled by default.
 # Uncomment and fill in the vars for your chosen provider.

--- a/compose.yaml
+++ b/compose.yaml
@@ -22,6 +22,8 @@ services:
       - ./tools/mediawiki_tool.json:/etc/mediawiki_tool.json
       - ./tools/web_search.py:/etc/web_search.py
       - ./tools/web_search.json:/etc/web_search.json
+      - ./tools/get_sources.py:/etc/get_sources.py
+      - ./tools/get_sources.json:/etc/get_sources.json
       - ./functions/video_inject.py:/etc/video_inject.py
       - ./functions/video_inject.json:/etc/video_inject.json
       - ./models:/etc/owui-models:ro

--- a/helpers/entrypoint.sh
+++ b/helpers/entrypoint.sh
@@ -367,10 +367,16 @@ install_get_sources_tool() {
     TOOL_CODE=$(jq -Rs . < "/etc/get_sources.py")
     DATA_RAW=$(jq --argjson content "${TOOL_CODE}" '.content=$content' /etc/get_sources.json)
 
-    CREATE_RESPONSE=$(curl -s -X POST "http://localhost:8080/api/v1/tools/create" \
+    CREATE_RESPONSE=$(curl -s --connect-timeout 10 --max-time 30 -X POST "http://localhost:8080/api/v1/tools/create" \
       -H "Authorization: Bearer ${API_KEY}" \
       -H "Content-Type: application/json" \
       --data-raw "${DATA_RAW}")
+    CURL_STATUS=$?
+
+    if [ "$CURL_STATUS" -ne 0 ]; then
+        echo "[Custom entrypoint] ERROR: Get Sources Tool install request failed (curl exit code ${CURL_STATUS}); not marking first_start so this retries on next boot." >&2
+        exit 1
+    fi
 
     TOOL_ID=$(echo "${CREATE_RESPONSE}" | jq -r '.id // empty')
     if [ -z "$TOOL_ID" ]; then

--- a/helpers/entrypoint.sh
+++ b/helpers/entrypoint.sh
@@ -374,15 +374,15 @@ install_get_sources_tool() {
     CURL_STATUS=$?
 
     if [ "$CURL_STATUS" -ne 0 ]; then
-        echo "[Custom entrypoint] ERROR: Get Sources Tool install request failed (curl exit code ${CURL_STATUS}); not marking first_start so this retries on next boot." >&2
-        exit 1
+        echo "[Custom entrypoint] WARNING: Get Sources Tool install request failed (curl exit code ${CURL_STATUS})" >&2
+        return
     fi
 
     TOOL_ID=$(echo "${CREATE_RESPONSE}" | jq -r '.id // empty')
     if [ -z "$TOOL_ID" ]; then
-        echo "[Custom entrypoint] ERROR: Get Sources Tool install failed; not marking first_start so this retries on next boot." >&2
+        echo "[Custom entrypoint] WARNING: Get Sources Tool install failed" >&2
         echo "${CREATE_RESPONSE}" >&2
-        exit 1
+        return
     fi
 
     echo "[Custom entrypoint] Get Sources Tool created with id: ${TOOL_ID}"
@@ -406,9 +406,9 @@ install_video_inject_filter() {
 
     FILTER_ID=$(echo "${CREATE_RESPONSE}" | jq -r '.id // empty')
     if [ -z "$FILTER_ID" ]; then
-        echo "[Custom entrypoint] ERROR: Video Inject Filter install failed" >&2
+        echo "[Custom entrypoint] WARNING: Video Inject Filter install failed" >&2
         echo "${CREATE_RESPONSE}" >&2
-        exit 1
+        return
     fi
 
     echo "[Custom entrypoint] Video Inject Filter created with id: ${FILTER_ID}"

--- a/helpers/entrypoint.sh
+++ b/helpers/entrypoint.sh
@@ -367,11 +367,11 @@ install_get_sources_tool() {
     TOOL_CODE=$(jq -Rs . < "/etc/get_sources.py")
     DATA_RAW=$(jq --argjson content "${TOOL_CODE}" '.content=$content' /etc/get_sources.json)
 
+    CURL_STATUS=0
     CREATE_RESPONSE=$(curl -s --connect-timeout 10 --max-time 30 -X POST "http://localhost:8080/api/v1/tools/create" \
       -H "Authorization: Bearer ${API_KEY}" \
       -H "Content-Type: application/json" \
-      --data-raw "${DATA_RAW}")
-    CURL_STATUS=$?
+      --data-raw "${DATA_RAW}") || CURL_STATUS=$?
 
     if [ "$CURL_STATUS" -ne 0 ]; then
         echo "[Custom entrypoint] WARNING: Get Sources Tool install request failed (curl exit code ${CURL_STATUS})" >&2

--- a/helpers/entrypoint.sh
+++ b/helpers/entrypoint.sh
@@ -265,6 +265,7 @@ do_first_start() {
 
     install_mediawiki_tool
     install_web_search_tool
+    install_get_sources_tool
     install_video_inject_filter
 
     touch /app/backend/data/.first_start
@@ -353,6 +354,32 @@ install_web_search_tool() {
         echo "[Custom entrypoint] TOOL_WEB_SEARCH_API_KEY not set. Set the tavily_api_key valve from Workspace -> Tools in the UI."
     fi
 
+}
+
+install_get_sources_tool() {
+    if [ "$TOOL_GET_SOURCES_ENABLED" != "True" ]; then
+        return 0
+    fi
+
+    echo ""
+    echo "[Custom entrypoint] Installing Get Sources Tool..."
+
+    TOOL_CODE=$(jq -Rs . < "/etc/get_sources.py")
+    DATA_RAW=$(jq --argjson content "${TOOL_CODE}" '.content=$content' /etc/get_sources.json)
+
+    CREATE_RESPONSE=$(curl -s -X POST "http://localhost:8080/api/v1/tools/create" \
+      -H "Authorization: Bearer ${API_KEY}" \
+      -H "Content-Type: application/json" \
+      --data-raw "${DATA_RAW}")
+
+    TOOL_ID=$(echo "${CREATE_RESPONSE}" | jq -r '.id // empty')
+    if [ -z "$TOOL_ID" ]; then
+        echo "[Custom entrypoint] ERROR: Get Sources Tool install failed; not marking first_start so this retries on next boot." >&2
+        echo "${CREATE_RESPONSE}" >&2
+        exit 1
+    fi
+
+    echo "[Custom entrypoint] Get Sources Tool created with id: ${TOOL_ID}"
 }
 
 install_video_inject_filter() {

--- a/tools/get_sources.json
+++ b/tools/get_sources.json
@@ -1,0 +1,9 @@
+{
+	"id": "get_sources",
+	"name": "Get Current Sources",
+	"content": "",
+	"meta": {
+		"description": "Retrieve all sources/citations emitted by tools during the current chat turn.",
+		"manifest": {}
+	}
+}

--- a/tools/get_sources.py
+++ b/tools/get_sources.py
@@ -153,7 +153,7 @@ class Tools:
 
 def _normalize_source(source) -> dict | None:
     """Validate a raw entry from _wikiteq_sources against the shared source
-    schema, returning it unchanged (shallow-copied) or None if malformed.
+    schema, returning it unchanged or None if malformed.
 
     Every source-emitting tool (web_search, roat_retrieval, mediawiki_tool)
     is expected to produce the same shape: {"source": {"name", "id", "url"?},
@@ -182,7 +182,7 @@ def _normalize_source(source) -> dict | None:
     if not isinstance(documents, list) or not documents or not isinstance(documents[0], str):
         return None
 
-    return dict(source)  # shallow copy; don't mutate the shared turn list
+    return source
 
 
 def _extract_url(source: dict) -> str:

--- a/tools/get_sources.py
+++ b/tools/get_sources.py
@@ -8,6 +8,7 @@ description: Retrieves sources/citations emitted by tools in the current chat tu
 requirements: pydantic>=2.0.0
 """
 
+import hashlib
 import logging
 
 from pydantic import BaseModel, Field
@@ -151,16 +152,15 @@ class Tools:
 
 
 def _normalize_source(source) -> dict | None:
-    """Coerce a raw entry from _wikiteq_sources into a safe-to-use shape.
+    """Validate a raw entry from _wikiteq_sources against the shared source
+    schema, returning it unchanged (shallow-copied) or None if malformed.
 
-    Source dicts come from other tools' emitted data (ultimately from
-    external APIs like ROAT/MediaWiki) and are not guaranteed to match the
-    expected shape. Without this, a malformed entry (source.source not a
-    dict, document[0] not a string) would raise and abort processing of
-    every other, valid source in the same turn. Returns None for entries
-    that can't be salvaged — this includes entries missing the inner
-    "source" dict entirely, since a source item with no source metadata
-    (no name/id/url) is too malformed to be worth surfacing.
+    Every source-emitting tool (web_search, roat_retrieval, mediawiki_tool)
+    is expected to produce the same shape: {"source": {"name", "id", "url"?},
+    "document": [str, ...], "metadata": [...]}. A malformed entry (source.source
+    not a dict, document not a non-empty list of strings) would otherwise raise
+    downstream and abort processing of every other, valid source in the same
+    turn — so it's rejected here instead of being coerced or partially salvaged.
     """
     if not isinstance(source, dict):
         return None
@@ -169,39 +169,52 @@ def _normalize_source(source) -> dict | None:
     if not isinstance(inner, dict):
         return None
 
-    source = dict(source)  # shallow copy; don't mutate the shared turn list
-    source["source"] = inner
+    # name feeds the dedup key directly (see get_sources()); a non-string,
+    # truthy name (e.g. a stray dict/list) would make that key unhashable
+    # and crash the whole turn's dedup pass, not just this one malformed
+    # entry. A missing/empty name is fine — it falls back to "(unnamed)".
+    for name_source in (inner, source):
+        name = name_source.get("name")
+        if name and not isinstance(name, str):
+            return None
 
-    documents = source.get("document", [])
-    if not isinstance(documents, list):
-        documents = [documents] if documents else []
-    documents = [d for d in documents if isinstance(d, str)]
-    source["document"] = documents
+    documents = source.get("document")
+    if not isinstance(documents, list) or not documents or not isinstance(documents[0], str):
+        return None
 
-    return source
+    return dict(source)  # shallow copy; don't mutate the shared turn list
 
 
 def _extract_url(source: dict) -> str:
     """Best-effort URL extraction from a source dict.
 
-    Only trusts fields that are actually URLs in every known emitter shape
-    (roat_retrieval, mediawiki_tool, web_search). metadata[0]["source"] is
-    deliberately excluded: in roat_retrieval it holds the document title,
-    not a URL, so treating it as one would mislabel a title as a link.
+    Tries real URL fields first — top-level "url", then source.url — before
+    falling back to source.id, since source.id is not trustworthy as a URL
+    for every emitter: web_search.py populates it with a real URL, but
+    roat_retrieval.py/mediawiki_tool.py populate it with a to_source_id()
+    slug (e.g. "some-kb-doc"), which is not a URL. Only accept source.id
+    when it actually looks like one, and only once url/source.url are absent.
 
-    source.id is also NOT trusted unconditionally: web_search.py populates
-    it with a real URL, but roat_retrieval.py/mediawiki_tool.py populate it
-    with a to_source_id() slug (e.g. "some-kb-doc"), which is not a URL.
-    Only accept it when it actually looks like one.
+    metadata[0]["source"] is deliberately excluded: in roat_retrieval it
+    holds the document title, not a URL, so treating it as one would
+    mislabel a title as a link.
 
     Assumes source has already passed through _normalize_source (source.source
     is a dict); top-level "url" is not normalized, so it's coerced here.
     """
+    url = source.get("url")
+    if isinstance(url, str) and url:
+        return url
+
+    url = source.get("source", {}).get("url")
+    if isinstance(url, str) and url:
+        return url
+
     source_id = source.get("source", {}).get("id", "")
     if isinstance(source_id, str) and source_id.startswith(("http://", "https://")):
         return source_id
-    url = source.get("url", "") or source.get("source", {}).get("url", "")
-    return url if isinstance(url, str) else ""
+
+    return ""
 
 
 def _content_fingerprint(source: dict) -> str:
@@ -209,10 +222,13 @@ def _content_fingerprint(source: dict) -> str:
 
     Without this, two distinct chunks of the same document (e.g. two
     non-adjacent ROAT KB passages with the same title, no url extra) would
-    dedup-collide on (name, "") and silently drop one from the output. Uses
-    the full document text (not a truncated prefix) so two sources that
-    happen to share a common prefix but diverge later still get distinct
-    keys. Assumes source has already passed through _normalize_source.
+    dedup-collide on (name, "") and silently drop one from the output.
+    Hashes the full document text (not a truncated prefix, and not the raw
+    text itself as the dict key) so two sources that happen to share a
+    common prefix but diverge later still get distinct keys. Assumes source
+    has already passed through _normalize_source.
     """
     documents = source.get("document", [])
-    return documents[0] if documents else ""
+    if not documents:
+        return ""
+    return hashlib.sha256(documents[0].encode("utf-8")).hexdigest()

--- a/tools/get_sources.py
+++ b/tools/get_sources.py
@@ -87,7 +87,8 @@ class Tools:
         all_sources = []
         seen = set()
         for source in current_sources:
-            if not isinstance(source, dict):
+            source = _normalize_source(source)
+            if source is None:
                 continue
             name = source.get("source", {}).get("name", "") or source.get("name", "")
             url = _extract_url(source)
@@ -105,23 +106,30 @@ class Tools:
         if len(all_sources) > self.valves.max_sources:
             all_sources = all_sources[-self.valves.max_sources:]
 
-        # Format output
+        # Format output. Sources were already normalized above (source.source
+        # is a dict, document[0]/url are strings if present), so no further
+        # isinstance guarding is needed here.
         sections = []
         for i, source in enumerate(all_sources, start=1):
             name = (
                 source.get("source", {}).get("name", "")
                 or source.get("name", "(unnamed)")
             )
+            source_id = source.get("source", {}).get("id", "")
             url = _extract_url(source)
             documents = source.get("document", [])
-            if not isinstance(documents, list):
-                documents = [documents] if documents else []
 
             lines = [f"=== Source {i}: {name} ==="]
+            # source_id may be a real URL (web_search.py) or a to_source_id()
+            # slug (roat_retrieval.py/mediawiki_tool.py) — either way it's
+            # useful for citation formatting, so surface it distinctly from
+            # the URL line below rather than silently dropping it.
+            if source_id and source_id != url:
+                lines.append(f"Source id: {source_id}")
             if url:
                 lines.append(f"URL: {url}")
             if documents:
-                doc_text = documents[0] if documents else ""
+                doc_text = documents[0]
                 if len(doc_text) > 500:
                     doc_text = doc_text[:500] + "..."
                 lines.append(f"Excerpt: {doc_text}")
@@ -132,6 +140,35 @@ class Tools:
             f"Sources from current turn ({len(all_sources)} total):\n\n"
             + "\n---\n\n".join(sections)
         )
+
+
+def _normalize_source(source) -> dict | None:
+    """Coerce a raw entry from _wikiteq_sources into a safe-to-use shape.
+
+    Source dicts come from other tools' emitted data (ultimately from
+    external APIs like ROAT/MediaWiki) and are not guaranteed to match the
+    expected shape. Without this, a malformed entry (source.source not a
+    dict, document[0] not a string) would raise and abort processing of
+    every other, valid source in the same turn. Returns None for entries
+    that can't be salvaged.
+    """
+    if not isinstance(source, dict):
+        return None
+
+    source = dict(source)  # shallow copy; don't mutate the shared turn list
+
+    inner = source.get("source")
+    if not isinstance(inner, dict):
+        inner = {}
+    source["source"] = inner
+
+    documents = source.get("document", [])
+    if not isinstance(documents, list):
+        documents = [documents] if documents else []
+    documents = [d for d in documents if isinstance(d, str)]
+    source["document"] = documents
+
+    return source
 
 
 def _extract_url(source: dict) -> str:
@@ -146,11 +183,15 @@ def _extract_url(source: dict) -> str:
     it with a real URL, but roat_retrieval.py/mediawiki_tool.py populate it
     with a to_source_id() slug (e.g. "some-kb-doc"), which is not a URL.
     Only accept it when it actually looks like one.
+
+    Assumes source has already passed through _normalize_source (source.source
+    is a dict); top-level "url" is not normalized, so it's coerced here.
     """
     source_id = source.get("source", {}).get("id", "")
     if isinstance(source_id, str) and source_id.startswith(("http://", "https://")):
         return source_id
-    return source.get("url", "") or source.get("source", {}).get("url", "")
+    url = source.get("url", "") or source.get("source", {}).get("url", "")
+    return url if isinstance(url, str) else ""
 
 
 def _content_fingerprint(source: dict) -> str:
@@ -158,10 +199,10 @@ def _content_fingerprint(source: dict) -> str:
 
     Without this, two distinct chunks of the same document (e.g. two
     non-adjacent ROAT KB passages with the same title, no url extra) would
-    dedup-collide on (name, "") and silently drop one from the output.
+    dedup-collide on (name, "") and silently drop one from the output. Uses
+    the full document text (not a truncated prefix) so two sources that
+    happen to share a common prefix but diverge later still get distinct
+    keys. Assumes source has already passed through _normalize_source.
     """
     documents = source.get("document", [])
-    if not isinstance(documents, list):
-        documents = [documents] if documents else []
-    text = documents[0] if documents else ""
-    return text[:200] if isinstance(text, str) else ""
+    return documents[0] if documents else ""

--- a/tools/get_sources.py
+++ b/tools/get_sources.py
@@ -25,6 +25,12 @@ class Tools:
             le=500,
             description="Maximum number of sources to return (1-500).",
         )
+        max_excerpt_chars: int = Field(
+            default=200,
+            ge=1,
+            le=500,
+            description="Maximum characters of each source's excerpt to include (1-500).",
+        )
 
     def __init__(self):
         self.valves = self.Valves()
@@ -122,16 +128,18 @@ class Tools:
             lines = [f"=== Source {i}: {name} ==="]
             # source_id may be a real URL (web_search.py) or a to_source_id()
             # slug (roat_retrieval.py/mediawiki_tool.py) — either way it's
-            # useful for citation formatting, so surface it distinctly from
-            # the URL line below rather than silently dropping it.
-            if source_id and source_id != url:
+            # useful for citation formatting, so always surface it distinctly
+            # from the URL line below rather than dropping it when the two
+            # happen to match.
+            if source_id:
                 lines.append(f"Source id: {source_id}")
             if url:
                 lines.append(f"URL: {url}")
             if documents:
                 doc_text = documents[0]
-                if len(doc_text) > 500:
-                    doc_text = doc_text[:500] + "..."
+                cap = self.valves.max_excerpt_chars
+                if len(doc_text) > cap:
+                    doc_text = doc_text[:cap] + "..."
                 lines.append(f"Excerpt: {doc_text}")
             sections.append("\n".join(lines))
 
@@ -150,16 +158,18 @@ def _normalize_source(source) -> dict | None:
     expected shape. Without this, a malformed entry (source.source not a
     dict, document[0] not a string) would raise and abort processing of
     every other, valid source in the same turn. Returns None for entries
-    that can't be salvaged.
+    that can't be salvaged — this includes entries missing the inner
+    "source" dict entirely, since a source item with no source metadata
+    (no name/id/url) is too malformed to be worth surfacing.
     """
     if not isinstance(source, dict):
         return None
 
-    source = dict(source)  # shallow copy; don't mutate the shared turn list
-
     inner = source.get("source")
     if not isinstance(inner, dict):
-        inner = {}
+        return None
+
+    source = dict(source)  # shallow copy; don't mutate the shared turn list
     source["source"] = inner
 
     documents = source.get("document", [])

--- a/tools/get_sources.py
+++ b/tools/get_sources.py
@@ -1,0 +1,167 @@
+"""
+title: Get Current Sources
+author: WikiTeq
+date: 2025-07-10
+version: 2.0
+license: MIT
+description: Retrieves sources/citations emitted by tools in the current chat turn. Useful when the model needs to reference sources for inline citations.
+requirements: pydantic>=2.0.0
+"""
+
+import logging
+
+from pydantic import BaseModel, Field
+
+log = logging.getLogger(__name__)
+
+
+class Tools:
+    """OpenWebUI tool that collects sources emitted during the current chat turn."""
+
+    class Valves(BaseModel):
+        max_sources: int = Field(
+            default=50,
+            ge=1,
+            le=500,
+            description="Maximum number of sources to return (1-500).",
+        )
+
+    def __init__(self):
+        self.valves = self.Valves()
+
+    async def get_sources(
+        self,
+        __event_emitter__=None,
+        __request__=None,
+    ) -> str:
+        """
+        Retrieve all sources/citations emitted by tools during the current chat turn.
+
+        Sources are collected from __request__.state, where source-emitting tools
+        (web_search, wiki_search, retrieval, etc.) store them as they run.
+        Only sources from the current turn are returned - previous turns are not
+        included since they are already visible in the chat history.
+
+        Use this tool when you need to:
+        - Review available sources for inline citations
+        - List references found so far in this response
+        - Get source IDs/names for citation formatting
+
+        Args: none
+
+        Returns:
+            A formatted list of current-turn sources, or a message if none found.
+        """
+        async def emit(message: str, done: bool = False, hidden: bool = True) -> None:
+            if __event_emitter__:
+                await __event_emitter__(
+                    {
+                        "type": "status",
+                        "data": {
+                            "description": message,
+                            "done": done,
+                            "hidden": hidden,
+                        },
+                    }
+                )
+
+        await emit("Collecting sources from current turn...")
+
+        # Current-turn sources are stored on __request__.state by
+        # source-emitting tools (web_search, wiki_search, retrieval).
+        # They share the same Request object within a single turn.
+        current_sources = []
+        if __request__:
+            try:
+                current_sources = getattr(
+                    __request__.state, "_wikiteq_sources", []
+                )
+            except Exception:
+                log.debug("No request state sources found", exc_info=True)
+
+        if not current_sources:
+            await emit("No sources found in current turn.", done=True, hidden=False)
+            return "No sources have been emitted in this turn so far."
+
+        # Deduplicate by (name, url), preserving insertion order.
+        all_sources = []
+        seen = set()
+        for source in current_sources:
+            if not isinstance(source, dict):
+                continue
+            name = source.get("source", {}).get("name", "") or source.get("name", "")
+            url = _extract_url(source)
+            key = (name, url) if url else (name, _content_fingerprint(source))
+            if key in seen:
+                continue
+            seen.add(key)
+            all_sources.append(source)
+
+        if not all_sources:
+            await emit("No sources found in current turn.", done=True, hidden=False)
+            return "No sources have been emitted in this turn so far."
+
+        # Apply limit (keep most recent if over cap)
+        if len(all_sources) > self.valves.max_sources:
+            all_sources = all_sources[-self.valves.max_sources:]
+
+        # Format output
+        sections = []
+        for i, source in enumerate(all_sources, start=1):
+            name = (
+                source.get("source", {}).get("name", "")
+                or source.get("name", "(unnamed)")
+            )
+            url = _extract_url(source)
+            documents = source.get("document", [])
+            if not isinstance(documents, list):
+                documents = [documents] if documents else []
+
+            lines = [f"=== Source {i}: {name} ==="]
+            if url:
+                lines.append(f"URL: {url}")
+            if documents:
+                doc_text = documents[0] if documents else ""
+                if len(doc_text) > 500:
+                    doc_text = doc_text[:500] + "..."
+                lines.append(f"Excerpt: {doc_text}")
+            sections.append("\n".join(lines))
+
+        await emit(f"Found {len(all_sources)} source(s).", done=True)
+        return (
+            f"Sources from current turn ({len(all_sources)} total):\n\n"
+            + "\n---\n\n".join(sections)
+        )
+
+
+def _extract_url(source: dict) -> str:
+    """Best-effort URL extraction from a source dict.
+
+    Only trusts fields that are actually URLs in every known emitter shape
+    (roat_retrieval, mediawiki_tool, web_search). metadata[0]["source"] is
+    deliberately excluded: in roat_retrieval it holds the document title,
+    not a URL, so treating it as one would mislabel a title as a link.
+
+    source.id is also NOT trusted unconditionally: web_search.py populates
+    it with a real URL, but roat_retrieval.py/mediawiki_tool.py populate it
+    with a to_source_id() slug (e.g. "some-kb-doc"), which is not a URL.
+    Only accept it when it actually looks like one.
+    """
+    source_id = source.get("source", {}).get("id", "")
+    if isinstance(source_id, str) and source_id.startswith(("http://", "https://")):
+        return source_id
+    return source.get("url", "") or source.get("source", {}).get("url", "")
+
+
+def _content_fingerprint(source: dict) -> str:
+    """Fallback dedup key for sources with no URL.
+
+    Without this, two distinct chunks of the same document (e.g. two
+    non-adjacent ROAT KB passages with the same title, no url extra) would
+    dedup-collide on (name, "") and silently drop one from the output.
+    """
+    documents = source.get("document", [])
+    if not isinstance(documents, list):
+        documents = [documents] if documents else []
+    text = documents[0] if documents else ""
+    return text[:200] if isinstance(text, str) else ""

--- a/tools/mediawiki_tool.py
+++ b/tools/mediawiki_tool.py
@@ -37,6 +37,12 @@ def _truncate(text: str, limit: int = MAX_ERROR_DETAIL_CHARS) -> str:
 _ILLEGAL_TITLE_CHARS = re.compile(r"[#<>\[\]|{}\x00-\x1f\x7f]")
 
 
+def to_source_id(text: str) -> str:
+    """Slugify a source name into an id: spaces -> hyphens, strip non-alnum/hyphen, lowercase."""
+    text_with_hyphens = text.replace(" ", "-")
+    return re.sub(r"[^a-zA-Z0-9-]", "", text_with_hyphens).lower()
+
+
 def _parse_wiki_url(wiki_url: str) -> tuple[str, str, str]:
     """
     Parse an api.php URL into (host, path, scheme) for mwclient.Site.
@@ -90,20 +96,49 @@ def _validate_title(title: str) -> None:
         )
 
 
-def _build_page_url(scheme: str, host: str, article_path: str, title: str) -> str:
-    """Build a canonical page URL with proper title encoding."""
-    # MediaWiki uses underscores and percent-encoding in URLs
+def _build_page_url(title: str, article_path: str, server: str | None = None) -> str:
+    """Build a canonical page URL with proper title encoding.
+
+    Uses the 'server' field from siteinfo (e.g. 'https://example.com')
+    combined with 'articlepath' (e.g. '/wiki/$1') to produce the full
+    public-facing page URL. Falls back to a relative path when server
+    is unavailable.
+    """
     encoded = quote(title.replace(" ", "_"), safe="/:")
-    return f"{scheme}://{host}{article_path.replace('$1', encoded)}"
+    path = article_path.replace("$1", encoded)
+    if server:
+        return f"{server}{path}"
+    return path
 
 
-def _get_article_path(site) -> str:
+def _get_site_info(site) -> tuple[str, str | None]:
+    """Fetch articlepath and server URL from MediaWiki siteinfo.
+
+    Returns (article_path, server). server is the canonical wiki base URL
+    from siteinfo's 'server' field (e.g. 'https://example.com'), or None
+    if the API call fails.
+    """
     try:
         result = site.api("query", meta="siteinfo", siprop="general")
-        return result["query"]["general"].get("articlepath", "/wiki/$1")
+        general = result["query"]["general"]
+        return general.get("articlepath", "/wiki/$1"), general.get("server")
     except Exception:
-        log.warning("Could not fetch articlepath from siteinfo; falling back to /wiki/$1", exc_info=True)
-        return "/wiki/$1"
+        log.warning("Could not fetch siteinfo; falling back to defaults", exc_info=True)
+        return "/wiki/$1", None
+
+
+def _store_turn_sources(request, sources: list) -> None:
+    """Append sources to __request__.state._wikiteq_sources for get_sources tool."""
+    if not request or not sources:
+        return
+    try:
+        turn_sources = getattr(request.state, "_wikiteq_sources", None)
+        if turn_sources is None:
+            turn_sources = []
+            request.state._wikiteq_sources = turn_sources
+        turn_sources.extend(sources)
+    except Exception:
+        log.debug("Could not store sources on request state", exc_info=True)
 
 
 def _connect_site(host: str, path: str, scheme: str, timeout: int, username: str, password: str):
@@ -160,6 +195,15 @@ class Tools:
                 " Longer pages are truncated. Range: 1–500,000."
             ),
         )
+        content_format: Literal["wikitext", "html", "markdown"] = Field(
+            default="wikitext",
+            description=(
+                "Output format for page content. 'wikitext' returns raw MediaWiki"
+                " markup (default). 'html' returns parsed HTML via the parse API."
+                " 'markdown' returns parsed HTML converted to Markdown using the"
+                " markdownify library."
+            ),
+        )
 
     def __init__(self):
         self.valves = self.Valves()
@@ -169,6 +213,7 @@ class Tools:
         query: str,
         content_format: Literal["wikitext", "html", "markdown"] = "wikitext",
         __event_emitter__: Callable[[dict], Awaitable[None]] | None = None,
+        __request__=None,
     ) -> str:
         """
         Search the MediaWiki wiki for pages matching a query and return their page content.
@@ -256,8 +301,8 @@ class Tools:
                 f"Error: could not connect to the wiki. Check the wiki_url in Tool Valves. Details: {_truncate(str(e))}"
             )
 
-        await emit("Fetching wiki article path…")
-        article_path = await asyncio.to_thread(_get_article_path, site)
+        await emit("Fetching wiki site info…")
+        article_path, server = await asyncio.to_thread(_get_site_info, site)
 
         await emit(f"Searching for '{query}'...")
 
@@ -362,12 +407,14 @@ class Tools:
         for i, (title, content) in enumerate(pages, start=1):
             if len(content) > cap:
                 content = content[:cap] + f"\n...(truncated {len(content) - cap} chars)"
-            url = _build_page_url(scheme, host, article_path, title)
-            sections.append(f"=== Result {i}: {title} ===\nURL: {url}\n\nPage content: {content}\n")
+            url = _build_page_url(title, article_path, server)
+            sections.append(
+                f"=== Result {i}: {title} ===\nSource id:{to_source_id(title)}\nURL: {url}\n\nPage content: {content}\n"
+            )
             if content not in _fetch_errors:
                 sources.append(
                     {
-                        "source": {"name": title, "url": url},
+                        "source": {"name": title, "url": url, "id": to_source_id(title)},
                         "document": [content],
                         "metadata": [{"source": title, "url": url}],
                     }
@@ -376,6 +423,7 @@ class Tools:
         if __event_emitter__:
             for src in sources:
                 await __event_emitter__({"type": "source", "data": src})
+        _store_turn_sources(__request__, sources)
 
         await emit(f"Found {len(pages)} result(s) for '{query}'.", done=True)
         return f"Search results for '{query}' ({len(pages)} page(s)):\n\n" + "\n---\n\n".join(sections)
@@ -528,8 +576,8 @@ class Tools:
         # --- Build canonical page URL (blocking — run in thread) ---
         await emit("Fetching page URL…")
 
-        article_path = await asyncio.to_thread(_get_article_path, site)
-        page_url = _build_page_url(scheme, host, article_path, title)
+        article_path, server = await asyncio.to_thread(_get_site_info, site)
+        page_url = _build_page_url(title, article_path, server)
 
         await emit(f"Saved: {page_url}", done=True)
         return page_url

--- a/tools/mediawiki_tool.py
+++ b/tools/mediawiki_tool.py
@@ -14,7 +14,7 @@ import logging
 import re
 from collections.abc import Awaitable, Callable
 from typing import Literal
-from urllib.parse import quote, urlparse
+from urllib.parse import quote, urljoin, urlparse
 
 from pydantic import BaseModel, Field
 
@@ -113,40 +113,64 @@ def _validate_title(title: str) -> None:
         )
 
 
-def _build_page_url(title: str, article_path: str, server: str | None, default_scheme: str) -> str | None:
+def _build_page_url(title: str, article_path: str, origin: str | None) -> str | None:
     """Build a canonical, absolute page URL with proper title encoding.
 
-    Uses the 'server' field from siteinfo (e.g. 'https://example.com')
-    combined with 'articlepath' (e.g. '/wiki/$1') to produce the full
-    public-facing page URL. Returns None when server is unavailable —
-    a relative path would resolve against the OpenWebUI origin instead
-    of the wiki's, which is worse than no URL at all.
+    Combines 'origin' (an absolute scheme+host, e.g. 'https://example.com')
+    with 'articlepath' (e.g. '/wiki/$1') to produce the full public-facing
+    page URL. Returns None when origin is unavailable — a relative path
+    would resolve against the OpenWebUI origin instead of the wiki's,
+    which is worse than no URL at all.
 
-    MediaWiki's siteinfo 'server' is often protocol-relative (e.g.
-    '//en.wikipedia.org'), which is only meaningful when embedded in an
-    HTML page — surfaced as plain text here, it's not a usable standalone
-    URL. default_scheme (the configured wiki_url's own scheme) fills that in.
+    MediaWiki titles may legally contain '/' (e.g. subpages). Combined with
+    a root short-URL articlepath ('/$1'), a title starting with '/' would
+    otherwise produce a path like '//Evil', which urljoin() interprets as
+    a network-path reference (resolving against a different host entirely)
+    rather than a path on 'origin'. Collapsing leading slashes keeps the
+    joined path anchored to origin regardless of title/articlepath shape.
     """
-    if not server:
+    if not origin:
         return None
-    if server.startswith("//"):
-        server = f"{default_scheme}:{server}"
     encoded = quote(title.replace(" ", "_"), safe="/:")
     path = article_path.replace("$1", encoded)
-    return f"{server}{path}"
+    path = "/" + path.lstrip("/")
+    return urljoin(origin, path)
 
 
 def _get_site_info(site) -> tuple[str, str | None]:
-    """Fetch articlepath and server URL from MediaWiki siteinfo.
+    """Fetch articlepath and the wiki's public origin from MediaWiki siteinfo.
 
-    Returns (article_path, server). server is the canonical wiki base URL
-    from siteinfo's 'server' field (e.g. 'https://example.com'), or None
-    if the API call fails.
+    Returns (article_path, origin). origin is an absolute scheme+host
+    (e.g. 'https://example.com') derived from siteinfo's 'base' field,
+    which always contains the full absolute public wiki URL including
+    scheme (e.g. 'https://example.com/wiki/Main_Page') — unlike 'server',
+    which is commonly protocol-relative (e.g. '//example.com') and, for
+    tools connecting via a private/in-cluster wiki_url, may not even share
+    the public scheme. Falls back to 'server' (normalizing a protocol-
+    relative value against the parsed 'base' scheme, or dropping it if
+    unusable) if 'base' is missing or fails to parse. Returns
+    (article_path, None) if the API call fails or no usable origin exists.
     """
     try:
         result = site.api("query", meta="siteinfo", siprop="general")
         general = result["query"]["general"]
-        return general.get("articlepath", "/wiki/$1"), general.get("server")
+        article_path = general.get("articlepath", "/wiki/$1")
+
+        base = general.get("base", "")
+        parsed_base = urlparse(base) if base else None
+        if parsed_base and parsed_base.scheme and parsed_base.netloc:
+            return article_path, f"{parsed_base.scheme}://{parsed_base.netloc}"
+
+        server = general.get("server", "")
+        if server:
+            if server.startswith("//"):
+                scheme = parsed_base.scheme if parsed_base and parsed_base.scheme else "https"
+                return article_path, f"{scheme}:{server}"
+            parsed_server = urlparse(server)
+            if parsed_server.scheme and parsed_server.netloc:
+                return article_path, f"{parsed_server.scheme}://{parsed_server.netloc}"
+
+        return article_path, None
     except Exception:
         log.warning("Could not fetch siteinfo; falling back to defaults", exc_info=True)
         return "/wiki/$1", None
@@ -330,7 +354,7 @@ class Tools:
             )
 
         await emit("Fetching wiki site info…")
-        article_path, server = await asyncio.to_thread(_get_site_info, site)
+        article_path, origin = await asyncio.to_thread(_get_site_info, site)
 
         await emit(f"Searching for '{query}'...")
 
@@ -439,7 +463,7 @@ class Tools:
             is_fetch_error = content in _fetch_errors
             if len(content) > cap:
                 content = content[:cap] + f"\n...(truncated {len(content) - cap} chars)"
-            url = _build_page_url(title, article_path, server, scheme)
+            url = _build_page_url(title, article_path, origin)
             url_line = f"\nURL: {url}" if url else ""
             sections.append(
                 f"=== Result {i}: {title} ===\nSource id:{to_source_id(title)}{url_line}\n\nPage content: {content}\n"
@@ -614,12 +638,12 @@ class Tools:
         # --- Build canonical page URL (blocking — run in thread) ---
         await emit("Fetching page URL…")
 
-        article_path, server = await asyncio.to_thread(_get_site_info, site)
-        page_url = _build_page_url(title, article_path, server, scheme)
+        article_path, origin = await asyncio.to_thread(_get_site_info, site)
+        page_url = _build_page_url(title, article_path, origin)
 
         if page_url:
             await emit(f"Saved: {page_url}", done=True)
             return page_url
 
-        await emit(f"Saved «{title}», but could not determine its URL.", done=True)
-        return f"Saved «{title}» to the wiki, but the page URL could not be determined."
+        await emit(f'Saved "{title}", but could not determine its URL.', done=True)
+        return f'Saved "{title}" to the wiki, but the page URL could not be determined.'

--- a/tools/mediawiki_tool.py
+++ b/tools/mediawiki_tool.py
@@ -122,10 +122,12 @@ def _build_page_url(title: str, article_path: str, origin: str | None) -> str | 
     would resolve against the OpenWebUI origin instead of the wiki's,
     which is worse than no URL at all.
 
-    MediaWiki titles may legally contain '/' (e.g. subpages). Combined with
-    a root short-URL articlepath ('/$1'), a title starting with '/' would
-    otherwise produce a path like '//Evil', which urljoin() interprets as
-    a network-path reference (resolving against a different host entirely)
+    MediaWiki's own naming restrictions reject titles starting with './'
+    or '../' (dot-segments), but a bare leading '/' (e.g. '/Foo') is not
+    banned (see mediawiki.org/wiki/Manual:Page_title, "Naming restrictions").
+    Combined with a root short-URL articlepath ('/$1'), such a title would
+    otherwise produce a path like '//Foo', which urljoin() interprets as a
+    network-path reference (resolving against a different host entirely)
     rather than a path on 'origin'. Collapsing leading slashes keeps the
     joined path anchored to origin regardless of title/articlepath shape.
     """
@@ -144,12 +146,10 @@ def _get_site_info(site) -> tuple[str, str | None]:
     (e.g. 'https://example.com') derived from siteinfo's 'base' field,
     which always contains the full absolute public wiki URL including
     scheme (e.g. 'https://example.com/wiki/Main_Page') — unlike 'server',
-    which is commonly protocol-relative (e.g. '//example.com') and, for
-    tools connecting via a private/in-cluster wiki_url, may not even share
-    the public scheme. Falls back to 'server' (normalizing a protocol-
-    relative value against the parsed 'base' scheme, or dropping it if
-    unusable) if 'base' is missing or fails to parse. Returns
-    (article_path, None) if the API call fails or no usable origin exists.
+    which is commonly protocol-relative and, for tools connecting via a
+    private/in-cluster wiki_url, may not even share the public scheme.
+    Returns (article_path, None) if the API call fails or 'base' is
+    missing/unparseable.
     """
     try:
         result = site.api("query", meta="siteinfo", siprop="general")
@@ -160,15 +160,6 @@ def _get_site_info(site) -> tuple[str, str | None]:
         parsed_base = urlparse(base) if base else None
         if parsed_base and parsed_base.scheme and parsed_base.netloc:
             return article_path, f"{parsed_base.scheme}://{parsed_base.netloc}"
-
-        server = general.get("server", "")
-        if server:
-            if server.startswith("//"):
-                scheme = parsed_base.scheme if parsed_base and parsed_base.scheme else "https"
-                return article_path, f"{scheme}:{server}"
-            parsed_server = urlparse(server)
-            if parsed_server.scheme and parsed_server.netloc:
-                return article_path, f"{parsed_server.scheme}://{parsed_server.netloc}"
 
         return article_path, None
     except Exception:

--- a/tools/mediawiki_tool.py
+++ b/tools/mediawiki_tool.py
@@ -247,15 +247,6 @@ class Tools:
                 " Longer pages are truncated. Range: 1–500,000."
             ),
         )
-        content_format: Literal["wikitext", "html", "markdown"] = Field(
-            default="wikitext",
-            description=(
-                "Output format for page content. 'wikitext' returns raw MediaWiki"
-                " markup (default). 'html' returns parsed HTML via the parse API."
-                " 'markdown' returns parsed HTML converted to Markdown using the"
-                " markdownify library."
-            ),
-        )
 
     def __init__(self):
         self.valves = self.Valves()

--- a/tools/mediawiki_tool.py
+++ b/tools/mediawiki_tool.py
@@ -38,7 +38,12 @@ _ILLEGAL_TITLE_CHARS = re.compile(r"[#<>\[\]|{}\x00-\x1f\x7f]")
 
 
 def to_source_id(text: str) -> str:
-    """Slugify a source name into an id: spaces -> hyphens, strip non-alnum/hyphen, lowercase."""
+    """Slugify a source name into an id: spaces -> hyphens, strip non-alnum/hyphen, lowercase.
+
+    Duplicated verbatim in roat_retrieval.py — OWUI loads each tool's source
+    as an independent module (no shared import path between tools), so keep
+    both copies in sync if this changes.
+    """
     text_with_hyphens = text.replace(" ", "-")
     return re.sub(r"[^a-zA-Z0-9-]", "", text_with_hyphens).lower()
 
@@ -128,7 +133,10 @@ def _get_site_info(site) -> tuple[str, str | None]:
 
 
 def _store_turn_sources(request, sources: list) -> None:
-    """Append sources to __request__.state._wikiteq_sources for get_sources tool."""
+    """Append sources to __request__.state._wikiteq_sources for get_sources tool.
+
+    Duplicated verbatim in roat_retrieval.py — see to_source_id() above for why.
+    """
     if not request or not sources:
         return
     try:

--- a/tools/mediawiki_tool.py
+++ b/tools/mediawiki_tool.py
@@ -39,11 +39,14 @@ _ILLEGAL_TITLE_CHARS = re.compile(r"[#<>\[\]|{}\x00-\x1f\x7f]")
 
 
 def to_source_id(text: str) -> str:
-    """Slugify a source name into an id: spaces -> hyphens, strip non-alnum/hyphen, lowercase.
+    """Slugify a source name into an id: spaces -> hyphens, strip non-alnum/hyphen, lowercase,
+    with a short digest of the original text appended for uniqueness.
 
-    Titles made up entirely of non-ASCII characters (e.g. "日本語") strip down
-    to an empty string, which is not a usable id. In that case, fall back to
-    a deterministic ASCII id derived from a digest of the original title.
+    The digest is always appended, not just when the slug is empty: stripping
+    punctuation means distinct titles like "C++", "C#", and "C" would otherwise
+    all slugify to the same "c" and collide. Titles made up entirely of
+    non-ASCII characters (e.g. "日本語") strip down to an empty slug, in which
+    case the id falls back to the digest alone.
 
     Duplicated verbatim in roat_retrieval.py — OWUI loads each tool's source
     as an independent module (no shared import path between tools), so keep
@@ -51,9 +54,9 @@ def to_source_id(text: str) -> str:
     """
     text_with_hyphens = text.replace(" ", "-")
     slug = re.sub(r"[^a-zA-Z0-9-]", "", text_with_hyphens).lower()
-    if slug:
-        return slug
     digest = hashlib.sha1(text.encode("utf-8")).hexdigest()[:8]
+    if slug:
+        return f"{slug}-{digest}"
     return f"src-{digest}"
 
 
@@ -110,7 +113,7 @@ def _validate_title(title: str) -> None:
         )
 
 
-def _build_page_url(title: str, article_path: str, server: str | None = None) -> str | None:
+def _build_page_url(title: str, article_path: str, server: str | None, default_scheme: str) -> str | None:
     """Build a canonical, absolute page URL with proper title encoding.
 
     Uses the 'server' field from siteinfo (e.g. 'https://example.com')
@@ -118,9 +121,16 @@ def _build_page_url(title: str, article_path: str, server: str | None = None) ->
     public-facing page URL. Returns None when server is unavailable —
     a relative path would resolve against the OpenWebUI origin instead
     of the wiki's, which is worse than no URL at all.
+
+    MediaWiki's siteinfo 'server' is often protocol-relative (e.g.
+    '//en.wikipedia.org'), which is only meaningful when embedded in an
+    HTML page — surfaced as plain text here, it's not a usable standalone
+    URL. default_scheme (the configured wiki_url's own scheme) fills that in.
     """
     if not server:
         return None
+    if server.startswith("//"):
+        server = f"{default_scheme}:{server}"
     encoded = quote(title.replace(" ", "_"), safe="/:")
     path = article_path.replace("$1", encoded)
     return f"{server}{path}"
@@ -423,14 +433,18 @@ class Tools:
         cap = self.valves.max_page_chars
         _fetch_errors = {"(Page not found — may have been deleted)", "(Content unavailable)"}
         for i, (title, content) in enumerate(pages, start=1):
+            # Check for a fetch failure before truncating — a low max_page_chars
+            # valve can truncate a sentinel string so it no longer matches
+            # _fetch_errors, which would wrongly treat the failure as real content.
+            is_fetch_error = content in _fetch_errors
             if len(content) > cap:
                 content = content[:cap] + f"\n...(truncated {len(content) - cap} chars)"
-            url = _build_page_url(title, article_path, server)
+            url = _build_page_url(title, article_path, server, scheme)
             url_line = f"\nURL: {url}" if url else ""
             sections.append(
                 f"=== Result {i}: {title} ===\nSource id:{to_source_id(title)}{url_line}\n\nPage content: {content}\n"
             )
-            if content not in _fetch_errors:
+            if not is_fetch_error:
                 source_entry = {"name": title, "id": to_source_id(title)}
                 metadata_entry = {"source": title}
                 if url:
@@ -601,7 +615,7 @@ class Tools:
         await emit("Fetching page URL…")
 
         article_path, server = await asyncio.to_thread(_get_site_info, site)
-        page_url = _build_page_url(title, article_path, server)
+        page_url = _build_page_url(title, article_path, server, scheme)
 
         if page_url:
             await emit(f"Saved: {page_url}", done=True)

--- a/tools/mediawiki_tool.py
+++ b/tools/mediawiki_tool.py
@@ -9,6 +9,7 @@ requirements: mwclient>=0.10.1, pydantic>=2.0.0, markdownify>=0.13.1
 """
 
 import asyncio
+import hashlib
 import logging
 import re
 from collections.abc import Awaitable, Callable
@@ -40,12 +41,20 @@ _ILLEGAL_TITLE_CHARS = re.compile(r"[#<>\[\]|{}\x00-\x1f\x7f]")
 def to_source_id(text: str) -> str:
     """Slugify a source name into an id: spaces -> hyphens, strip non-alnum/hyphen, lowercase.
 
+    Titles made up entirely of non-ASCII characters (e.g. "日本語") strip down
+    to an empty string, which is not a usable id. In that case, fall back to
+    a deterministic ASCII id derived from a digest of the original title.
+
     Duplicated verbatim in roat_retrieval.py — OWUI loads each tool's source
     as an independent module (no shared import path between tools), so keep
     both copies in sync if this changes.
     """
     text_with_hyphens = text.replace(" ", "-")
-    return re.sub(r"[^a-zA-Z0-9-]", "", text_with_hyphens).lower()
+    slug = re.sub(r"[^a-zA-Z0-9-]", "", text_with_hyphens).lower()
+    if slug:
+        return slug
+    digest = hashlib.sha1(text.encode("utf-8")).hexdigest()[:8]
+    return f"src-{digest}"
 
 
 def _parse_wiki_url(wiki_url: str) -> tuple[str, str, str]:
@@ -101,19 +110,20 @@ def _validate_title(title: str) -> None:
         )
 
 
-def _build_page_url(title: str, article_path: str, server: str | None = None) -> str:
-    """Build a canonical page URL with proper title encoding.
+def _build_page_url(title: str, article_path: str, server: str | None = None) -> str | None:
+    """Build a canonical, absolute page URL with proper title encoding.
 
     Uses the 'server' field from siteinfo (e.g. 'https://example.com')
     combined with 'articlepath' (e.g. '/wiki/$1') to produce the full
-    public-facing page URL. Falls back to a relative path when server
-    is unavailable.
+    public-facing page URL. Returns None when server is unavailable —
+    a relative path would resolve against the OpenWebUI origin instead
+    of the wiki's, which is worse than no URL at all.
     """
+    if not server:
+        return None
     encoded = quote(title.replace(" ", "_"), safe="/:")
     path = article_path.replace("$1", encoded)
-    if server:
-        return f"{server}{path}"
-    return path
+    return f"{server}{path}"
 
 
 def _get_site_info(site) -> tuple[str, str | None]:
@@ -416,15 +426,21 @@ class Tools:
             if len(content) > cap:
                 content = content[:cap] + f"\n...(truncated {len(content) - cap} chars)"
             url = _build_page_url(title, article_path, server)
+            url_line = f"\nURL: {url}" if url else ""
             sections.append(
-                f"=== Result {i}: {title} ===\nSource id:{to_source_id(title)}\nURL: {url}\n\nPage content: {content}\n"
+                f"=== Result {i}: {title} ===\nSource id:{to_source_id(title)}{url_line}\n\nPage content: {content}\n"
             )
             if content not in _fetch_errors:
+                source_entry = {"name": title, "id": to_source_id(title)}
+                metadata_entry = {"source": title}
+                if url:
+                    source_entry["url"] = url
+                    metadata_entry["url"] = url
                 sources.append(
                     {
-                        "source": {"name": title, "url": url, "id": to_source_id(title)},
+                        "source": source_entry,
                         "document": [content],
-                        "metadata": [{"source": title, "url": url}],
+                        "metadata": [metadata_entry],
                     }
                 )
 
@@ -587,5 +603,9 @@ class Tools:
         article_path, server = await asyncio.to_thread(_get_site_info, site)
         page_url = _build_page_url(title, article_path, server)
 
-        await emit(f"Saved: {page_url}", done=True)
-        return page_url
+        if page_url:
+            await emit(f"Saved: {page_url}", done=True)
+            return page_url
+
+        await emit(f"Saved «{title}», but could not determine its URL.", done=True)
+        return f"Saved «{title}» to the wiki, but the page URL could not be determined."

--- a/tools/roat_retrieval.py
+++ b/tools/roat_retrieval.py
@@ -55,7 +55,12 @@ def _extract_http_error_detail(err: requests.HTTPError) -> str:
 
 
 def to_source_id(text: str) -> str:
-    """Slugify a source name into an id: spaces -> hyphens, strip non-alnum/hyphen, lowercase."""
+    """Slugify a source name into an id: spaces -> hyphens, strip non-alnum/hyphen, lowercase.
+
+    Duplicated verbatim in mediawiki_tool.py — OWUI loads each tool's source
+    as an independent module (no shared import path between tools), so keep
+    both copies in sync if this changes.
+    """
     text_with_hyphens = text.replace(" ", "-")
     return re.sub(r"[^a-zA-Z0-9-]", "", text_with_hyphens).lower()
 
@@ -91,7 +96,10 @@ def _find_video_url(references: list, field: str = "video_url") -> tuple[str | N
 
 
 def _store_turn_sources(request, sources: list) -> None:
-    """Append sources to __request__.state._wikiteq_sources for get_sources tool."""
+    """Append sources to __request__.state._wikiteq_sources for get_sources tool.
+
+    Duplicated verbatim in mediawiki_tool.py — see to_source_id() above for why.
+    """
     if not request or not sources:
         return
     try:

--- a/tools/roat_retrieval.py
+++ b/tools/roat_retrieval.py
@@ -9,6 +9,7 @@ requirements: requests, pyyaml
 """
 
 import asyncio
+import hashlib
 import logging
 import os
 import re
@@ -57,12 +58,20 @@ def _extract_http_error_detail(err: requests.HTTPError) -> str:
 def to_source_id(text: str) -> str:
     """Slugify a source name into an id: spaces -> hyphens, strip non-alnum/hyphen, lowercase.
 
+    Titles made up entirely of non-ASCII characters (e.g. "日本語") strip down
+    to an empty string, which is not a usable id. In that case, fall back to
+    a deterministic ASCII id derived from a digest of the original title.
+
     Duplicated verbatim in mediawiki_tool.py — OWUI loads each tool's source
     as an independent module (no shared import path between tools), so keep
     both copies in sync if this changes.
     """
     text_with_hyphens = text.replace(" ", "-")
-    return re.sub(r"[^a-zA-Z0-9-]", "", text_with_hyphens).lower()
+    slug = re.sub(r"[^a-zA-Z0-9-]", "", text_with_hyphens).lower()
+    if slug:
+        return slug
+    digest = hashlib.sha1(text.encode("utf-8")).hexdigest()[:8]
+    return f"src-{digest}"
 
 
 def _parse_raw_chunk(raw_text: str) -> dict:

--- a/tools/roat_retrieval.py
+++ b/tools/roat_retrieval.py
@@ -54,6 +54,12 @@ def _extract_http_error_detail(err: requests.HTTPError) -> str:
         return _truncate(resp.text)
 
 
+def to_source_id(text: str) -> str:
+    """Slugify a source name into an id: spaces -> hyphens, strip non-alnum/hyphen, lowercase."""
+    text_with_hyphens = text.replace(" ", "-")
+    return re.sub(r"[^a-zA-Z0-9-]", "", text_with_hyphens).lower()
+
+
 def _parse_raw_chunk(raw_text: str) -> dict:
     match = re.match(r"Score:\s*([\d.]+)\s*\|\s*Text:\s*(.*)", raw_text, re.DOTALL)
     if match:
@@ -82,6 +88,20 @@ def _find_video_url(references: list, field: str = "video_url") -> tuple[str | N
         if url and isinstance(url, str) and url.startswith("https://"):
             return url, ref.get("title") or ref.get("source_name") or "Source"
     return None, None
+
+
+def _store_turn_sources(request, sources: list) -> None:
+    """Append sources to __request__.state._wikiteq_sources for get_sources tool."""
+    if not request or not sources:
+        return
+    try:
+        turn_sources = getattr(request.state, "_wikiteq_sources", None)
+        if turn_sources is None:
+            turn_sources = []
+            request.state._wikiteq_sources = turn_sources
+        turn_sources.extend(sources)
+    except Exception:
+        log.debug("Could not store sources on request state", exc_info=True)
 
 
 def _call_rag_service(
@@ -134,9 +154,9 @@ def _format_context_and_sources(rag_result: dict, max_document_preview_chars: in
         filename = _get_filename_from_extras(extras)
         source_name = ref.get("title") or ref.get("source_name") or filename or f"Source {i + 1}"
 
-        metadata_fields = {"title": source_name}
+        metadata_fields = {"title": source_name, "id": to_source_id(source_name)}
         metadata_fields.update(
-            {k: v for k, v in extras.items() if k not in _internal_fields and k != "url" and v is not None}
+            {k: v for k, v in extras.items() if k not in _internal_fields and k not in ("url", "id") and v is not None}
         )
         url = ref.get("url") or extras.get("url")
         if url:
@@ -156,7 +176,7 @@ def _format_context_and_sources(rag_result: dict, max_document_preview_chars: in
         )
 
         source_obj = {
-            "source": {"name": source_name},
+            "source": {"name": source_name, "id": to_source_id(source_name)},
             "document": [text[:max_document_preview_chars] if max_document_preview_chars > 0 else text],
             "metadata": [
                 {
@@ -217,6 +237,7 @@ class Tools:
         query: str,
         metadata_filters: list[dict] = [],
         __event_emitter__: Callable[[dict], Awaitable[None]] | None = None,
+        __request__=None,
     ) -> str:
         """
         Search the organizational knowledge base to answer questions about company
@@ -358,6 +379,7 @@ class Tools:
         if __event_emitter__:
             for src in sources:
                 await __event_emitter__({"type": "source", "data": src})
+        _store_turn_sources(__request__, sources)
 
         await emit(f"Found {len(sources)} relevant source(s).", done=True)
         log.info("Returning context with %d sources (%d chars)", len(sources), len(context))

--- a/tools/roat_retrieval.py
+++ b/tools/roat_retrieval.py
@@ -174,7 +174,7 @@ def _format_context_and_sources(rag_result: dict, max_document_preview_chars: in
         filename = _get_filename_from_extras(extras)
         source_name = ref.get("title") or ref.get("source_name") or filename or f"Source {i + 1}"
 
-        metadata_fields = {"title": source_name, "id": to_source_id(source_name)}
+        metadata_fields = {"title": source_name}
         metadata_fields.update(
             {k: v for k, v in extras.items() if k not in _internal_fields and k not in ("url", "id") and v is not None}
         )
@@ -216,6 +216,7 @@ def _format_context_and_sources(rag_result: dict, max_document_preview_chars: in
         url = ref.get("url") or extras.get("url")
         if url:
             source_obj["source"]["url"] = url
+            source_obj["metadata"][0]["url"] = url
 
         sources.append(source_obj)
 

--- a/tools/roat_retrieval.py
+++ b/tools/roat_retrieval.py
@@ -56,11 +56,14 @@ def _extract_http_error_detail(err: requests.HTTPError) -> str:
 
 
 def to_source_id(text: str) -> str:
-    """Slugify a source name into an id: spaces -> hyphens, strip non-alnum/hyphen, lowercase.
+    """Slugify a source name into an id: spaces -> hyphens, strip non-alnum/hyphen, lowercase,
+    with a short digest of the original text appended for uniqueness.
 
-    Titles made up entirely of non-ASCII characters (e.g. "日本語") strip down
-    to an empty string, which is not a usable id. In that case, fall back to
-    a deterministic ASCII id derived from a digest of the original title.
+    The digest is always appended, not just when the slug is empty: stripping
+    punctuation means distinct titles like "C++", "C#", and "C" would otherwise
+    all slugify to the same "c" and collide. Titles made up entirely of
+    non-ASCII characters (e.g. "日本語") strip down to an empty slug, in which
+    case the id falls back to the digest alone.
 
     Duplicated verbatim in mediawiki_tool.py — OWUI loads each tool's source
     as an independent module (no shared import path between tools), so keep
@@ -68,9 +71,9 @@ def to_source_id(text: str) -> str:
     """
     text_with_hyphens = text.replace(" ", "-")
     slug = re.sub(r"[^a-zA-Z0-9-]", "", text_with_hyphens).lower()
-    if slug:
-        return slug
     digest = hashlib.sha1(text.encode("utf-8")).hexdigest()[:8]
+    if slug:
+        return f"{slug}-{digest}"
     return f"src-{digest}"
 
 


### PR DESCRIPTION
## Summary
- Adds a `get_sources` OpenWebUI tool that lets the model retrieve sources emitted during the current chat turn, to reduce hallucinated or malformed citations.
- Wires `roat_retrieval.py` and `mediawiki_tool.py` to stash their emitted sources on `__request__.state` so `get_sources` has data to read (per SK-20/MAIT-331: source-emitting tools require an update for the new tool to work).
- Ports `to_source_id()` slugification (new `source.id` field) into both tools, and `mediawiki_tool.py`'s `content_format` valve (wikitext/html/markdown via `markdownify`) and `_get_site_info()` (uses siteinfo's canonical `server` URL instead of reconstructing from scheme+host).
- Keeps `roat_retrieval.py`'s MAIT-299 `<document>` XML tag + YAML frontmatter hardening (prompt-injection protection via `_escape_document_tags`) — did not port the reference implementation's reversion to the older `[Source: name]` format.

**Out of scope (deferred):** `tools/web_search.py` only exists on the unmerged `MAIT-306` branch, not `main`. Wiring it for `get_sources` is tracked as a follow-up once that branch merges.

New env flag: `TOOL_GET_SOURCES_ENABLED` (documented in `.env.openwebui.example`), off by default — no impact on existing deployments.

## Test plan
- [x] All changed Python files pass `py_compile`; `entrypoint.sh` passes `bash -n`; `get_sources.json` is valid JSON.
- [x] Unit-verified `get_sources.py`'s URL extraction/dedup logic against all four source shapes (roat with/without url, mediawiki, web_search) — fixed two bugs found in the reference implementation (operator-precedence URL-fallback bug, and slug/title being mislabeled as a URL).
- [x] Live-tested end-to-end in the running container: enabled `TOOL_GET_SOURCES_ENABLED`, confirmed all three tools install cleanly via entrypoint logs (`markdownify` resolves, no import errors), then via browser drove two chats (`openai/gpt-4.1-nano` and `wikiteq/centurion`) that triggered `search_wiki` followed by `get_sources` — confirmed 10 sources round-tripped correctly with real URLs (`URL: //en.wikipedia.org/wiki/JavaScript`).
- [ ] `roat_retrieval.py`'s changes are unit-tested but not live-tested (local ROAT knowledge base has no indexed data) — lower confidence on this path, flagged for reviewer awareness.