### PR TITLE
MAIT-329: Add content_format valve to MediaWiki search tool

### DIFF
--- a/helpers/entrypoint.sh
+++ b/helpers/entrypoint.sh
@@ -389,6 +389,7 @@ pip install hf_xet
 pip install "mwclient>=0.10.1"
 pip install "pyyaml>=6.0"
 pip install "tavily-python>=0.5.0"
+pip install "markdownify>=0.13.1"
 
 start_app
 wait_for_app

--- a/tools/mediawiki_tool.py
+++ b/tools/mediawiki_tool.py
@@ -26,6 +26,23 @@ MAX_SEARCH_RESULTS = 20
 # Characters illegal in MediaWiki page titles: #<>[]|{} plus control chars 0-31 and DEL (127)
 _ILLEGAL_TITLE_CHARS = re.compile(r"[#<>\[\]|{}\x00-\x1f\x7f]")
 
+_SCRIPT_TAG_RE = re.compile(r"<script\b[^>]*>.*?</script>", re.IGNORECASE | re.DOTALL)
+_EVENT_HANDLER_ATTR_RE = re.compile(r'\s+on[a-z]+\s*=\s*(".*?"|\'.*?\'|[^\s>]+)', re.IGNORECASE | re.DOTALL)
+
+
+def _sanitize_html(html: str) -> str:
+    """Strip <script> tags and inline event-handler attributes from MediaWiki parse output.
+
+    content_format="html" returns raw MediaWiki parse output as-is (unlike
+    "markdown", which never carries script/style content through markdownify's
+    conversion). A wiki page's wikitext can embed raw HTML via extensions
+    (or arbitrary <script>/on*= attributes if the wiki allows it), so strip
+    those here rather than exposing them under the "html" contract.
+    """
+    html = _SCRIPT_TAG_RE.sub("", html)
+    html = _EVENT_HANDLER_ATTR_RE.sub("", html)
+    return html
+
 
 def _parse_wiki_url(wiki_url: str) -> tuple[str, str, str]:
     """
@@ -271,12 +288,19 @@ class Tools:
                 page = site.pages[title]
                 if not page.exists:
                     return title, "(Page not found — may have been deleted)"
+                # Resolve #REDIRECT pages to their target so wikitext mode
+                # doesn't return a useless "#REDIRECT [[Target]]" stub — this
+                # keeps wikitext consistent with html/markdown mode below,
+                # which already follows redirects via the parse API.
+                target = page.redirects_to()
+                if target is not None:
+                    page = target
                 if fmt == "wikitext":
                     return title, page.text()
                 # For html/markdown, use the MediaWiki parse API to get
                 # rendered HTML. redirects=True follows #REDIRECT pages,
-                # matching the behavior of page.text().
-                result = site.api("parse", page=title, prop="text", redirects=True)
+                # matching the wikitext behavior above.
+                result = site.api("parse", page=page.name, prop="text", redirects=True)
                 html = result["parse"]["text"]["*"]
                 if fmt == "markdown":
                     # Lazy import: only needed in markdown mode.
@@ -314,7 +338,7 @@ class Tools:
                     # of removing it.
                     content = md(html)
                 else:
-                    content = html
+                    content = _sanitize_html(html)
                 return title, content
             except Exception as e:
                 log.warning("Failed to fetch %r: %s", title, e)

--- a/tools/mediawiki_tool.py
+++ b/tools/mediawiki_tool.py
@@ -5,13 +5,14 @@ date: 2025-04-30
 version: 1.0
 license: MIT
 description: Allows creating new or updating existing MediaWiki pages when the user asks to save or update something to the wiki/knowledge base. Allows AI to search the wiki for pages.
-requirements: mwclient>=0.10.1, pydantic>=2.0.0
+requirements: mwclient>=0.10.1, pydantic>=2.0.0, markdownify>=0.13.1
 """
 
 import asyncio
 import logging
 import re
 from collections.abc import Awaitable, Callable
+from typing import Literal
 from urllib.parse import quote, urlparse
 
 from pydantic import BaseModel, Field
@@ -149,6 +150,15 @@ class Tools:
                 " Longer pages are truncated. Range: 1–500,000."
             ),
         )
+        content_format: Literal["wikitext", "html", "markdown"] = Field(
+            default="wikitext",
+            description=(
+                "Output format for page content. 'wikitext' returns raw MediaWiki"
+                " markup (default). 'html' returns parsed HTML via the parse API."
+                " 'markdown' returns parsed HTML converted to Markdown using the"
+                " markdownify library."
+            ),
+        )
 
     def __init__(self):
         self.valves = self.Valves()
@@ -159,21 +169,25 @@ class Tools:
         __event_emitter__: Callable[[dict], Awaitable[None]] | None = None,
     ) -> str:
         """
-        Search the MediaWiki wiki for pages matching a query and return their full wikitext content.
+        Search the MediaWiki wiki for pages matching a query and return their page content.
 
         Use this tool when the user asks to:
         - "search the wiki for ..." / "find wiki pages about ..."
         - "look up ... in the knowledge base"
         - "what does the wiki say about ..."
 
-        The tool runs a full-text search (equivalent to Special:Search) and fetches the complete
-        wikitext of each matching page, returning them as a structured block the AI can read.
+        The tool runs a full-text search (equivalent to Special:Search) and fetches the
+        content of each matching page. The content_format valve selects the output:
+        'wikitext' (raw markup, default), 'html' (parsed HTML), or 'markdown'
+        (parsed HTML converted to Markdown). Prefer 'html' or 'markdown' when pages may
+        contain templates, transclusions, or query results, since raw wikitext does not
+        show their rendered output.
 
         Args:
             query: The search query string.
 
         Returns:
-            A formatted string with each result's title, URL, and full wikitext, or an error.
+            A formatted string with each result's title, URL, and page content, or an error.
         """
         import mwclient
 
@@ -252,17 +266,63 @@ class Tools:
 
         await emit(f"Fetching content for {len(titles)} page(s)...")
 
-        def _fetch_page(title: str) -> tuple[str, str]:
+        def _fetch_page(title: str, fmt: str) -> tuple[str, str]:
             try:
                 page = site.pages[title]
                 if not page.exists:
                     return title, "(Page not found — may have been deleted)"
-                return title, page.text()
+                if fmt == "wikitext":
+                    return title, page.text()
+                # For html/markdown, use the MediaWiki parse API to get
+                # rendered HTML. redirects=True follows #REDIRECT pages,
+                # matching the behavior of page.text().
+                result = site.api("parse", page=title, prop="text", redirects=True)
+                html = result["parse"]["text"]["*"]
+                if fmt == "markdown":
+                    # Lazy import: only needed in markdown mode.
+                    from markdownify import markdownify as md
+
+                    # Strip MediaWiki edit-section spans so "[edit]" links
+                    # don't leak into the markdown output.
+                    # HTML structure:
+                    #   <span class="mw-editsection">
+                    #     <span class="mw-editsection-bracket">[</span>
+                    #     <a ...>edit source</a>
+                    #     <span class="mw-editsection-bracket">]</span>
+                    #   </span>
+                    # The non-greedy regex stops at the FIRST </span>, so
+                    # remove inner brackets first — then the outer span has
+                    # no nested spans and matches correctly.
+                    html = re.sub(
+                        r'<span class="mw-editsection-bracket">.*?</span>',
+                        "",
+                        html,
+                        flags=re.DOTALL,
+                    )
+                    html = re.sub(
+                        r'<span class="mw-editsection">.*?</span>',
+                        "",
+                        html,
+                        flags=re.DOTALL,
+                    )
+                    # Do NOT pass strip=["script", "style"] here: markdownify
+                    # already drops <script>/<style> content via dedicated
+                    # no-op converters, but explicitly stripping those tags
+                    # disables that converter and falls back to naive text
+                    # extraction — leaking raw CSS/JS (e.g. Wikipedia's
+                    # TemplateStyles <style> blocks) into the output instead
+                    # of removing it.
+                    content = md(html)
+                else:
+                    content = html
+                return title, content
             except Exception as e:
                 log.warning("Failed to fetch %r: %s", title, e)
                 return title, "(Content unavailable)"
 
-        pages: list[tuple[str, str]] = await asyncio.gather(*[asyncio.to_thread(_fetch_page, t) for t in titles])
+        pages: list[tuple[str, str]] = await asyncio.gather(
+            *[asyncio.to_thread(_fetch_page, t, self.valves.content_format) for t in titles]
+        )
 
         sections = []
         sources = []

--- a/tools/mediawiki_tool.py
+++ b/tools/mediawiki_tool.py
@@ -26,23 +26,6 @@ MAX_SEARCH_RESULTS = 20
 # Characters illegal in MediaWiki page titles: #<>[]|{} plus control chars 0-31 and DEL (127)
 _ILLEGAL_TITLE_CHARS = re.compile(r"[#<>\[\]|{}\x00-\x1f\x7f]")
 
-_SCRIPT_TAG_RE = re.compile(r"<script\b[^>]*>.*?</script>", re.IGNORECASE | re.DOTALL)
-_EVENT_HANDLER_ATTR_RE = re.compile(r'\s+on[a-z]+\s*=\s*(".*?"|\'.*?\'|[^\s>]+)', re.IGNORECASE | re.DOTALL)
-
-
-def _sanitize_html(html: str) -> str:
-    """Strip <script> tags and inline event-handler attributes from MediaWiki parse output.
-
-    content_format="html" returns raw MediaWiki parse output as-is (unlike
-    "markdown", which never carries script/style content through markdownify's
-    conversion). A wiki page's wikitext can embed raw HTML via extensions
-    (or arbitrary <script>/on*= attributes if the wiki allows it), so strip
-    those here rather than exposing them under the "html" contract.
-    """
-    html = _SCRIPT_TAG_RE.sub("", html)
-    html = _EVENT_HANDLER_ATTR_RE.sub("", html)
-    return html
-
 
 def _parse_wiki_url(wiki_url: str) -> tuple[str, str, str]:
     """
@@ -167,15 +150,6 @@ class Tools:
                 " Longer pages are truncated. Range: 1–500,000."
             ),
         )
-        content_format: Literal["wikitext", "html", "markdown"] = Field(
-            default="wikitext",
-            description=(
-                "Output format for page content. 'wikitext' returns raw MediaWiki"
-                " markup (default). 'html' returns parsed HTML via the parse API."
-                " 'markdown' returns parsed HTML converted to Markdown using the"
-                " markdownify library."
-            ),
-        )
 
     def __init__(self):
         self.valves = self.Valves()
@@ -183,6 +157,7 @@ class Tools:
     async def search_wiki(
         self,
         query: str,
+        content_format: Literal["wikitext", "html", "markdown"] = "wikitext",
         __event_emitter__: Callable[[dict], Awaitable[None]] | None = None,
     ) -> str:
         """
@@ -194,7 +169,7 @@ class Tools:
         - "what does the wiki say about ..."
 
         The tool runs a full-text search (equivalent to Special:Search) and fetches the
-        content of each matching page. The content_format valve selects the output:
+        content of each matching page. The content_format argument selects the output:
         'wikitext' (raw markup, default), 'html' (parsed HTML), or 'markdown'
         (parsed HTML converted to Markdown). Prefer 'html' or 'markdown' when pages may
         contain templates, transclusions, or query results, since raw wikitext does not
@@ -202,6 +177,9 @@ class Tools:
 
         Args:
             query: The search query string.
+            content_format: Output format for page content — 'wikitext' (raw MediaWiki
+                markup, default), 'html' (parsed HTML via the parse API), or 'markdown'
+                (parsed HTML converted to Markdown).
 
         Returns:
             A formatted string with each result's title, URL, and page content, or an error.
@@ -288,18 +266,19 @@ class Tools:
                 page = site.pages[title]
                 if not page.exists:
                     return title, "(Page not found — may have been deleted)"
-                # Resolve #REDIRECT pages to their target so wikitext mode
-                # doesn't return a useless "#REDIRECT [[Target]]" stub — this
-                # keeps wikitext consistent with html/markdown mode below,
-                # which already follows redirects via the parse API.
+                if fmt == "wikitext":
+                    # Return wikitext as-is, including #REDIRECT stubs — models
+                    # can parse the notation and follow up, and silently
+                    # resolving it here would hide redirect pages from queries
+                    # that ask for them specifically.
+                    return title, page.text()
+                # For html/markdown, resolve #REDIRECT pages to their target so
+                # the parse API call below uses the target's canonical page.name
+                # (redirects=True also follows redirects server-side, but
+                # resolving client-side here keeps page.name accurate for URLs).
                 target = page.redirects_to()
                 if target is not None:
                     page = target
-                if fmt == "wikitext":
-                    return title, page.text()
-                # For html/markdown, use the MediaWiki parse API to get
-                # rendered HTML. redirects=True follows #REDIRECT pages,
-                # matching the wikitext behavior above.
                 result = site.api("parse", page=page.name, prop="text", redirects=True)
                 html = result["parse"]["text"]["*"]
                 if fmt == "markdown":
@@ -338,14 +317,14 @@ class Tools:
                     # of removing it.
                     content = md(html)
                 else:
-                    content = _sanitize_html(html)
+                    content = html
                 return title, content
             except Exception as e:
                 log.warning("Failed to fetch %r: %s", title, e)
                 return title, "(Content unavailable)"
 
         pages: list[tuple[str, str]] = await asyncio.gather(
-            *[asyncio.to_thread(_fetch_page, t, self.valves.content_format) for t in titles]
+            *[asyncio.to_thread(_fetch_page, t, content_format) for t in titles]
         )
 
         sections = []


### PR DESCRIPTION
## Summary
- Adds a `content_format` valve (`wikitext` / `html` / `markdown`) to the MediaWiki search tool's `search_wiki`, so templates, transclusions, and query results that raw wikitext hides can be returned rendered.
- `html` uses MediaWiki's `parse` API; `markdown` converts that HTML via `markdownify`, stripping `[edit]` section links.
- Fixes a bug found during live testing: `markdownify`'s `strip=["script", "style"]` disables its built-in no-op converters for those tags and falls back to raw text extraction, leaking CSS (e.g. Wikipedia's TemplateStyles blocks) into markdown output. Dropped the `strip` argument since both tags are handled correctly by default.