### PR TITLE
MAIT-341: Remove OWUI upgrade note from SSO docs

### DIFF
--- a/docs/configuration/sso.mdx
+++ b/docs/configuration/sso.mdx
@@ -11,13 +11,6 @@ keywords:
   - authentication
 ---
 
-<Note>
-  Verified against OpenWebUI **open-webui:0.6.5**. If you upgrade the image version in
-  `compose.yaml`, re-verify env var names against the new version before enabling SSO —
-  variable names can change between releases. Check the OpenWebUI changelog and update
-  this doc accordingly.
-</Note>
-
 mAItion inherits OpenWebUI's SSO support. Authentication is configured via environment
 variables in your `.env` file (copied from `.env.openwebui.example`). No application code
 changes are needed.


### PR DESCRIPTION
## Summary
- Removes the `<Note>` block in `docs/configuration/sso.mdx` that instructed users to re-verify env var names if they upgrade OpenWebUI beyond `open-webui:0.6.5`
- mAItion doesn't support OWUI versions higher than 0.6.5, so this "if you upgrade" caveat was misleading

## Jira
https://wikiteq.atlassian.net/browse/MAIT-341