### PR TITLE
Update rag-of-all-trades image to bcdfb51

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -94,7 +94,7 @@ services:
 
   # rag-of-all-trades API
   api:
-    image: ghcr.io/wikiteq/rag-of-all-trades:2c89efa
+    image: ghcr.io/wikiteq/rag-of-all-trades:bcdfb51
     extra_hosts:
       - "host.docker.internal:host-gateway"
     depends_on:
@@ -118,7 +118,7 @@ services:
 
   # rag-of-all-trades WORKER
   celery_worker:
-    image: ghcr.io/wikiteq/rag-of-all-trades:2c89efa
+    image: ghcr.io/wikiteq/rag-of-all-trades:bcdfb51
     extra_hosts:
       - "host.docker.internal:host-gateway"
     depends_on:
@@ -144,7 +144,7 @@ services:
 
   # rag-of-all-trades BEAT
   celery_beat:
-    image: ghcr.io/wikiteq/rag-of-all-trades:2c89efa
+    image: ghcr.io/wikiteq/rag-of-all-trades:bcdfb51
     depends_on:
       postgres:
         condition: service_healthy


### PR DESCRIPTION
## Summary
- Bumps `rag-of-all-trades` image tag to `bcdfb51` across all three services (`api`, `celery_worker`, `celery_beat`) in `compose.yaml`

[MAIT-138]

[MAIT-138]: https://wikiteq.atlassian.net/browse/MAIT-138?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ