### PR TITLE
Replicate model mount and CREATE_CUSTOM_WORKSPACE_MODEL changes from open-web-ui

### DIFF
--- a/.env.openwebui.example
+++ b/.env.openwebui.example
@@ -38,9 +38,12 @@ OPENAI_API_BASE_URL=https://openrouter.ai/api/v1
 OPENAI_API_KEY=sk-or-v1-xxxxxxxxx
 # replace with your desired model!
 OPENAI_DEFAULT_MODEL=openai/gpt-4.1-nano
-# set to "True" to make the default model private and create a public Workspace model on first boot
+# CREATE_CUSTOM_WORKSPACE_MODEL="True" installs the bundled wikiteqcenturion.json
+# (kept for backward compatibility). Set it to a filename under models/
+# (e.g. "wikiteqcenturion.json") to install a different bundled model instead.
+# "False" or unset installs no custom workspace model.
 # CREATE_CUSTOM_WORKSPACE_MODEL=True
-# Model system prompt override/extension (optional, applies when CREATE_CUSTOM_WORKSPACE_MODEL=True):
+# Model system prompt override/extension (optional, applies whenever CREATE_CUSTOM_WORKSPACE_MODEL installs a model):
 # - OWUI_MODEL_PROMPT fully replaces the bundled system prompt
 # - OWUI_MODEL_PROMPT_APPEND appends to the bundled (or overridden) system prompt, separated by a blank line
 #OWUI_MODEL_PROMPT=

--- a/compose.yaml
+++ b/compose.yaml
@@ -24,7 +24,7 @@ services:
       - ./tools/web_search.json:/etc/web_search.json
       - ./functions/video_inject.py:/etc/video_inject.py
       - ./functions/video_inject.json:/etc/video_inject.json
-      - ./models/wikiteqcenturion.json:/etc/wikiteqcenturion.json:ro
+      - ./models:/etc/owui-models:ro
       - ./helpers/entrypoint.sh:/custom-entrypoint.sh
       - ./helpers/healthz.py:/etc/healthz.py
       - ./patches:/etc/patches

--- a/helpers/entrypoint.sh
+++ b/helpers/entrypoint.sh
@@ -173,6 +173,19 @@ do_first_start() {
               --data-raw "{\"ui\":{\"version\":\"0.6.5\",\"models\":[\"$OPENAI_DEFAULT_MODEL\"]}}"
 
             if [ "$CREATE_CUSTOM_WORKSPACE_MODEL" == "True" ]; then
+                WORKSPACE_MODEL_FILE="wikiteqcenturion.json"
+            elif [ "$CREATE_CUSTOM_WORKSPACE_MODEL" == "False" ] || [ -z "$CREATE_CUSTOM_WORKSPACE_MODEL" ]; then
+                WORKSPACE_MODEL_FILE=""
+            else
+                WORKSPACE_MODEL_FILE="$CREATE_CUSTOM_WORKSPACE_MODEL"
+            fi
+
+            if [ -n "$WORKSPACE_MODEL_FILE" ]; then
+                if [ ! -f "/etc/owui-models/${WORKSPACE_MODEL_FILE}" ]; then
+                    echo "[Custom entrypoint] ERROR: CREATE_CUSTOM_WORKSPACE_MODEL is set to '${CREATE_CUSTOM_WORKSPACE_MODEL}' but /etc/owui-models/${WORKSPACE_MODEL_FILE} was not found" >&2
+                    exit 1
+                fi
+
                 echo ""
                 echo "[Custom entrypoint] Making default model private"
                 curl -s -X POST "http://localhost:8080/api/v1/models/create" \
@@ -185,7 +198,7 @@ do_first_start() {
                 WORKSPACE_MODEL_DATA=$(jq \
                   --arg base_model "$OPENAI_DEFAULT_MODEL" \
                   '.[0].base_model_id = $base_model | .[0]' \
-                  "/etc/wikiteqcenturion.json")
+                  "/etc/owui-models/${WORKSPACE_MODEL_FILE}")
 
                 if [ -n "$OWUI_MODEL_PROMPT" ]; then
                     WORKSPACE_MODEL_DATA=$(echo "${WORKSPACE_MODEL_DATA}" | jq \

--- a/helpers/entrypoint.sh
+++ b/helpers/entrypoint.sh
@@ -77,6 +77,22 @@ do_first_start() {
     echo ""
     echo "[Custom entrypoint] First start detected.."
 
+    # Resolve and validate the custom workspace model file up front, before any
+    # API calls are made, so a bad CREATE_CUSTOM_WORKSPACE_MODEL value stops
+    # initialization cleanly with no side effects (signup, tool/provider setup, etc).
+    if [ "$CREATE_CUSTOM_WORKSPACE_MODEL" == "True" ]; then
+        WORKSPACE_MODEL_FILE="wikiteqcenturion.json"
+    elif [ "$CREATE_CUSTOM_WORKSPACE_MODEL" == "False" ] || [ -z "$CREATE_CUSTOM_WORKSPACE_MODEL" ]; then
+        WORKSPACE_MODEL_FILE=""
+    else
+        WORKSPACE_MODEL_FILE="$CREATE_CUSTOM_WORKSPACE_MODEL"
+    fi
+
+    if [ -n "$WORKSPACE_MODEL_FILE" ] && [ ! -f "/etc/owui-models/${WORKSPACE_MODEL_FILE}" ]; then
+        echo "[Custom entrypoint] ERROR: CREATE_CUSTOM_WORKSPACE_MODEL is set to '${CREATE_CUSTOM_WORKSPACE_MODEL}' but /etc/owui-models/${WORKSPACE_MODEL_FILE} was not found" >&2
+        exit 1
+    fi
+
     echo ""
     echo "[Custom entrypoint] Sign up default admin user ..."
     SIGNUP_RESPONSE=$(curl -s -X POST "http://localhost:8080/api/v1/auths/signup" \
@@ -172,20 +188,7 @@ do_first_start() {
               -H "Content-Type: application/json" \
               --data-raw "{\"ui\":{\"version\":\"0.6.5\",\"models\":[\"$OPENAI_DEFAULT_MODEL\"]}}"
 
-            if [ "$CREATE_CUSTOM_WORKSPACE_MODEL" == "True" ]; then
-                WORKSPACE_MODEL_FILE="wikiteqcenturion.json"
-            elif [ "$CREATE_CUSTOM_WORKSPACE_MODEL" == "False" ] || [ -z "$CREATE_CUSTOM_WORKSPACE_MODEL" ]; then
-                WORKSPACE_MODEL_FILE=""
-            else
-                WORKSPACE_MODEL_FILE="$CREATE_CUSTOM_WORKSPACE_MODEL"
-            fi
-
             if [ -n "$WORKSPACE_MODEL_FILE" ]; then
-                if [ ! -f "/etc/owui-models/${WORKSPACE_MODEL_FILE}" ]; then
-                    echo "[Custom entrypoint] ERROR: CREATE_CUSTOM_WORKSPACE_MODEL is set to '${CREATE_CUSTOM_WORKSPACE_MODEL}' but /etc/owui-models/${WORKSPACE_MODEL_FILE} was not found" >&2
-                    exit 1
-                fi
-
                 echo ""
                 echo "[Custom entrypoint] Making default model private"
                 curl -s -X POST "http://localhost:8080/api/v1/models/create" \


### PR DESCRIPTION
## Summary
- Mounts the whole `models/` directory (`./models:/etc/owui-models:ro`) instead of a single bind-mount per model file.
- Changes `CREATE_CUSTOM_WORKSPACE_MODEL` from a boolean to a string filename, with a file-existence check that fails clearly if the configured model isn't found. `"True"` still defaults to `wikiteqcenturion.json` for backward compatibility.
- Updates `.env.openwebui.example` to document the new behavior.

[SK-30]


[SK-30]: https://wikiteq.atlassian.net/browse/SK-30?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ