### PR TITLE
Update rag-of-all-trades image to 938e1c9

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -96,7 +96,7 @@ services:
 
   # rag-of-all-trades API
   api:
-    image: ghcr.io/wikiteq/rag-of-all-trades:bcdfb51
+    image: ghcr.io/wikiteq/rag-of-all-trades:938e1c9
     extra_hosts:
       - "host.docker.internal:host-gateway"
     depends_on:
@@ -120,7 +120,7 @@ services:
 
   # rag-of-all-trades WORKER
   celery_worker:
-    image: ghcr.io/wikiteq/rag-of-all-trades:bcdfb51
+    image: ghcr.io/wikiteq/rag-of-all-trades:938e1c9
     extra_hosts:
       - "host.docker.internal:host-gateway"
     depends_on:
@@ -146,7 +146,7 @@ services:
 
   # rag-of-all-trades BEAT
   celery_beat:
-    image: ghcr.io/wikiteq/rag-of-all-trades:bcdfb51
+    image: ghcr.io/wikiteq/rag-of-all-trades:938e1c9
     depends_on:
       postgres:
         condition: service_healthy


### PR DESCRIPTION
## Summary
- Bumps `rag-of-all-trades` image tag to `938e1c9` across all three services (`api`, `celery_worker`, `celery_beat`) in `compose.yaml`