### PR TITLE
SK-25: Show YouTube videos as a thumbnail and link, not a broken <video> tag

### DIFF
--- a/functions/video_inject.py
+++ b/functions/video_inject.py
@@ -2,19 +2,61 @@
 title: Video Inject Filter
 author: WikiTeq
 date: 2025-05-20
-version: 1.0
+version: 1.1
 license: MIT
-description: Reads VIDEO markers from tool messages and appends an inline <video> player after the assistant response.
+description: Reads VIDEO markers from tool messages and appends an inline player after the assistant response. Direct video file URLs use an HTML5 <video> tag; YouTube URLs use a clickable thumbnail linking out to YouTube (OWUI strips raw <iframe> embeds, so an inline player isn't available for YouTube on our pinned version).
 """
 
 import logging
 import re
 from html import escape as html_escape
 from html import unescape
+from urllib.parse import parse_qs, urlparse
 
 from pydantic import BaseModel
 
 log = logging.getLogger(__name__)
+
+YOUTUBE_HOSTS = {
+    "youtube.com",
+    "www.youtube.com",
+    "m.youtube.com",
+    "youtube-nocookie.com",
+    "www.youtube-nocookie.com",
+}
+_VIDEO_ID_RE = re.compile(r"^[\w-]{11}$")
+
+
+def _extract_youtube_id(video_url: str) -> tuple[str | None, str | None]:
+    """Return (video_id, start_time) if video_url is a YouTube URL, else (None, None).
+
+    Handles watch/shorts/embed/live/youtu.be shapes, `v=` anywhere in the
+    query string, and preserves a `t=`/`start=` timestamp if present.
+    """
+    try:
+        parsed = urlparse(video_url)
+    except ValueError:
+        return None, None
+
+    host = parsed.hostname or ""
+    video_id = None
+
+    if host == "youtu.be":
+        video_id = parsed.path.lstrip("/").split("/")[0]
+    elif host in YOUTUBE_HOSTS:
+        path_parts = [p for p in parsed.path.split("/") if p]
+        if path_parts and path_parts[0] in ("shorts", "embed", "live") and len(path_parts) > 1:
+            video_id = path_parts[1]
+        elif parsed.path in ("/watch", "/"):
+            query = parse_qs(parsed.query)
+            video_id = (query.get("v") or [None])[0]
+
+    if not video_id or not _VIDEO_ID_RE.match(video_id):
+        return None, None
+
+    query = parse_qs(parsed.query)
+    start_time = (query.get("t") or query.get("start") or [None])[0]
+    return video_id, start_time
 
 
 class Filter:
@@ -75,11 +117,34 @@ class Filter:
                     if isinstance(part, dict) and isinstance(part.get("text"), str):
                         part["text"] = strip_markers(part["text"])
 
-        safe_url = html_escape(video_url, quote=True)
-        ext = video_url.rsplit(".", 1)[-1].split("?")[0].lower()
-        mime_types = {"mp4": "video/mp4", "webm": "video/webm", "ogg": "video/ogg", "mov": "video/quicktime"}
-        mime = mime_types.get(ext, "video/mp4")
-        video_block = f'<video controls style="max-width:100%">\n<source src="{safe_url}" type="{mime}">\n</video>'
+        video_id, start_time = _extract_youtube_id(video_url)
+        if video_id:
+            watch_url = f"https://www.youtube.com/watch?v={video_id}"
+            if start_time:
+                watch_url += f"&t={start_time}"
+            safe_watch_url = html_escape(watch_url, quote=True)
+            safe_thumb_url = html_escape(f"https://img.youtube.com/vi/{video_id}/hqdefault.jpg", quote=True)
+            # Note: OWUI's markdown renderer only special-cases raw HTML blocks
+            # containing "<video" — any other raw HTML (e.g. a plain <img>) is
+            # printed as literal text, not rendered. Use markdown image/link
+            # syntax instead; marked renders both natively.
+            #
+            # The thumbnail is deliberately NOT wrapped in a link to the video:
+            # OWUI renders every markdown image through its own lightbox
+            # component, and wrapping it in an <a> caused the lightbox to load
+            # the YouTube watch page inside the overlay while a second tab also
+            # opened — a confusing double-open. The plain "Watch on YouTube"
+            # link below is the only clickable way to reach the video.
+            video_block = (
+                f"![YouTube video thumbnail]({safe_thumb_url})\n\n"
+                f"[▶ Watch on YouTube]({safe_watch_url})"
+            )
+        else:
+            safe_url = html_escape(video_url, quote=True)
+            ext = video_url.rsplit(".", 1)[-1].split("?")[0].lower()
+            mime_types = {"mp4": "video/mp4", "webm": "video/webm", "ogg": "video/ogg", "mov": "video/quicktime"}
+            mime = mime_types.get(ext, "video/mp4")
+            video_block = f'<video controls style="max-width:100%">\n<source src="{safe_url}" type="{mime}">\n</video>'
 
         for msg in reversed(messages):
             if msg.get("role") == "assistant" and isinstance(msg.get("content"), str):

--- a/functions/video_inject.py
+++ b/functions/video_inject.py
@@ -11,7 +11,7 @@ import logging
 import re
 from html import escape as html_escape
 from html import unescape
-from urllib.parse import parse_qs, urlparse
+from urllib.parse import parse_qs, urlencode, urlparse
 
 from pydantic import BaseModel
 
@@ -119,9 +119,10 @@ class Filter:
 
         video_id, start_time = _extract_youtube_id(video_url)
         if video_id:
-            watch_url = f"https://www.youtube.com/watch?v={video_id}"
+            query_params = {"v": video_id}
             if start_time:
-                watch_url += f"&t={start_time}"
+                query_params["t"] = start_time
+            watch_url = f"https://www.youtube.com/watch?{urlencode(query_params)}"
             safe_watch_url = html_escape(watch_url, quote=True)
             safe_thumb_url = html_escape(f"https://img.youtube.com/vi/{video_id}/hqdefault.jpg", quote=True)
             # Note: OWUI's markdown renderer only special-cases raw HTML blocks


### PR DESCRIPTION
## What

A `<video>` tag cannot play a YouTube URL. The filter now shows a thumbnail
image and a "Watch on YouTube" link for these URLs instead. Other video
URLs still use the old `<video>` tag.

## Why

This PR follows SK-4 (`cf704e3`, PR #66). That PR added `<video>` tag
support. SK-25 has the full investigation. We ruled out iframe and Rich-UI
embedding. Our OWUI version (0.6.5) does not support Rich-UI. A backport
would take real effort. The stakeholder decided to ship a thumbnail for
now.

## Two OWUI quirks found and worked around

- OWUI's markdown renderer only renders raw HTML that contains `<video`.
  It prints other raw HTML as plain text. Markdown image and link syntax
  avoids this problem.
- OWUI wraps every markdown image in a lightbox, even when the image is
  also a link. A linked thumbnail made the lightbox load the YouTube page.
  A second tab opened too. The thumbnail is now a plain image. It is not
  a link. Only the text link opens the video.

## Also

- The link now keeps the video's start time, if the source URL has one.
- The filter now matches more YouTube URL shapes: `shorts/`, `embed/`,
  `live/`, `youtu.be/`, and `youtube-nocookie.com`. It also finds `v=`
  anywhere in the query string, not just first.