### PR TITLE
Update rag-of-all-trades image to 01d6a7d

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -98,7 +98,7 @@ services:
 
   # rag-of-all-trades API
   api:
-    image: ghcr.io/wikiteq/rag-of-all-trades:9d60ff7
+    image: ghcr.io/wikiteq/rag-of-all-trades:01d6a7d
     extra_hosts:
       - "host.docker.internal:host-gateway"
     depends_on:
@@ -122,7 +122,7 @@ services:
 
   # rag-of-all-trades WORKER
   celery_worker:
-    image: ghcr.io/wikiteq/rag-of-all-trades:9d60ff7
+    image: ghcr.io/wikiteq/rag-of-all-trades:01d6a7d
     extra_hosts:
       - "host.docker.internal:host-gateway"
     depends_on:
@@ -148,7 +148,7 @@ services:
 
   # rag-of-all-trades BEAT
   celery_beat:
-    image: ghcr.io/wikiteq/rag-of-all-trades:9d60ff7
+    image: ghcr.io/wikiteq/rag-of-all-trades:01d6a7d
     depends_on:
       postgres:
         condition: service_healthy


### PR DESCRIPTION
## Summary
- Bumps `rag-of-all-trades` image tag to `01d6a7d` across all three services (`api`, `celery_worker`, `celery_beat`) in `compose.yaml`