### PR TITLE
Update rag-of-all-trades image to 01332c8

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -98,7 +98,7 @@ services:
 
   # rag-of-all-trades API
   api:
-    image: ghcr.io/wikiteq/rag-of-all-trades:01d6a7d
+    image: ghcr.io/wikiteq/rag-of-all-trades:01332c8
     extra_hosts:
       - "host.docker.internal:host-gateway"
     depends_on:
@@ -122,7 +122,7 @@ services:
 
   # rag-of-all-trades WORKER
   celery_worker:
-    image: ghcr.io/wikiteq/rag-of-all-trades:01d6a7d
+    image: ghcr.io/wikiteq/rag-of-all-trades:01332c8
     extra_hosts:
       - "host.docker.internal:host-gateway"
     depends_on:
@@ -148,7 +148,7 @@ services:
 
   # rag-of-all-trades BEAT
   celery_beat:
-    image: ghcr.io/wikiteq/rag-of-all-trades:01d6a7d
+    image: ghcr.io/wikiteq/rag-of-all-trades:01332c8
     depends_on:
       postgres:
         condition: service_healthy


### PR DESCRIPTION
## Summary
- Bumps `rag-of-all-trades` image tag to `01332c8` across all three services (`api`, `celery_worker`, `celery_beat`) in `compose.yaml`