### PR TITLE
Document workspace models format & bootstrapping (WIK-2591)

### DIFF
--- a/docs/configuration/workspace-models.mdx
+++ b/docs/configuration/workspace-models.mdx
@@ -57,8 +57,12 @@ Separately from `CREATE_CUSTOM_WORKSPACE_MODEL`, the entrypoint also registers
 model file was selected:
 
 - If a custom model file **is** selected, the default model is created **private**,
-  and the custom model file becomes the public-facing model instead (with its
-  `base_model_id` pointed at the default model — see below).
+  and the custom model file is installed in its place (with its `base_model_id`
+  pointed at the default model — see below). The custom model's own visibility is
+  not set by the entrypoint — it comes from the `access_control` value already in
+  the file. `access_control: null`, as in the bundled `wikiteqcenturion.json`,
+  means OpenWebUI's default visibility rules apply (in practice, public). A file
+  with a restrictive `access_control` object stays restricted.
 - If no custom model file is selected, the default model is created **public**.
 
 Both cases require first-start bootstrap to run, `ENABLE_OPENAI_API=True`, and

--- a/docs/configuration/workspace-models.mdx
+++ b/docs/configuration/workspace-models.mdx
@@ -1,0 +1,154 @@
+---
+title: "Workspace Models"
+description: "How mAItion installs a custom workspace model from ./models on first boot, the JSON file format, and how to add your own."
+keywords:
+  - mAItion
+  - workspace model
+  - bootstrap
+  - models
+  - OpenWebUI
+---
+
+mAItion can install one custom OpenWebUI **workspace model** automatically the first
+time the stack boots. This page explains the mechanism, the JSON file format, and how
+to add a model of your own.
+
+## Overview
+
+The `./models` directory is mounted read-only into the `openwebui` container at
+`/etc/owui-models` (see `compose.yaml`). On first boot, the custom entrypoint can take
+one JSON file from that directory and install it as a private workspace model tied to
+your default OpenAI-compatible model.
+
+The repository ships one example: `models/wikiteqcenturion.json`.
+
+## How It Works
+
+The bootstrap logic lives in `helpers/entrypoint.sh` and runs only when both of these
+are true:
+
+- `ENABLE_OPENAI_API=True`
+- `OPENAI_DEFAULT_MODEL` is set to a non-empty model ID
+
+It also runs only on **first start**. The entrypoint tracks this with a
+`/app/backend/data/.first_start` sentinel file, not by checking whether the database is
+empty. In practice: a fresh database with an existing sentinel file does not
+re-trigger the bootstrap, and an existing database without the sentinel file can
+trigger it again.
+
+### Selecting a model file
+
+`CREATE_CUSTOM_WORKSPACE_MODEL` controls which file installs, if any:
+
+- `True` installs the bundled `wikiteqcenturion.json` (kept for backward
+  compatibility).
+- Any other non-empty value is treated as a filename under `models/` — for example
+  `CREATE_CUSTOM_WORKSPACE_MODEL=my-model.json` installs `models/my-model.json`.
+- `False` or unset installs no custom model.
+
+The entrypoint validates the selected file exists **before** doing anything else —
+including before it signs up the admin user or configures any provider. If the file is
+missing, the container exits immediately with an error and no side effects.
+
+### What happens to the default model
+
+Separately from `CREATE_CUSTOM_WORKSPACE_MODEL`, the entrypoint also registers
+`OPENAI_DEFAULT_MODEL` as a workspace model. Its visibility depends on whether a custom
+model file was selected:
+
+- If a custom model file **is** selected, the default model is created **private**,
+  and the custom model file becomes the public-facing model instead (with its
+  `base_model_id` pointed at the default model — see below).
+- If no custom model file is selected, the default model is created **public**.
+
+Both cases require first-start bootstrap to run, `ENABLE_OPENAI_API=True`, and
+`OPENAI_DEFAULT_MODEL` to be set — this is not unconditional behavior.
+
+### Runtime overrides
+
+A few environment variables modify the installed model before it's created:
+
+- The entrypoint always overwrites the file's `base_model_id` with
+  `OPENAI_DEFAULT_MODEL` at runtime. Whatever value the file itself has for
+  `base_model_id` is ignored.
+- `OWUI_MODEL_PROMPT`, if set, fully replaces the file's `params.system` prompt.
+- `OWUI_MODEL_PROMPT_APPEND`, if set, appends to the system prompt (bundled or
+  already replaced by `OWUI_MODEL_PROMPT`), separated by a blank line.
+- `TOOL_MEDIAWIKI_ENABLED=True` adds `"mediawiki"` to the model's `meta.toolIds`
+  list. This only adds the tool ID to the model definition — it does not by itself
+  confirm that the MediaWiki tool installed successfully, which additionally requires
+  `MEDIAWIKI_API_URL` to be set. Check that the tool actually appears under the
+  model in the OpenWebUI workspace.
+
+### A note on reliability
+
+The bootstrap calls the OpenWebUI API with plain `curl -s`, without response-status
+checking. A failed call (bad admin credentials, a transient network error) does not
+necessarily stop the script or produce a visible error. After first boot, confirm the
+model appears as expected in the OpenWebUI workspace rather than assuming a clean log
+means success.
+
+## JSON File Format
+
+A custom model file must be a **JSON array**, with the model definition as the array's
+first item — the entrypoint reads and installs only `.[0]` of the file. A file shaped
+as a bare JSON object instead of an array will not install correctly.
+
+The following table documents the fields present in the bundled
+`models/wikiteqcenturion.json` example:
+
+| Field | Required | Default | Description |
+|---|---|---|---|
+| `id` | Yes | — | Unique model identifier used internally by OpenWebUI. |
+| `user_id` | No | `""` | Owning user ID. Leave blank; not needed for bootstrap-installed models. |
+| `base_model_id` | No | — | Ignored at install time — the entrypoint always overwrites this with `OPENAI_DEFAULT_MODEL`. |
+| `name` | Yes | — | Display name shown in the OpenWebUI model picker. |
+| `params.function_calling` | No | — | Function-calling mode, e.g. `"native"`. |
+| `params.system` | No | — | System prompt. Replaced by `OWUI_MODEL_PROMPT` or extended by `OWUI_MODEL_PROMPT_APPEND` if set. |
+| `params.reasoning_effort` | No | — | Reasoning effort hint for models that support it, e.g. `"medium"`. |
+| `meta.profile_image_url` | No | — | Avatar image for the model. Can be a data URI (base64-encoded image) or a static path. |
+| `meta.description` | No | `null` | Short description shown in the model picker. |
+| `meta.capabilities.vision` | No | `false` | Whether the model accepts image input. |
+| `meta.capabilities.usage` | No | `false` | Whether token usage is reported to the user. |
+| `meta.capabilities.citations` | No | `true` | Whether source citations are shown. |
+| `meta.suggestion_prompts` | No | `null` | Optional list of starter prompt suggestions. |
+| `meta.tags` | No | `[]` | Optional tag list for the model. |
+| `meta.toolIds` | No | `[]` | Tool IDs attached to the model (e.g. `roat_retrieval`). `TOOL_MEDIAWIKI_ENABLED=True` appends `"mediawiki"` to this list. |
+| `access_control` | No | `null` | OpenWebUI access-control object. `null` means default visibility rules apply. |
+| `is_active` | No | `true` | Whether the model is active/selectable. |
+| `created_at` | No | — | Export timestamp from OpenWebUI. Not meaningful to set by hand. |
+| `updated_at` | No | — | Export timestamp from OpenWebUI. Not meaningful to set by hand. |
+| `user` | No | `{}` | Export metadata about the owning user. Not meaningful to set by hand. |
+
+## Configuration Reference
+
+These environment variables (in `.env`, copied from `.env.openwebui.example`) control
+workspace model bootstrapping. `ENABLE_OPENAI_API` and `OPENAI_DEFAULT_MODEL` are also
+documented in [Environment Variables (Frontend)](/configuration/frontend-env) — they're
+repeated here because both are required for any of the workspace-model behavior on this
+page to run at all.
+
+| Field | Required | Default | Description |
+|---|---|---|---|
+| `ENABLE_OPENAI_API` | Yes, for this feature | `False` | Must be exactly `True` for workspace model bootstrap to run at all. |
+| `OPENAI_DEFAULT_MODEL` | Yes, for this feature | — | Must be a non-empty model ID. Used as `base_model_id` for any installed custom model. |
+| `CREATE_CUSTOM_WORKSPACE_MODEL` | No | unset | `True` installs the bundled `wikiteqcenturion.json`. A filename installs that file from `models/` instead. `False`/unset installs no custom model. |
+| `OWUI_MODEL_PROMPT` | No | unset | Fully replaces the installed model's system prompt. |
+| `OWUI_MODEL_PROMPT_APPEND` | No | unset | Appends to the installed model's system prompt (bundled or replaced), separated by a blank line. |
+| `TOOL_MEDIAWIKI_ENABLED` | No | `False` | Only the exact value `True` adds `"mediawiki"` to the installed model's `meta.toolIds`. Also requires `MEDIAWIKI_API_URL` for the tool itself to install. |
+
+## Adding a Custom Model
+
+To install your own workspace model instead of the bundled example:
+
+1. Copy an existing file under `models/`, for example `models/wikiteqcenturion.json`,
+   to a new file such as `models/my-model.json`. Keep the JSON array wrapper.
+2. Edit the fields you want to change — typically `id`, `name`, `params.system`, and
+   `meta.toolIds`. Leave `base_model_id` as-is; it gets overwritten at install time
+   regardless of what you put there.
+3. Set `CREATE_CUSTOM_WORKSPACE_MODEL=my-model.json` in your `.env` file.
+4. Start (or restart, if this is truly the first start) the stack.
+
+This only works on **first start**. If your instance has already bootstrapped, the
+entrypoint's first-start step will not run again — create the model by hand instead,
+using the OpenWebUI workspace UI or its API.

--- a/docs/configuration/workspace-models.mdx
+++ b/docs/configuration/workspace-models.mdx
@@ -22,18 +22,21 @@ To install your own workspace model instead of the bundled example:
    `meta.toolIds`. Leave `base_model_id` as-is; it gets overwritten at install time
    regardless of what you put there.
 3. Set `CREATE_CUSTOM_WORKSPACE_MODEL=my-model.json` in your `.env` file.
-4. Start (or restart, if this is truly the first start) the stack.
+4. Start the stack.
 
-This only works on **first start**. If your instance has already bootstrapped, the
-first-start step will not run again — create the model by hand instead, using the
-workspace UI or its API.
+This only works on first boot. If your instance has already bootstrapped, create the
+model by hand instead, using the workspace UI or its API.
+
+<Note>
+This installs only during first-start initialization — the setup that runs only once, the first time the container boots, gated on a marker file. Setting `CREATE_CUSTOM_WORKSPACE_MODEL` on an already-running instance does not install it retroactively.
+</Note>
 
 ## Overview
 
 The `./models` directory is mounted read-only into the container at
 `/etc/owui-models` (see `compose.yaml`). On first boot, the entrypoint can take one
 JSON file from that directory and install it as a workspace model tied to your
-default OpenAI-compatible model.
+default model.
 
 The repository ships one example: `models/wikiteqcenturion.json`.
 
@@ -64,17 +67,19 @@ missing, the container exits immediately with an error and no side effects.
 
 ### What happens to the default model
 
-The entrypoint always creates a workspace model for `OPENAI_DEFAULT_MODEL`, whether or
-not a custom model file is selected. What changes is that model's visibility:
+`OPENAI_DEFAULT_MODEL` configures a **base model** — a provider-derived model
+registered with your provider configuration. Setting it alone does not create a
+workspace model.
 
-- If a custom model file **is** selected, the default model is created **private**.
-  The custom model file is installed as a **second, separate** workspace model, with
-  its `base_model_id` pointed at the default model (see below). The custom model's own
-  visibility is not set by the entrypoint — it comes from the `access_control` value
-  already in the file. `access_control: null`, as in the bundled
-  `wikiteqcenturion.json`, means default visibility rules apply (in practice, public).
-  A file with a restrictive `access_control` object stays restricted.
-- If no custom model file is selected, the default model is created **public**.
+Whether a workspace model gets created from it, and how visible that model is, depends
+on `CREATE_CUSTOM_WORKSPACE_MODEL`:
+
+- If no custom model file is selected, the entrypoint creates a workspace model for
+  `OPENAI_DEFAULT_MODEL` and makes it **public**.
+- If a custom model file **is** selected, the entrypoint instead creates the
+  `OPENAI_DEFAULT_MODEL` workspace model as **private**, and adds the custom model
+  file as its own, **public** workspace model — with its `base_model_id` pointed at
+  `OPENAI_DEFAULT_MODEL` (see below).
 
 Both cases require first-start bootstrap to run, `ENABLE_OPENAI_API=True`, and
 `OPENAI_DEFAULT_MODEL` to be set — this is not unconditional behavior.
@@ -89,15 +94,6 @@ A few environment variables modify the installed model before it's created:
 - `OWUI_MODEL_PROMPT`, if set, fully replaces the file's `params.system` prompt.
 - `OWUI_MODEL_PROMPT_APPEND`, if set, appends to the system prompt (bundled or
   already replaced by `OWUI_MODEL_PROMPT`), separated by a blank line.
-- Enabling a tool at bootstrap can add its ID to the installed model's
-  `meta.toolIds` list. Check the tool's own docs for whether it does this and under
-  which environment variable.
-
-### A note on reliability
-
-The bootstrap calls the API without checking each response. After first boot, confirm
-the model appears as expected in the workspace rather than assuming a clean log means
-success.
 
 ## JSON File Format
 
@@ -114,17 +110,17 @@ The following table documents the fields present in the bundled
 | `user_id` | No | `""` | Owning user ID. Leave blank; not needed for bootstrap-installed models. |
 | `base_model_id` | No | — | Ignored at install time — the entrypoint always overwrites this with `OPENAI_DEFAULT_MODEL`. |
 | `name` | Yes | — | Display name shown in the model picker. |
-| `params.function_calling` | Yes | — | Must be `"native"`. |
+| `params.function_calling` | **Yes** | — | Must be exactly `"native"`. |
 | `params.system` | No | — | System prompt. Replaced by `OWUI_MODEL_PROMPT` or extended by `OWUI_MODEL_PROMPT_APPEND` if set. |
 | `params.reasoning_effort` | No | — | Reasoning effort hint for models that support it, e.g. `"medium"`. |
-| `meta.profile_image_url` | No | — | Avatar image for the model. A base64 data URI is recommended for portability; a static path also works. |
+| `meta.profile_image_url` | No | — | Avatar image for the model. Use a base64 data URI for portability rather than a static path. |
 | `meta.description` | No | `null` | Short description shown in the model picker. |
 | `meta.capabilities.vision` | No | `false` | Whether the model accepts image input. |
 | `meta.capabilities.usage` | No | `false` | Whether token usage is reported to the user. |
 | `meta.capabilities.citations` | No | `true` | Whether source citations are shown. |
 | `meta.suggestion_prompts` | No | `null` | Optional list of starter prompt suggestions. |
 | `meta.tags` | No | `[]` | Optional tag list for the model. |
-| `meta.toolIds` | No | `[]` | Tool IDs attached to the model (e.g. `roat_retrieval`). Some tools may add their own ID to this list at bootstrap time — see Runtime overrides above. |
+| `meta.toolIds` | No | `[]` | Tool IDs attached to the model. Tool registration during bootstrap may automatically add an ID to this list — check the tool's own docs. |
 | `access_control` | No | `null` | Access-control object. `null` means default visibility rules apply. |
 | `is_active` | No | `true` | Whether the model is active/selectable. |
 | `created_at` | No | — | Timestamp field. Not meaningful to set by hand. |

--- a/docs/configuration/workspace-models.mdx
+++ b/docs/configuration/workspace-models.mdx
@@ -6,19 +6,34 @@ keywords:
   - workspace model
   - bootstrap
   - models
-  - OpenWebUI
 ---
 
-mAItion can install one custom OpenWebUI **workspace model** automatically the first
-time the stack boots. This page explains the mechanism, the JSON file format, and how
-to add a model of your own.
+mAItion can install one custom **workspace model** automatically the first time the
+stack boots. This page explains the mechanism, the JSON file format, and how to add a
+model of your own.
+
+## Adding a Custom Model
+
+To install your own workspace model instead of the bundled example:
+
+1. Copy an existing file under `models/`, for example `models/wikiteqcenturion.json`,
+   to a new file such as `models/my-model.json`. Keep the JSON array wrapper.
+2. Edit the fields you want to change — typically `id`, `name`, `params.system`, and
+   `meta.toolIds`. Leave `base_model_id` as-is; it gets overwritten at install time
+   regardless of what you put there.
+3. Set `CREATE_CUSTOM_WORKSPACE_MODEL=my-model.json` in your `.env` file.
+4. Start (or restart, if this is truly the first start) the stack.
+
+This only works on **first start**. If your instance has already bootstrapped, the
+first-start step will not run again — create the model by hand instead, using the
+workspace UI or its API.
 
 ## Overview
 
-The `./models` directory is mounted read-only into the `openwebui` container at
-`/etc/owui-models` (see `compose.yaml`). On first boot, the custom entrypoint can take
-one JSON file from that directory and install it as a private workspace model tied to
-your default OpenAI-compatible model.
+The `./models` directory is mounted read-only into the container at
+`/etc/owui-models` (see `compose.yaml`). On first boot, the entrypoint can take one
+JSON file from that directory and install it as a workspace model tied to your
+default OpenAI-compatible model.
 
 The repository ships one example: `models/wikiteqcenturion.json`.
 
@@ -30,18 +45,15 @@ are true:
 - `ENABLE_OPENAI_API=True`
 - `OPENAI_DEFAULT_MODEL` is set to a non-empty model ID
 
-It also runs only on **first start**. The entrypoint tracks this with a
-`/app/backend/data/.first_start` sentinel file, not by checking whether the database is
-empty. In practice: a fresh database with an existing sentinel file does not
-re-trigger the bootstrap, and an existing database without the sentinel file can
-trigger it again.
+It also runs only once, on first start. Changing `CREATE_CUSTOM_WORKSPACE_MODEL` or
+any of the other variables on this page after that has no effect on an
+already-bootstrapped instance.
 
 ### Selecting a model file
 
 `CREATE_CUSTOM_WORKSPACE_MODEL` controls which file installs, if any:
 
-- `True` installs the bundled `wikiteqcenturion.json` (kept for backward
-  compatibility).
+- `True` installs the bundled `wikiteqcenturion.json`.
 - Any other non-empty value is treated as a filename under `models/` — for example
   `CREATE_CUSTOM_WORKSPACE_MODEL=my-model.json` installs `models/my-model.json`.
 - `False` or unset installs no custom model.
@@ -52,17 +64,16 @@ missing, the container exits immediately with an error and no side effects.
 
 ### What happens to the default model
 
-Separately from `CREATE_CUSTOM_WORKSPACE_MODEL`, the entrypoint also registers
-`OPENAI_DEFAULT_MODEL` as a workspace model. Its visibility depends on whether a custom
-model file was selected:
+The entrypoint always creates a workspace model for `OPENAI_DEFAULT_MODEL`, whether or
+not a custom model file is selected. What changes is that model's visibility:
 
-- If a custom model file **is** selected, the default model is created **private**,
-  and the custom model file is installed in its place (with its `base_model_id`
-  pointed at the default model — see below). The custom model's own visibility is
-  not set by the entrypoint — it comes from the `access_control` value already in
-  the file. `access_control: null`, as in the bundled `wikiteqcenturion.json`,
-  means OpenWebUI's default visibility rules apply (in practice, public). A file
-  with a restrictive `access_control` object stays restricted.
+- If a custom model file **is** selected, the default model is created **private**.
+  The custom model file is installed as a **second, separate** workspace model, with
+  its `base_model_id` pointed at the default model (see below). The custom model's own
+  visibility is not set by the entrypoint — it comes from the `access_control` value
+  already in the file. `access_control: null`, as in the bundled
+  `wikiteqcenturion.json`, means default visibility rules apply (in practice, public).
+  A file with a restrictive `access_control` object stays restricted.
 - If no custom model file is selected, the default model is created **public**.
 
 Both cases require first-start bootstrap to run, `ENABLE_OPENAI_API=True`, and
@@ -78,19 +89,15 @@ A few environment variables modify the installed model before it's created:
 - `OWUI_MODEL_PROMPT`, if set, fully replaces the file's `params.system` prompt.
 - `OWUI_MODEL_PROMPT_APPEND`, if set, appends to the system prompt (bundled or
   already replaced by `OWUI_MODEL_PROMPT`), separated by a blank line.
-- `TOOL_MEDIAWIKI_ENABLED=True` adds `"mediawiki"` to the model's `meta.toolIds`
-  list. This only adds the tool ID to the model definition — it does not by itself
-  confirm that the MediaWiki tool installed successfully, which additionally requires
-  `MEDIAWIKI_API_URL` to be set. Check that the tool actually appears under the
-  model in the OpenWebUI workspace.
+- Enabling a tool at bootstrap can add its ID to the installed model's
+  `meta.toolIds` list. Check the tool's own docs for whether it does this and under
+  which environment variable.
 
 ### A note on reliability
 
-The bootstrap calls the OpenWebUI API with plain `curl -s`, without response-status
-checking. A failed call (bad admin credentials, a transient network error) does not
-necessarily stop the script or produce a visible error. After first boot, confirm the
-model appears as expected in the OpenWebUI workspace rather than assuming a clean log
-means success.
+The bootstrap calls the API without checking each response. After first boot, confirm
+the model appears as expected in the workspace rather than assuming a clean log means
+success.
 
 ## JSON File Format
 
@@ -103,34 +110,32 @@ The following table documents the fields present in the bundled
 
 | Field | Required | Default | Description |
 |---|---|---|---|
-| `id` | Yes | — | Unique model identifier used internally by OpenWebUI. |
+| `id` | Yes | — | Unique model identifier used internally. |
 | `user_id` | No | `""` | Owning user ID. Leave blank; not needed for bootstrap-installed models. |
 | `base_model_id` | No | — | Ignored at install time — the entrypoint always overwrites this with `OPENAI_DEFAULT_MODEL`. |
-| `name` | Yes | — | Display name shown in the OpenWebUI model picker. |
-| `params.function_calling` | No | — | Function-calling mode, e.g. `"native"`. |
+| `name` | Yes | — | Display name shown in the model picker. |
+| `params.function_calling` | Yes | — | Must be `"native"`. |
 | `params.system` | No | — | System prompt. Replaced by `OWUI_MODEL_PROMPT` or extended by `OWUI_MODEL_PROMPT_APPEND` if set. |
 | `params.reasoning_effort` | No | — | Reasoning effort hint for models that support it, e.g. `"medium"`. |
-| `meta.profile_image_url` | No | — | Avatar image for the model. Can be a data URI (base64-encoded image) or a static path. |
+| `meta.profile_image_url` | No | — | Avatar image for the model. A base64 data URI is recommended for portability; a static path also works. |
 | `meta.description` | No | `null` | Short description shown in the model picker. |
 | `meta.capabilities.vision` | No | `false` | Whether the model accepts image input. |
 | `meta.capabilities.usage` | No | `false` | Whether token usage is reported to the user. |
 | `meta.capabilities.citations` | No | `true` | Whether source citations are shown. |
 | `meta.suggestion_prompts` | No | `null` | Optional list of starter prompt suggestions. |
 | `meta.tags` | No | `[]` | Optional tag list for the model. |
-| `meta.toolIds` | No | `[]` | Tool IDs attached to the model (e.g. `roat_retrieval`). `TOOL_MEDIAWIKI_ENABLED=True` appends `"mediawiki"` to this list. |
-| `access_control` | No | `null` | OpenWebUI access-control object. `null` means default visibility rules apply. |
+| `meta.toolIds` | No | `[]` | Tool IDs attached to the model (e.g. `roat_retrieval`). Some tools may add their own ID to this list at bootstrap time — see Runtime overrides above. |
+| `access_control` | No | `null` | Access-control object. `null` means default visibility rules apply. |
 | `is_active` | No | `true` | Whether the model is active/selectable. |
-| `created_at` | No | — | Export timestamp from OpenWebUI. Not meaningful to set by hand. |
-| `updated_at` | No | — | Export timestamp from OpenWebUI. Not meaningful to set by hand. |
-| `user` | No | `{}` | Export metadata about the owning user. Not meaningful to set by hand. |
+| `created_at` | No | — | Timestamp field. Not meaningful to set by hand. |
+| `updated_at` | No | — | Timestamp field. Not meaningful to set by hand. |
+| `user` | No | `{}` | Metadata about the owning user. Not meaningful to set by hand. |
 
 ## Configuration Reference
 
-These environment variables (in `.env`, copied from `.env.openwebui.example`) control
-workspace model bootstrapping. `ENABLE_OPENAI_API` and `OPENAI_DEFAULT_MODEL` are also
-documented in [Environment Variables (Frontend)](/configuration/frontend-env) — they're
-repeated here because both are required for any of the workspace-model behavior on this
-page to run at all.
+These environment variables control workspace model bootstrapping.
+`ENABLE_OPENAI_API` and `OPENAI_DEFAULT_MODEL` are also documented in
+[Environment Variables (Frontend)](/configuration/frontend-env).
 
 | Field | Required | Default | Description |
 |---|---|---|---|
@@ -139,20 +144,3 @@ page to run at all.
 | `CREATE_CUSTOM_WORKSPACE_MODEL` | No | unset | `True` installs the bundled `wikiteqcenturion.json`. A filename installs that file from `models/` instead. `False`/unset installs no custom model. |
 | `OWUI_MODEL_PROMPT` | No | unset | Fully replaces the installed model's system prompt. |
 | `OWUI_MODEL_PROMPT_APPEND` | No | unset | Appends to the installed model's system prompt (bundled or replaced), separated by a blank line. |
-| `TOOL_MEDIAWIKI_ENABLED` | No | `False` | Only the exact value `True` adds `"mediawiki"` to the installed model's `meta.toolIds`. Also requires `MEDIAWIKI_API_URL` for the tool itself to install. |
-
-## Adding a Custom Model
-
-To install your own workspace model instead of the bundled example:
-
-1. Copy an existing file under `models/`, for example `models/wikiteqcenturion.json`,
-   to a new file such as `models/my-model.json`. Keep the JSON array wrapper.
-2. Edit the fields you want to change — typically `id`, `name`, `params.system`, and
-   `meta.toolIds`. Leave `base_model_id` as-is; it gets overwritten at install time
-   regardless of what you put there.
-3. Set `CREATE_CUSTOM_WORKSPACE_MODEL=my-model.json` in your `.env` file.
-4. Start (or restart, if this is truly the first start) the stack.
-
-This only works on **first start**. If your instance has already bootstrapped, the
-entrypoint's first-start step will not run again — create the model by hand instead,
-using the OpenWebUI workspace UI or its API.

--- a/docs/configuration/workspace-models.mdx
+++ b/docs/configuration/workspace-models.mdx
@@ -24,9 +24,6 @@ To install your own workspace model instead of the bundled example:
 3. Set `CREATE_CUSTOM_WORKSPACE_MODEL=my-model.json` in your `.env` file.
 4. Start the stack.
 
-This only works on first boot. If your instance has already bootstrapped, create the
-model by hand instead, using the workspace UI or its API.
-
 <Note>
 This installs only during first-start initialization — the setup that runs only once, the first time the container boots, gated on a marker file. Setting `CREATE_CUSTOM_WORKSPACE_MODEL` on an already-running instance does not install it retroactively.
 </Note>
@@ -47,10 +44,6 @@ are true:
 
 - `ENABLE_OPENAI_API=True`
 - `OPENAI_DEFAULT_MODEL` is set to a non-empty model ID
-
-It also runs only once, on first start. Changing `CREATE_CUSTOM_WORKSPACE_MODEL` or
-any of the other variables on this page after that has no effect on an
-already-bootstrapped instance.
 
 ### Selecting a model file
 

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -81,7 +81,8 @@
 							"configuration/config-reference",
 							"configuration/frontend-env",
 							"configuration/backend-env",
-							"configuration/sso"
+							"configuration/sso",
+							"configuration/workspace-models"
 						]
 					}
 				]


### PR DESCRIPTION
## Summary

Adds a new Configuration docs page explaining how mAItion installs a custom OpenWebUI workspace model from `./models` on first boot, the required JSON file format, and how to add a custom model of your own.

## What's included

- `docs/configuration/workspace-models.mdx` (new): overview, bootstrap mechanism (env var gating, first-start sentinel behavior, `base_model_id` override, prompt override/append, MediaWiki tool-id caveat), annotated JSON field table based on `models/wikiteqcenturion.json`, env var reference table, and a short "Adding a Custom Model" how-to.
- `docs/docs.json`: registers the new page in the Configuration nav group, after `sso`.

## Notes

- Docs-only change, no runtime/service impact.
- Verified locally via `cd docs && docker compose up -d --build` (Mintlify dev server on port 3333).
- Technical claims in the page were independently checked against `helpers/entrypoint.sh` source (env var gating, `.first_start` sentinel mechanism, JSON array + `.[0]` read requirement, `base_model_id` runtime overwrite).

Jira: WIK-2591