### PR TITLE
WIK-2590: Document ROAT retrieval Tool

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -79,7 +79,8 @@
 						"group": "Tools",
 						"pages": [
 							"tools/image-resizer",
-							"tools/web-search"
+							"tools/web-search",
+							"tools/roat-retrieval"
 						]
 					},
 					{

--- a/docs/tools/roat-retrieval.mdx
+++ b/docs/tools/roat-retrieval.mdx
@@ -14,31 +14,6 @@ The **Knowledge Base Search** tool (`roat_retrieval`) is a mAItion Workspace Too
 
 Use it for questions about internal documents, company processes, or organization-specific topics. Skip it for general knowledge questions (math, programming syntax, public facts) that don't need internal data — the tool's own description tells the model the same thing.
 
-## What It Does
-
-The tool exposes one function, `search_knowledge_base`, with two parameters:
-
-- **`query`** — a free-text search string for the semantic part of the question.
-- **`metadata_filters`** — an optional list of filters to narrow results by a metadata field (for example `project`, `status`, `assignee`). Each filter is `{"name": ..., "operator": ..., "value": ...}`.
-
-Supported operators:
-
-| Operator | Use for |
-|---|---|
-| `EQ`, `NE`, `GT`, `GTE`, `LT`, `LTE`, `TEXT_MATCH` | A field with a single value. `value` is a single value. |
-| `IN`, `NIN` | A field with a single value, checked against a list of candidates. `value` is a list. |
-| `ANY`, `ALL` | A field whose own value is a list (for example `tags: ["urgent", "billing"]`). `ANY` matches if the field contains at least one given value; `ALL` matches only if it contains every given value. |
-
-`IN`/`NIN` and `ANY`/`ALL` are not interchangeable: using `IN`/`NIN` on a list-valued field compares the whole list as one unit and will not match individual list elements. Use `ANY`/`ALL` for list-valued fields instead.
-
-**Response format:** the tool returns one `<document>` block per result, each with YAML frontmatter (built from the source's metadata, plus a `url` field when available) and the matched text. Citations are not embedded inline in this text — each result is also emitted as a separate `source` event, and stored on the request for the current chat turn. A separate tool (`get_sources`, not covered on this page) can read that same stored data back later in the conversation.
-
-**Requirement:** the selected model must support native function calling for the LLM to call this tool at all.
-
-### Video playback
-
-If the ENV variable `FUNCTION_VIDEO_INJECT_ENABLED=True` is set, and a result's metadata contains an `https://` URL under the field named by the `video_metadata_field` valve, the tool prepends a hidden marker to its response. A separate filter turns that marker into an inline video player in the chat. This is what the `video_metadata_field` valve controls — it does nothing unless the video-inject filter is also enabled.
-
 ## Valves
 
 | Field | Required | Default | Description |
@@ -48,7 +23,7 @@ If the ENV variable `FUNCTION_VIDEO_INJECT_ENABLED=True` is set, and a result's 
 | `rag_service_timeout` | no | `30` | Request timeout, in seconds. |
 | `top_k` | no | `20` | Number of top results to retrieve from the knowledge base. |
 | `max_document_preview_chars` | no | `0` | Maximum characters shown in the document preview of each source citation. `0` means unlimited. |
-| `video_metadata_field` | no | `"video_url"` | Metadata field name to check for a video URL. See [Video playback](#video-playback). |
+| `video_metadata_field` | no | `"video_url"` | Metadata field name to check for a video URL. When a result's metadata has one, the tool prepends a hidden marker to its response that the Video Inject Filter turns into an inline player — this valve has no effect unless that filter is also enabled. |
 
 Valves can be edited after install from **Workspace → Tools** in mAItion.
 
@@ -60,10 +35,9 @@ Valves can be edited after install from **Workspace → Tools** in mAItion.
 This installs only during first-start initialization — the setup that runs only once, the first time the container boots, gated on a marker file. On an already-running instance, this tool is already installed; the ENV variables below only affect what it connects to, and changing them takes effect only if you configure the resulting valves manually afterward from the admin UI.
 </Note>
 
-The only thing you configure via ENV is where it connects. In `.env` (from `.env.openwebui.example`):
+The only thing you configure via ENV is where it connects. In `.env`:
 
 ```bash
-# the URL of the ROAT API, keep default
 ROAT_API_URL=http://api:8000
 ROAT_API_KEY=12345
 ```

--- a/docs/tools/roat-retrieval.mdx
+++ b/docs/tools/roat-retrieval.mdx
@@ -10,9 +10,11 @@ keywords:
   - retrieval
 ---
 
-The **Knowledge Base Search** tool (`roat_retrieval`) is a mAItion Workspace Tool. It lets the LLM decide, on its own, when to call the ROAT knowledge base to answer a question — instead of every message going through a filter.
+The **Knowledge Base Search** tool (`roat_retrieval`) is a mAItion Workspace Tool. It lets the LLM decide, on its own, when to call the knowledge base to answer a question.
 
-Use it for questions about internal documents, company processes, or organization-specific topics. Skip it for general knowledge questions (math, programming syntax, public facts) that don't need internal data — the tool's own description tells the model the same thing.
+Use it for questions about internal documents, company processes, or organization-specific topics. Skip it for general knowledge questions (math, programming syntax, public facts) that don't need internal data.
+
+The knowledge base is powered by [ROAT (rag-of-all-trades)](https://github.com/WikiTeq/rag-of-all-trades), mAItion's RAG backend.
 
 ## Valves
 
@@ -27,25 +29,23 @@ Use it for questions about internal documents, company processes, or organizatio
 
 Valves can be edited after install from **Workspace → Tools** in mAItion.
 
-## Enabling via ENV
-
-**Knowledge Base Search has no opt-in flag.** It is always installed — there is no `TOOL_ROAT_RETRIEVAL_ENABLED`-style variable to set.
+## Configuration via ENV
 
 <Note>
-This installs only during first-start initialization — the setup that runs only once, the first time the container boots, gated on a marker file. On an already-running instance, this tool is already installed; the ENV variables below only affect what it connects to, and changing them takes effect only if you configure the resulting valves manually afterward from the admin UI.
+Knowledge Base Search is always installed — there is no opt-in flag. The ENV variables below only affect what it connects to, and only apply during first-start initialization (the setup that runs only once, the first time the container boots, gated on a marker file). On an already-running instance, configure the resulting valves manually from the admin UI instead.
 </Note>
 
-The only thing you configure via ENV is where it connects. In `.env`:
+| Field | Required | Default | Description |
+|---|---|---|---|
+| `ROAT_API_URL` | yes | `http://api:8000` | Base URL of the ROAT API — the host and port only, with no path suffix. Used to set the tool's `rag_service_url` valve at first start. |
+| `ROAT_API_KEY` | no | `12345` | Bearer token for the ROAT API. Used to set the tool's `rag_service_api_key` valve at first start. |
+
+Example `.env`:
 
 ```bash
 ROAT_API_URL=http://api:8000
 ROAT_API_KEY=12345
 ```
-
-At first start, the entrypoint script sets the tool's valves from these two variables — but not as a direct copy of `ROAT_API_URL`. It appends the query path:
-
-- `rag_service_url` is set to `${ROAT_API_URL}/api/v1/query` — with the defaults above, `http://api:8000/api/v1/query`.
-- `rag_service_api_key` is set to `ROAT_API_KEY`.
 
 If you configure `rag_service_url` manually later (for example after changing `ROAT_API_URL` post-install), remember to include the `/api/v1/query` path — the bare host URL alone will not work.
 

--- a/docs/tools/roat-retrieval.mdx
+++ b/docs/tools/roat-retrieval.mdx
@@ -1,0 +1,81 @@
+---
+title: "Knowledge Base Search"
+description: "Configure the ROAT Knowledge Base Search tool, the Workspace Tool that lets the LLM query mAItion's knowledge base on demand."
+keywords:
+  - mAItion
+  - tool
+  - workspace tool
+  - knowledge base
+  - ROAT
+  - retrieval
+---
+
+The **Knowledge Base Search** tool (`roat_retrieval`) is an Open WebUI Workspace Tool. It lets the LLM decide, on its own, when to call the ROAT knowledge base to answer a question — instead of every message going through a filter.
+
+Use it for questions about internal documents, company processes, or organization-specific topics. Skip it for general knowledge questions (math, programming syntax, public facts) that don't need internal data — the tool's own description tells the model the same thing.
+
+## What It Does
+
+The tool exposes one function, `search_knowledge_base`, with two parameters:
+
+- **`query`** — a free-text search string for the semantic part of the question.
+- **`metadata_filters`** — an optional list of filters to narrow results by a metadata field (for example `project`, `status`, `assignee`). Each filter is `{"name": ..., "operator": ..., "value": ...}`.
+
+Supported operators:
+
+| Operator | Use for |
+|---|---|
+| `EQ`, `NE`, `GT`, `GTE`, `LT`, `LTE`, `TEXT_MATCH` | A field with a single value. `value` is a single value. |
+| `IN`, `NIN` | A field with a single value, checked against a list of candidates. `value` is a list. |
+| `ANY`, `ALL` | A field whose own value is a list (for example `tags: ["urgent", "billing"]`). `ANY` matches if the field contains at least one given value; `ALL` matches only if it contains every given value. |
+
+`IN`/`NIN` and `ANY`/`ALL` are not interchangeable: using `IN`/`NIN` on a list-valued field compares the whole list as one unit and will not match individual list elements. Use `ANY`/`ALL` for list-valued fields instead.
+
+**Response format:** the tool returns one `<document>` block per result, each with YAML frontmatter (built from the source's metadata, plus a `url` field when available) and the matched text. Citations are not embedded inline in this text — each result is also emitted to Open WebUI as a separate `source` event, and stored on the request for the current chat turn. A separate tool (`get_sources`, not covered on this page) can read that same stored data back later in the conversation.
+
+**Requirement:** the selected model must support native function calling for the LLM to call this tool at all.
+
+### Video playback
+
+If the ENV variable `FUNCTION_VIDEO_INJECT_ENABLED=True` is set, and a result's metadata contains an `https://` URL under the field named by the `video_metadata_field` valve, the tool prepends a hidden marker to its response. A separate filter turns that marker into an inline video player in the chat. This is what the `video_metadata_field` valve controls — it does nothing unless the video-inject filter is also enabled.
+
+## Valves
+
+| Field | Required | Default | Description |
+|---|---|---|---|
+| `rag_service_url` | **yes** | `""` | Full URL to the ROAT query endpoint. Empty by default — the tool returns an error and will not run until this is set. |
+| `rag_service_api_key` | no | `""` | Bearer token for the ROAT API. Leave blank if the API doesn't require one. |
+| `rag_service_timeout` | no | `30` | Request timeout, in seconds. |
+| `top_k` | no | `20` | Number of top results to retrieve from the knowledge base. |
+| `max_document_preview_chars` | no | `0` | Maximum characters shown in the document preview of each source citation. `0` means unlimited. |
+| `video_metadata_field` | no | `"video_url"` | Metadata field name to check for a video URL. See [Video playback](#video-playback). |
+
+Valves can be edited after install from **Workspace → Tools** in the Open WebUI admin UI.
+
+## Enabling via ENV
+
+Unlike the MediaWiki, Web Search, and Get Sources tools, **Knowledge Base Search has no opt-in flag.** It is always installed, during first-start initialization (the one-time setup that runs the first time the `openwebui` container boots) — there is no `TOOL_ROAT_RETRIEVAL_ENABLED`-style variable to set.
+
+The only thing you configure via ENV is where it connects. In `.env` (from `.env.openwebui.example`):
+
+```bash
+# the URL of the ROAT API, keep default
+ROAT_API_URL=http://api:8000
+ROAT_API_KEY=12345
+```
+
+At first start, the entrypoint script sets the tool's valves from these two variables — but not as a direct copy of `ROAT_API_URL`. It appends the query path:
+
+- `rag_service_url` is set to `${ROAT_API_URL}/api/v1/query` — with the defaults above, `http://api:8000/api/v1/query`.
+- `rag_service_api_key` is set to `ROAT_API_KEY`.
+
+If you configure `rag_service_url` manually later (for example after changing `ROAT_API_URL` post-install), remember to include the `/api/v1/query` path — the bare host URL alone will not work.
+
+## Troubleshooting
+
+| Symptom | Cause |
+|---|---|
+| `Error: rag_service_url is not configured in Tool Valves.` | The `rag_service_url` valve is empty. Set it via ENV (see above) or manually from Workspace → Tools. |
+| `Error: the knowledge base rejected this request (<status>). ...` | The ROAT API returned an HTTP error — check the status code and detail in the message, and confirm `rag_service_api_key` is correct. |
+| `Error: could not reach the knowledge base. ...` | The `api` service is unreachable from `rag_service_url` — check the `api` service is up and the URL/network path is correct. |
+| `No relevant information was found in the knowledge base for this query.` | Not an error — the search ran but found nothing. Confirm a connector has indexed data relevant to the query. |

--- a/docs/tools/roat-retrieval.mdx
+++ b/docs/tools/roat-retrieval.mdx
@@ -10,7 +10,7 @@ keywords:
   - retrieval
 ---
 
-The **Knowledge Base Search** tool (`roat_retrieval`) is an Open WebUI Workspace Tool. It lets the LLM decide, on its own, when to call the ROAT knowledge base to answer a question — instead of every message going through a filter.
+The **Knowledge Base Search** tool (`roat_retrieval`) is a mAItion Workspace Tool. It lets the LLM decide, on its own, when to call the ROAT knowledge base to answer a question — instead of every message going through a filter.
 
 Use it for questions about internal documents, company processes, or organization-specific topics. Skip it for general knowledge questions (math, programming syntax, public facts) that don't need internal data — the tool's own description tells the model the same thing.
 
@@ -31,7 +31,7 @@ Supported operators:
 
 `IN`/`NIN` and `ANY`/`ALL` are not interchangeable: using `IN`/`NIN` on a list-valued field compares the whole list as one unit and will not match individual list elements. Use `ANY`/`ALL` for list-valued fields instead.
 
-**Response format:** the tool returns one `<document>` block per result, each with YAML frontmatter (built from the source's metadata, plus a `url` field when available) and the matched text. Citations are not embedded inline in this text — each result is also emitted to Open WebUI as a separate `source` event, and stored on the request for the current chat turn. A separate tool (`get_sources`, not covered on this page) can read that same stored data back later in the conversation.
+**Response format:** the tool returns one `<document>` block per result, each with YAML frontmatter (built from the source's metadata, plus a `url` field when available) and the matched text. Citations are not embedded inline in this text — each result is also emitted as a separate `source` event, and stored on the request for the current chat turn. A separate tool (`get_sources`, not covered on this page) can read that same stored data back later in the conversation.
 
 **Requirement:** the selected model must support native function calling for the LLM to call this tool at all.
 
@@ -50,11 +50,15 @@ If the ENV variable `FUNCTION_VIDEO_INJECT_ENABLED=True` is set, and a result's 
 | `max_document_preview_chars` | no | `0` | Maximum characters shown in the document preview of each source citation. `0` means unlimited. |
 | `video_metadata_field` | no | `"video_url"` | Metadata field name to check for a video URL. See [Video playback](#video-playback). |
 
-Valves can be edited after install from **Workspace → Tools** in the Open WebUI admin UI.
+Valves can be edited after install from **Workspace → Tools** in mAItion.
 
 ## Enabling via ENV
 
-Unlike the MediaWiki, Web Search, and Get Sources tools, **Knowledge Base Search has no opt-in flag.** It is always installed, during first-start initialization (the one-time setup that runs the first time the `openwebui` container boots) — there is no `TOOL_ROAT_RETRIEVAL_ENABLED`-style variable to set.
+**Knowledge Base Search has no opt-in flag.** It is always installed — there is no `TOOL_ROAT_RETRIEVAL_ENABLED`-style variable to set.
+
+<Note>
+This installs only during first-start initialization — the setup that runs only once, the first time the container boots, gated on a marker file. On an already-running instance, this tool is already installed; the ENV variables below only affect what it connects to, and changing them takes effect only if you configure the resulting valves manually afterward from the admin UI.
+</Note>
 
 The only thing you configure via ENV is where it connects. In `.env` (from `.env.openwebui.example`):
 
@@ -75,7 +79,7 @@ If you configure `rag_service_url` manually later (for example after changing `R
 
 | Symptom | Cause |
 |---|---|
-| `Error: rag_service_url is not configured in Tool Valves.` | The `rag_service_url` valve is empty. Set it via ENV (see above) or manually from Workspace → Tools. |
+| `Error: rag_service_url is not configured in Tool Valves.` | The `rag_service_url` valve is empty. Set it via ENV (see above) or manually from Workspace → Tools in mAItion. |
 | `Error: the knowledge base rejected this request (<status>). ...` | The ROAT API returned an HTTP error — check the status code and detail in the message, and confirm `rag_service_api_key` is correct. |
 | `Error: could not reach the knowledge base. ...` | The `api` service is unreachable from `rag_service_url` — check the `api` service is up and the URL/network path is correct. |
 | `No relevant information was found in the knowledge base for this query.` | Not an error — the search ran but found nothing. Confirm a connector has indexed data relevant to the query. |


### PR DESCRIPTION
## Summary

Adds Mintlify documentation for the Knowledge Base Search tool (`tools/roat_retrieval.py`), under a new "Tools" docs section.

- New nav group `Tools` in `docs/docs.json`, sibling to `Connectors` and `Configuration`.
- New page `docs/tools/roat-retrieval.mdx` covering:
  - What the tool does (`search_knowledge_base`: query + metadata filters, all supported operators, response format, citation mechanism)
  - Video playback behavior tied to `video_metadata_field` / `FUNCTION_VIDEO_INJECT_ENABLED`
  - Full Valves configuration reference table (defaults, required status)
  - How it's enabled via ENV — installed unconditionally at first-start (no opt-in flag, unlike the other three tools), only `ROAT_API_URL`/`ROAT_API_KEY` are configurable, with the exact `${ROAT_API_URL}/api/v1/query` computation the entrypoint script performs
  - Troubleshooting table for the tool's error paths

Docs-only change — no code, no runtime impact.

## Scope

Documents only `roat_retrieval.py`, per ticket. `mediawiki_tool`, `web_search`, and `get_sources` are out of scope for this ticket.

## Test plan

- [x] `docs/docs.json` validated as well-formed JSON
- [x] Every factual claim in the new page cross-checked line-by-line against `tools/roat_retrieval.py`, `tools/roat_retrieval.json`, `helpers/entrypoint.sh`, and `.env.openwebui.example`
- [x] Independent second opinion via `codex exec` consult against the plan and source files before implementation
- [ ] Optional: preview locally via `cd docs && docker compose up -d --build` on port 3333

Jira: WIK-2590