### PR TITLE
WIK-2589: Document MediaWiki Tool

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -80,7 +80,8 @@
 						"pages": [
 							"tools/image-resizer",
 							"tools/web-search",
-							"tools/roat-retrieval"
+							"tools/roat-retrieval",
+							"tools/mediawiki-tool"
 						]
 					},
 					{

--- a/docs/tools/mediawiki-tool.mdx
+++ b/docs/tools/mediawiki-tool.mdx
@@ -11,64 +11,9 @@ keywords:
   - write
 ---
 
-The **MediaWiki Search & Write Tool** (`mediawiki`) is an Open WebUI Workspace Tool. It gives the LLM two on-demand functions: searching your wiki, and creating or updating wiki pages.
+The **MediaWiki Search & Write Tool** (`mediawiki`) is a mAItion Workspace Tool. It gives the LLM two on-demand functions: searching your wiki, and creating or updating wiki pages.
 
 Use `search_wiki` when the user asks to look something up on the wiki. Use `save_to_wiki` when the user asks to save, write, or update content on the wiki.
-
-## What It Does
-
-### `search_wiki`
-
-Runs a full-text search (equivalent to Special:Search) and fetches the content of each matching page.
-
-- **`query`** — the search string.
-- **`content_format`** — `wikitext` (raw markup, default), `html` (parsed HTML), or `markdown` (parsed HTML converted to Markdown). Prefer `html` or `markdown` when pages may contain templates, transclusions, or query results, since raw wikitext doesn't show their rendered output.
-
-`max_search_results` caps the number of results (effective range 1–20 — this is a runtime clamp, not a hard validation, so a value outside that range is silently adjusted rather than rejected). `max_page_chars` truncates each page's content. Results are emitted to Open WebUI as `source` citations, the same mechanism `roat_retrieval` uses — a separate tool (`get_sources`, not covered on this page) can read them back later in the conversation.
-
-Distinct outcomes you may see:
-
-- `wiki_url` not configured
-- empty search query
-- invalid `wiki_url` format
-- authentication failed — `username`/`password` were provided but rejected
-- could not connect to the wiki
-- this wiki denies the search request (`readapidenied`/`permissiondenied`) — the acting user (anonymous or logged in) lacks the right to read
-- other wiki API errors (with the error code included)
-- unexpected errors
-- no results found
-- a single result's page content unavailable — returned as `(Page not found — may have been deleted)` or `(Content unavailable)` for that one result, without failing the rest of the search
-
-### `save_to_wiki`
-
-Creates a new page or updates an existing one.
-
-- **`title`** — the page title.
-- **`content`** — the page content, already formatted as MediaWiki markup. **The tool does not convert content for you** — plain text or Markdown passed as `content` is saved as literal wiki markup, not rendered.
-
-Title rules (enforced by the tool):
-
-- Main-namespace pages only — the title must not contain `:`
-- Maximum length: 255 characters
-- Illegal characters: `# < > [ ] | { }` and ASCII control characters (0–31 and 127)
-
-Content size limit: 2,000,000 UTF-8-encoded **bytes**. A page heavy in multi-byte characters can hit this limit at well under 2,000,000 characters — the limit is measured on the encoded byte length, not the character count.
-
-Distinct outcomes you may see:
-
-- `wiki_url` not configured
-- empty title
-- title exceeds 255 characters
-- content exceeds the 2,000,000-byte size limit
-- title contains an illegal character or a `:`
-- invalid `wiki_url` format
-- authentication failed — `username`/`password` were provided but rejected
-- could not connect to the wiki
-- this wiki denies the write request (`writeapidenied`/`permissiondenied`) — the acting user (anonymous or logged in) lacks the right to write
-- page is protected and cannot be edited
-- other wiki API errors (with the error code included)
-- unexpected errors
-- saved successfully, but the page URL could not be determined — still a success, just without a returned link
 
 ## Authentication
 
@@ -94,15 +39,13 @@ When credentials are needed, use a [BotPassword](https://www.mediawiki.org/wiki/
 | `max_search_results` | no | `10` | Maximum number of search results to return. Effective range 1–20 — values outside this range are clamped at runtime, not rejected. |
 | `max_page_chars` | no | `20000` | Maximum characters per page in search results; longer pages are truncated. Valid range 1–500,000, enforced at the schema level. |
 
-Tool id: `mediawiki`. Display name: "MediaWiki Search & Write Tool". Valves can be edited after install from **Workspace → Tools** in the Open WebUI admin UI.
+Tool id: `mediawiki`. Display name: "MediaWiki Search & Write Tool". Valves can be edited after install from **Workspace → Tools** in mAItion.
 
 ## Enabling via ENV
 
-Unlike the Knowledge Base Search tool, the MediaWiki tool **is opt-in**. It installs only when both of these are true at first-start initialization (the one-time setup that runs the first time the `openwebui` container boots):
+This tool is opt-in. It installs only when both of these are true:
 
 ```bash
-# MediaWiki Tool (optional): set TOOL_MEDIAWIKI_ENABLED=True to auto-install the
-# MediaWiki Search & Write Tool on first boot. MEDIAWIKI_API_URL is required when enabled.
 TOOL_MEDIAWIKI_ENABLED=True
 MEDIAWIKI_API_URL=https://wiki.example.com/w/api.php
 MEDIAWIKI_USERNAME=
@@ -120,13 +63,27 @@ At install, only three valves are set from ENV:
 
 `timeout`, `edit_summary`, `max_search_results`, and `max_page_chars` are **not** configurable via ENV. They stay at their defaults above unless changed later from Workspace → Tools.
 
+<Note>
+This installs only during first-start initialization — the setup that runs only once, the first time the container boots, gated on a marker file. Setting `TOOL_MEDIAWIKI_ENABLED=True` on an already-running instance does not install it retroactively.
+</Note>
+
 ## Troubleshooting
 
 | Symptom | Cause |
 |---|---|
 | `Error: wiki_url is not configured.` | The `wiki_url` valve is empty. Set it via ENV (see above) or manually from Workspace → Tools. |
+| `Error: wiki_url must start with http:// or https://. ...` / `Error: wiki_url has no host. ...` | The `wiki_url` valve isn't a valid URL. |
+| `Error: search query cannot be empty.` / `Error: page title cannot be empty.` | An empty query or title was passed to the tool. |
 | `Error: authentication failed. ...` | Login failed — check `username`/`password`. If using a BotPassword, confirm the `Username@BotName` format. |
 | `Error: this wiki requires authentication to search.` / `...to write.` | MediaWiki denied the request (`readapidenied`/`writeapidenied`/`permissiondenied`) — the acting user, anonymous or logged in, lacks the right for that action. If anonymous, configure `username` and `password`; if already logged in, the account itself lacks the required right. |
 | `Error: page '<title>' is protected.` | The page can't be edited by this account (save only). |
 | `Error: could not connect to the wiki. ...` | `wiki_url` is unreachable — check the URL and network path. |
-| Title-related errors (empty, too long, illegal character, contains `:`) | The title failed validation before any wiki API call was made (save only). See "Title rules" under [What It Does](#what-it-does) above. |
+| `Error: page title exceeds maximum length of 255 characters.` | The title is longer than 255 characters (save only). |
+| `Error: Page title must not contain ':'. ...` | Only main-namespace pages are supported — the title contains a `:` (save only). |
+| `Error: Page title contains an illegal character: ...` | The title contains `# < > [ ] \| { }` or a control character (save only). |
+| `Error: content exceeds maximum allowed size of 2 MB.` | The page content exceeds the byte-size limit, measured on UTF-8-encoded bytes, not characters (save only). |
+| `Error: wiki API returned an error (<code>). ...` | The wiki's API returned an error not covered above; the error code is included in the message. |
+| `Error: unexpected error during search. ...` / `Error: an unexpected error occurred while saving. ...` | An unhandled error occurred. Check server logs. |
+| `No wiki pages found matching '<query>'.` | Not an error — the search ran but found nothing. |
+| `(Page not found — may have been deleted)` / `(Content unavailable)` | Not an error — one search result's page content couldn't be fetched; the rest of the search still returns normally. |
+| `Saved "<title>" to the wiki, but the page URL could not be determined.` | Not an error — the save succeeded; the response just didn't return a link (save only). |

--- a/docs/tools/mediawiki-tool.mdx
+++ b/docs/tools/mediawiki-tool.mdx
@@ -21,7 +21,7 @@ Use `search_wiki` when the user asks to look something up on the wiki. Use `save
 
 Two distinct failure modes can occur, and the tool reports them differently: **authentication** failure (the supplied `username`/`password` are wrong — the tool reports this directly), and **authorization** failure (the acting user, whether anonymous or logged in, lacks permission for that specific action on this wiki — MediaWiki denies the request itself, independent of whether login succeeded).
 
-When credentials are needed, use a [BotPassword](https://www.mediawiki.org/wiki/Manual:Bot_passwords) (Special:BotPasswords on your wiki) rather than a real account password. The expected format is `Username@BotName`.
+When credentials are needed, use a [BotPassword](https://www.mediawiki.org/wiki/Manual:Bot_passwords) (Special:BotPasswords on your wiki) rather than a real account password.
 
 ## Connecting to the Wiki
 
@@ -32,7 +32,7 @@ When credentials are needed, use a [BotPassword](https://www.mediawiki.org/wiki/
 | Field | Required | Default | Description |
 |---|---|---|---|
 | `wiki_url` | **yes** | `""` | Full URL to the MediaWiki `api.php` script. Empty by default — the tool returns an error and will not run until this is set. |
-| `username` | no | `""` | MediaWiki username. For production wikis, use a BotPassword in the format `Username@BotName`. |
+| `username` | no | `""` | MediaWiki username. For production wikis, use a BotPassword. |
 | `password` | no | `""` | MediaWiki password or BotPassword token. |
 | `timeout` | no | `30` | Request timeout, in seconds. |
 | `edit_summary` | no | `"Saved via mAItion AI assistant"` | Edit summary recorded in the wiki page history. |
@@ -43,7 +43,17 @@ Tool id: `mediawiki`. Display name: "MediaWiki Search & Write Tool". Valves can 
 
 ## Enabling via ENV
 
-This tool is opt-in. It installs only when both of these are true:
+This tool is opt-in. Installing it requires both of these:
+
+- `TOOL_MEDIAWIKI_ENABLED=True`
+- `MEDIAWIKI_API_URL` set to a non-empty value
+
+If `MEDIAWIKI_API_URL` is missing while the flag is `True`, the entrypoint script skips
+the install and prints a warning to the container logs — it does not fail the boot, so
+the omission is easy to miss.
+
+`MEDIAWIKI_USERNAME` and `MEDIAWIKI_PASSWORD` are optional — set them if the wiki needs
+credentials. In `.env`:
 
 ```bash
 TOOL_MEDIAWIKI_ENABLED=True
@@ -51,9 +61,6 @@ MEDIAWIKI_API_URL=https://wiki.example.com/w/api.php
 MEDIAWIKI_USERNAME=
 MEDIAWIKI_PASSWORD=
 ```
-
-- `TOOL_MEDIAWIKI_ENABLED=True` is required to attempt install.
-- `MEDIAWIKI_API_URL` must also be non-empty. If it's missing while the flag is `True`, the entrypoint script skips the install and prints a warning to the container logs — it does not fail the boot, so the omission is easy to miss.
 
 At install, only three valves are set from ENV:
 
@@ -74,7 +81,7 @@ This installs only during first-start initialization — the setup that runs onl
 | `Error: wiki_url is not configured.` | The `wiki_url` valve is empty. Set it via ENV (see above) or manually from Workspace → Tools. |
 | `Error: wiki_url must start with http:// or https://. ...` / `Error: wiki_url has no host. ...` | The `wiki_url` valve isn't a valid URL. |
 | `Error: search query cannot be empty.` / `Error: page title cannot be empty.` | An empty query or title was passed to the tool. |
-| `Error: authentication failed. ...` | Login failed — check `username`/`password`. If using a BotPassword, confirm the `Username@BotName` format. |
+| `Error: authentication failed. ...` | Login failed — check `username`/`password`. |
 | `Error: this wiki requires authentication to search.` / `...to write.` | MediaWiki denied the request (`readapidenied`/`writeapidenied`/`permissiondenied`) — the acting user, anonymous or logged in, lacks the right for that action. If anonymous, configure `username` and `password`; if already logged in, the account itself lacks the required right. |
 | `Error: page '<title>' is protected.` | The page can't be edited by this account (save only). |
 | `Error: could not connect to the wiki. ...` | `wiki_url` is unreachable — check the URL and network path. |

--- a/docs/tools/mediawiki-tool.mdx
+++ b/docs/tools/mediawiki-tool.mdx
@@ -1,0 +1,132 @@
+---
+title: "MediaWiki Search & Write Tool"
+description: "Configure the MediaWiki Search & Write Tool, the Workspace Tool that lets the LLM search and save pages on your MediaWiki wiki."
+keywords:
+  - mAItion
+  - tool
+  - workspace tool
+  - MediaWiki
+  - wiki
+  - search
+  - write
+---
+
+The **MediaWiki Search & Write Tool** (`mediawiki`) is an Open WebUI Workspace Tool. It gives the LLM two on-demand functions: searching your wiki, and creating or updating wiki pages.
+
+Use `search_wiki` when the user asks to look something up on the wiki. Use `save_to_wiki` when the user asks to save, write, or update content on the wiki.
+
+## What It Does
+
+### `search_wiki`
+
+Runs a full-text search (equivalent to Special:Search) and fetches the content of each matching page.
+
+- **`query`** — the search string.
+- **`content_format`** — `wikitext` (raw markup, default), `html` (parsed HTML), or `markdown` (parsed HTML converted to Markdown). Prefer `html` or `markdown` when pages may contain templates, transclusions, or query results, since raw wikitext doesn't show their rendered output.
+
+`max_search_results` caps the number of results (effective range 1–20 — this is a runtime clamp, not a hard validation, so a value outside that range is silently adjusted rather than rejected). `max_page_chars` truncates each page's content. Results are emitted to Open WebUI as `source` citations, the same mechanism `roat_retrieval` uses — a separate tool (`get_sources`, not covered on this page) can read them back later in the conversation.
+
+Distinct outcomes you may see:
+
+- `wiki_url` not configured
+- empty search query
+- invalid `wiki_url` format
+- authentication failed — `username`/`password` were provided but rejected
+- could not connect to the wiki
+- this wiki denies the search request (`readapidenied`/`permissiondenied`) — the acting user (anonymous or logged in) lacks the right to read
+- other wiki API errors (with the error code included)
+- unexpected errors
+- no results found
+- a single result's page content unavailable — returned as `(Page not found — may have been deleted)` or `(Content unavailable)` for that one result, without failing the rest of the search
+
+### `save_to_wiki`
+
+Creates a new page or updates an existing one.
+
+- **`title`** — the page title.
+- **`content`** — the page content, already formatted as MediaWiki markup. **The tool does not convert content for you** — plain text or Markdown passed as `content` is saved as literal wiki markup, not rendered.
+
+Title rules (enforced by the tool):
+
+- Main-namespace pages only — the title must not contain `:`
+- Maximum length: 255 characters
+- Illegal characters: `# < > [ ] | { }` and ASCII control characters (0–31 and 127)
+
+Content size limit: 2,000,000 UTF-8-encoded **bytes**. A page heavy in multi-byte characters can hit this limit at well under 2,000,000 characters — the limit is measured on the encoded byte length, not the character count.
+
+Distinct outcomes you may see:
+
+- `wiki_url` not configured
+- empty title
+- title exceeds 255 characters
+- content exceeds the 2,000,000-byte size limit
+- title contains an illegal character or a `:`
+- invalid `wiki_url` format
+- authentication failed — `username`/`password` were provided but rejected
+- could not connect to the wiki
+- this wiki denies the write request (`writeapidenied`/`permissiondenied`) — the acting user (anonymous or logged in) lacks the right to write
+- page is protected and cannot be edited
+- other wiki API errors (with the error code included)
+- unexpected errors
+- saved successfully, but the page URL could not be determined — still a success, just without a returned link
+
+## Authentication
+
+`username` and `password` are optional. The tool connects **anonymously** when both are empty, and only attempts to log in when both are set. Credentials are not required for every wiki — only wikis that restrict the relevant action reject the request.
+
+Two distinct failure modes can occur, and the tool reports them differently: **authentication** failure (the supplied `username`/`password` are wrong — the tool reports this directly), and **authorization** failure (the acting user, whether anonymous or logged in, lacks permission for that specific action on this wiki — MediaWiki denies the request itself, independent of whether login succeeded).
+
+When credentials are needed, use a [BotPassword](https://www.mediawiki.org/wiki/Manual:Bot_passwords) (Special:BotPasswords on your wiki) rather than a real account password. The expected format is `Username@BotName`.
+
+## Connecting to the Wiki
+
+`wiki_url` must be the full URL to your wiki's `api.php` script (for example `https://wiki.example.com/w/api.php`), starting with `http://` or `https://` and including a resolvable host. The tool can derive a working site path even from a URL that doesn't literally end in `/api.php`, but the supported and documented form is the full `api.php` URL.
+
+## Valves
+
+| Field | Required | Default | Description |
+|---|---|---|---|
+| `wiki_url` | **yes** | `""` | Full URL to the MediaWiki `api.php` script. Empty by default — the tool returns an error and will not run until this is set. |
+| `username` | no | `""` | MediaWiki username. For production wikis, use a BotPassword in the format `Username@BotName`. |
+| `password` | no | `""` | MediaWiki password or BotPassword token. |
+| `timeout` | no | `30` | Request timeout, in seconds. |
+| `edit_summary` | no | `"Saved via mAItion AI assistant"` | Edit summary recorded in the wiki page history. |
+| `max_search_results` | no | `10` | Maximum number of search results to return. Effective range 1–20 — values outside this range are clamped at runtime, not rejected. |
+| `max_page_chars` | no | `20000` | Maximum characters per page in search results; longer pages are truncated. Valid range 1–500,000, enforced at the schema level. |
+
+Tool id: `mediawiki`. Display name: "MediaWiki Search & Write Tool". Valves can be edited after install from **Workspace → Tools** in the Open WebUI admin UI.
+
+## Enabling via ENV
+
+Unlike the Knowledge Base Search tool, the MediaWiki tool **is opt-in**. It installs only when both of these are true at first-start initialization (the one-time setup that runs the first time the `openwebui` container boots):
+
+```bash
+# MediaWiki Tool (optional): set TOOL_MEDIAWIKI_ENABLED=True to auto-install the
+# MediaWiki Search & Write Tool on first boot. MEDIAWIKI_API_URL is required when enabled.
+TOOL_MEDIAWIKI_ENABLED=True
+MEDIAWIKI_API_URL=https://wiki.example.com/w/api.php
+MEDIAWIKI_USERNAME=
+MEDIAWIKI_PASSWORD=
+```
+
+- `TOOL_MEDIAWIKI_ENABLED=True` is required to attempt install.
+- `MEDIAWIKI_API_URL` must also be non-empty. If it's missing while the flag is `True`, the entrypoint script skips the install and prints a warning to the container logs — it does not fail the boot, so the omission is easy to miss.
+
+At install, only three valves are set from ENV:
+
+- `wiki_url` ← `MEDIAWIKI_API_URL`
+- `username` ← `MEDIAWIKI_USERNAME`
+- `password` ← `MEDIAWIKI_PASSWORD`
+
+`timeout`, `edit_summary`, `max_search_results`, and `max_page_chars` are **not** configurable via ENV. They stay at their defaults above unless changed later from Workspace → Tools.
+
+## Troubleshooting
+
+| Symptom | Cause |
+|---|---|
+| `Error: wiki_url is not configured.` | The `wiki_url` valve is empty. Set it via ENV (see above) or manually from Workspace → Tools. |
+| `Error: authentication failed. ...` | Login failed — check `username`/`password`. If using a BotPassword, confirm the `Username@BotName` format. |
+| `Error: this wiki requires authentication to search.` / `...to write.` | MediaWiki denied the request (`readapidenied`/`writeapidenied`/`permissiondenied`) — the acting user, anonymous or logged in, lacks the right for that action. If anonymous, configure `username` and `password`; if already logged in, the account itself lacks the required right. |
+| `Error: page '<title>' is protected.` | The page can't be edited by this account (save only). |
+| `Error: could not connect to the wiki. ...` | `wiki_url` is unreachable — check the URL and network path. |
+| Title-related errors (empty, too long, illegal character, contains `:`) | The title failed validation before any wiki API call was made (save only). See "Title rules" under [What It Does](#what-it-does) above. |


### PR DESCRIPTION
## Summary

Adds Mintlify documentation for the MediaWiki Search & Write Tool (`tools/mediawiki_tool.py`), under a new "Tools" docs section.

- New nav group `Tools` in `docs/docs.json`, sibling to `Connectors` and `Configuration`.
- New page `docs/tools/mediawiki-tool.mdx` covering:
  - Both functions: `search_wiki` (full-text search, three `content_format` options, distinct error/edge outcomes) and `save_to_wiki` (creates/updates a page, exact title rules and illegal-character set, byte-based content size limit)
  - Authentication behavior — anonymous by default, credentials only attempted when both are set, BotPassword recommendation
  - Full Valves configuration reference table, including which valves have real Pydantic validation vs. runtime clamping
  - How it's enabled via ENV — genuinely opt-in, gated on **both** `TOOL_MEDIAWIKI_ENABLED=True` and non-empty `MEDIAWIKI_API_URL`; only 3 of 7 valves are ENV-configurable
  - Troubleshooting table for the tool's error paths

Docs-only change — no code, no runtime impact.

## Scope

Documents only `mediawiki_tool.py`, per ticket. `web_search` and `get_sources` are out of scope for this ticket.

## Note: overlaps with (#111)

Both this PR and #111 (ROAT retrieval tool docs) add a `"Tools"` nav group to `docs/docs.json` at the same location, since this branch was created from `main` before #111 merged. Whichever merges second will need a small manual conflict resolution merging both `pages` arrays into one `"Tools"` group rather than keeping two separate groups.

## Test plan

- [x] `docs/docs.json` validated as well-formed JSON
- [x] Every factual claim cross-checked line-by-line against `tools/mediawiki_tool.py`, `tools/mediawiki_tool.json`, `helpers/entrypoint.sh`, and `.env.openwebui.example`, including a second independent re-verification pass after the initial draft that caught additional gaps (missing auth-failure error outcomes, a broken doc anchor link, a dropped docstring qualifier)
- [x] Independent second opinion via `codex exec` consult against the plan and source files before implementation
- [ ] Optional: preview locally via `cd docs && docker compose up -d --build` on port 3333

Jira: WIK-2589