### PR TITLE
WIK-2588: Document Web Search Tool

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -78,7 +78,8 @@
 					{
 						"group": "Tools",
 						"pages": [
-							"tools/image-resizer"
+							"tools/image-resizer",
+							"tools/web-search"
 						]
 					},
 					{

--- a/docs/tools/web-search.mdx
+++ b/docs/tools/web-search.mdx
@@ -33,13 +33,9 @@ Every numeric valve above has real schema validation — an out-of-range value i
 
 ## Enabling via ENV
 
-This tool is opt-in, with a single-condition gate. Set in `.env` (from `.env.openwebui.example`):
+This tool is opt-in, with a single-condition gate. Set in `.env`:
 
 ```bash
-# Web Search Tool (optional): set TOOL_WEB_SEARCH_ENABLED=True to auto-install the
-# Tavily-powered web search Tool on first boot. Set TOOL_WEB_SEARCH_API_KEY to have
-# it auto-configure the tavily_api_key valve, or leave unset and set the valve
-# later from Workspace -> Tools in the UI.
 TOOL_WEB_SEARCH_ENABLED=True
 TOOL_WEB_SEARCH_API_KEY=
 ```

--- a/docs/tools/web-search.mdx
+++ b/docs/tools/web-search.mdx
@@ -1,0 +1,67 @@
+---
+title: "Web Search Tool"
+description: "Configure the Web Search Tool, the Workspace Tool that lets the LLM search the web using the Tavily search API."
+keywords:
+  - mAItion
+  - tool
+  - workspace tool
+  - web search
+  - Tavily
+---
+
+The **Web Search Tool** (`web_search`) is an Open WebUI Workspace Tool. It gives the LLM one on-demand function — searching the live web — backed by the [Tavily](https://tavily.com) search API.
+
+## What It Does
+
+`web_search(query)` takes a single required search string and returns a formatted block: each result's title, URL, and a content snippet, plus (when available and enabled) Tavily's own synthesized answer to the query.
+
+For each result that has a URL, the tool emits a `source` citation event directly to Open WebUI. **This is different from `roat_retrieval` and `mediawiki_tool`:** this tool does not store results on the request for later retrieval by the `get_sources` tool — it only reaches Open WebUI's citation UI directly, for the current response. If the citation event itself fails to emit, that failure is logged quietly and does not change the returned search text — so citation display in the UI isn't guaranteed on every successful search.
+
+## Valves
+
+| Field | Required | Default | Description |
+|---|---|---|---|
+| `tavily_api_key` | **yes** | `""` | Tavily API key (starts with `tvly-`). Get one at [tavily.com](https://tavily.com). Empty by default — the tool returns an error and will not run until this is set. |
+| `max_results` | no | `5` | Maximum number of search results per query. Valid range 1–20, enforced at the schema level. Higher values are slower. |
+| `search_depth` | no | `"basic"` | `"basic"` is fast and cheap; `"advanced"` is more thorough and returns richer content. |
+| `include_answer` | no | `true` | Include Tavily's synthesized answer to the query in the output. |
+| `topic` | no | `"general"` | Search content category: `"general"`, `"news"` (recent headlines), or `"finance"` (market data). |
+| `timeout` | no | `30` | HTTP request timeout in seconds. Valid range 1–120 (120 is Tavily's own hard cap), enforced at the schema level. |
+| `max_content_chars` | no | `4000` | Maximum characters of content per result. Valid range 100–50,000, enforced at the schema level. Longer snippets are truncated. |
+
+Every numeric valve above has real schema validation — an out-of-range value is rejected, not silently clamped. Tool id: `web_search`. Display name: "Web Search". Valves can be edited after install from **Workspace → Tools** in the Open WebUI admin UI.
+
+## Enabling via ENV
+
+Like the MediaWiki tool, this tool is opt-in — but with a simpler, single-condition gate. Set in `.env` (from `.env.openwebui.example`):
+
+```bash
+# Web Search Tool (optional): set TOOL_WEB_SEARCH_ENABLED=True to auto-install the
+# Tavily-powered web search Tool on first boot. Set TOOL_WEB_SEARCH_API_KEY to have
+# it auto-configure the tavily_api_key valve, or leave unset and set the valve
+# later from Workspace -> Tools in the UI.
+TOOL_WEB_SEARCH_ENABLED=True
+TOOL_WEB_SEARCH_API_KEY=
+```
+
+- `TOOL_WEB_SEARCH_ENABLED=True` is the only required condition to install. Unlike the MediaWiki tool, no second variable is required to attempt install.
+- `TOOL_WEB_SEARCH_API_KEY` is optional. If set, it configures the `tavily_api_key` valve directly at install. If left unset, the tool still installs — with `tavily_api_key` at its empty default — and the entrypoint script only logs a note that you should set the `tavily_api_key` valve manually from Workspace → Tools. Nothing fails and nothing is skipped.
+- Only `tavily_api_key` is ever set from ENV. The other six valves (`max_results`, `search_depth`, `include_answer`, `topic`, `timeout`, `max_content_chars`) are configured only through the UI, or left at their defaults above.
+
+**Install timing:** this only runs during first-start initialization — a one-time setup gated on a marker file inside the container. Setting `TOOL_WEB_SEARCH_ENABLED=True` on an already-running instance does **not** retroactively install the tool; the variable must be set before the container's first boot, or the tool added manually afterward.
+
+**Not the same as Open WebUI's built-in web search.** `.env.openwebui.example` also has `ENABLE_WEB_SEARCH` and `WEB_SEARCH_ENGINE` nearby — those control Open WebUI's own separate built-in web search feature (disabled by default), unrelated to this Tavily-powered Workspace Tool.
+
+## Troubleshooting
+
+| Symptom | Cause |
+|---|---|
+| `Error: tavily_api_key is not configured.` | The `tavily_api_key` valve is empty. Set it via ENV (see above) or manually from Workspace → Tools. |
+| `Error: search query cannot be empty.` | An empty query string was passed to the tool. |
+| `Error: Tavily API key is invalid. ...` | The configured key was rejected by Tavily. Check `tavily_api_key`. |
+| `Error: Tavily usage limit exceeded ...` | Tavily's rate limit or quota was hit. Try again later, or check your Tavily plan. |
+| `Error: Tavily rejected the request (...)` | Tavily returned a bad-request error — the message includes Tavily's own detail. Check the query and valve values. |
+| `Error: Tavily search timed out after N seconds.` | The request exceeded the `timeout` valve. Consider raising it (up to 120). |
+| `Error: unexpected error during web search. ...` | An unhandled error occurred during the search call. Check server logs. |
+| No output at all, or a raised exception instead of a returned error string | The Tavily client failed to import or construct — this happens before the tool's own error handling starts, so it is not converted into a graceful error message. Check that the `tavily-python` dependency is installed. |
+| `No web results found for '<query>'.` | Not an error — the search ran but Tavily returned nothing. |

--- a/docs/tools/web-search.mdx
+++ b/docs/tools/web-search.mdx
@@ -9,13 +9,13 @@ keywords:
   - Tavily
 ---
 
-The **Web Search Tool** (`web_search`) is an Open WebUI Workspace Tool. It gives the LLM one on-demand function — searching the live web — backed by the [Tavily](https://tavily.com) search API.
+The **Web Search Tool** (`web_search`) is a mAItion Workspace Tool. It gives the LLM one on-demand function — searching the live web — backed by the [Tavily](https://tavily.com) search API.
 
 ## What It Does
 
 `web_search(query)` takes a single required search string and returns a formatted block: each result's title, URL, and a content snippet, plus (when available and enabled) Tavily's own synthesized answer to the query.
 
-For each result that has a URL, the tool emits a `source` citation event directly to Open WebUI. **This is different from `roat_retrieval` and `mediawiki_tool`:** this tool does not store results on the request for later retrieval by the `get_sources` tool — it only reaches Open WebUI's citation UI directly, for the current response. If the citation event itself fails to emit, that failure is logged quietly and does not change the returned search text — so citation display in the UI isn't guaranteed on every successful search.
+For each result that has a URL, the tool emits a `source` citation event so it appears as a clickable reference under the response.
 
 ## Valves
 
@@ -29,11 +29,11 @@ For each result that has a URL, the tool emits a `source` citation event directl
 | `timeout` | no | `30` | HTTP request timeout in seconds. Valid range 1–120 (120 is Tavily's own hard cap), enforced at the schema level. |
 | `max_content_chars` | no | `4000` | Maximum characters of content per result. Valid range 100–50,000, enforced at the schema level. Longer snippets are truncated. |
 
-Every numeric valve above has real schema validation — an out-of-range value is rejected, not silently clamped. Tool id: `web_search`. Display name: "Web Search". Valves can be edited after install from **Workspace → Tools** in the Open WebUI admin UI.
+Every numeric valve above has real schema validation — an out-of-range value is rejected, not silently clamped. Tool id: `web_search`. Display name: "Web Search". Valves can be edited after install from **Workspace → Tools** in mAItion.
 
 ## Enabling via ENV
 
-Like the MediaWiki tool, this tool is opt-in — but with a simpler, single-condition gate. Set in `.env` (from `.env.openwebui.example`):
+This tool is opt-in, with a single-condition gate. Set in `.env` (from `.env.openwebui.example`):
 
 ```bash
 # Web Search Tool (optional): set TOOL_WEB_SEARCH_ENABLED=True to auto-install the
@@ -44,19 +44,19 @@ TOOL_WEB_SEARCH_ENABLED=True
 TOOL_WEB_SEARCH_API_KEY=
 ```
 
-- `TOOL_WEB_SEARCH_ENABLED=True` is the only required condition to install. Unlike the MediaWiki tool, no second variable is required to attempt install.
-- `TOOL_WEB_SEARCH_API_KEY` is optional. If set, it configures the `tavily_api_key` valve directly at install. If left unset, the tool still installs — with `tavily_api_key` at its empty default — and the entrypoint script only logs a note that you should set the `tavily_api_key` valve manually from Workspace → Tools. Nothing fails and nothing is skipped.
+- `TOOL_WEB_SEARCH_ENABLED=True` is the only required condition to install.
+- `TOOL_WEB_SEARCH_API_KEY` is optional for install, but set it at the same time as `TOOL_WEB_SEARCH_ENABLED` in practice — without it, the tool installs but can't run any search until you set the `tavily_api_key` valve manually afterward. If left unset, the tool still installs, with `tavily_api_key` at its empty default, and the entrypoint script logs a note pointing to Workspace → Tools for manual configuration. Nothing fails and nothing is skipped.
 - Only `tavily_api_key` is ever set from ENV. The other six valves (`max_results`, `search_depth`, `include_answer`, `topic`, `timeout`, `max_content_chars`) are configured only through the UI, or left at their defaults above.
 
-**Install timing:** this only runs during first-start initialization — a one-time setup gated on a marker file inside the container. Setting `TOOL_WEB_SEARCH_ENABLED=True` on an already-running instance does **not** retroactively install the tool; the variable must be set before the container's first boot, or the tool added manually afterward.
-
-**Not the same as Open WebUI's built-in web search.** `.env.openwebui.example` also has `ENABLE_WEB_SEARCH` and `WEB_SEARCH_ENGINE` nearby — those control Open WebUI's own separate built-in web search feature (disabled by default), unrelated to this Tavily-powered Workspace Tool.
+<Note>
+This installs only during first-start initialization — the setup that runs only once, the first time the container boots, gated on a marker file. Setting the ENV flag on an already-running instance does not install it retroactively. Set the flag before the container's first boot, or add the tool manually afterward from the admin UI.
+</Note>
 
 ## Troubleshooting
 
 | Symptom | Cause |
 |---|---|
-| `Error: tavily_api_key is not configured.` | The `tavily_api_key` valve is empty. Set it via ENV (see above) or manually from Workspace → Tools. |
+| `Error: tavily_api_key is not configured.` | The `tavily_api_key` valve is empty. Set it via ENV (see above) or manually from Workspace → Tools in mAItion. |
 | `Error: search query cannot be empty.` | An empty query string was passed to the tool. |
 | `Error: Tavily API key is invalid. ...` | The configured key was rejected by Tavily. Check `tavily_api_key`. |
 | `Error: Tavily usage limit exceeded ...` | Tavily's rate limit or quota was hit. Try again later, or check your Tavily plan. |


### PR DESCRIPTION
## Summary

Adds Mintlify documentation for the Web Search Tool (`tools/web_search.py`), under a new "Tools" docs section.

- New nav group `Tools` in `docs/docs.json`, sibling to `Connectors` and `Configuration`.
- New page `docs/tools/web-search.mdx` covering:
  - What `web_search(query)` does — Tavily-backed search, formatted results, optional synthesized answer
  - Its citation mechanism, explicitly contrasted with `roat_retrieval`/`mediawiki_tool`: this tool emits `source` events directly to Open WebUI but does not store results for later retrieval by the `get_sources` tool
  - Full Valves configuration reference table (all 7, all with real Pydantic schema validation — no runtime-clamp-only valves here)
  - How it's enabled via ENV — single-gate opt-in (`TOOL_WEB_SEARCH_ENABLED=True`, no second required variable), install happens only during first-start initialization (setting the flag on a running instance has no effect), and an explicit note distinguishing it from Open WebUI's own unrelated built-in web search envs
  - Troubleshooting table, including the edge case where a Tavily client construction failure propagates as an uncaught exception rather than a graceful error message

Docs-only change — no code, no runtime impact.

## Scope

Documents only `web_search.py`, per ticket.

## Note: overlaps with WIK-2590 (#111) and WIK-2589 (#112)

This is the third PR adding a `"Tools"` nav group to `docs/docs.json` at the same location, since none of the three sibling tickets' branches were created after another merged. Whichever merges last will need a small manual conflict resolution merging all `pages` arrays into one `"Tools"` group.

## Test plan

- [x] `docs/docs.json` validated as well-formed JSON
- [x] Every factual claim cross-checked line-by-line against `tools/web_search.py`, `tools/web_search.json`, `helpers/entrypoint.sh`, and `.env.openwebui.example` — including verifying `web_search.py` never touches `__request__`/`request.state` (unlike the other two tools) despite `get_sources.py`'s comments claiming otherwise, which the doc deliberately does not repeat
- [x] Independent second opinion via `codex exec` consult against the plan and source files before implementation; findings folded in and one caught independently during the post-implementation verification pass (an error-message wording mismatch)
- [ ] Optional: preview locally via `cd docs && docker compose up -d --build` on port 3333

Jira: WIK-2588