### PR TITLE
WIK-2586: Document Image Resizer function

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -76,6 +76,12 @@
 						]
 					},
 					{
+						"group": "Tools",
+						"pages": [
+							"tools/image-resizer"
+						]
+					},
+					{
 						"group": "Configuration",
 						"pages": [
 							"configuration/config-reference",

--- a/docs/tools/image-resizer.mdx
+++ b/docs/tools/image-resizer.mdx
@@ -1,0 +1,71 @@
+---
+title: "Image Resizer Filter"
+description: "Configure the Image Resizer Filter, which downscales oversized images in chat messages before they reach the model."
+keywords:
+  - mAItion
+  - filter
+  - image
+  - resize
+  - downscale
+---
+
+The **Image Resizer Filter** (`image_resizer`) is an Open WebUI **Filter**, not a Workspace Tool. It uses the `inlet` hook: it runs automatically on every **incoming** message, before the model ever sees it. This is the opposite direction from the [Video Inject Filter](/tools/video-inject), which uses `outlet` and runs on the **response**, after the model replies.
+
+## What It Does
+
+The filter scans every message for `content` items whose type is `image_url` and whose `image_url.url` starts with `data:image/` (a case-sensitive substring match — a URL like `data:IMAGE/...` would not match). Everything else — text, non-`data:image/` URLs, malformed `content`/`image_url` structures — is skipped without modification.
+
+### Two safety limits, at two different points
+
+- **Before decoding:** if the base64-encoded payload is longer than 26,214,400 characters (25 × 1024 × 1024 — 25 MiB), the filter rejects it outright, before ever calling `base64.b64decode`. This guards against being forced into a large in-memory decode by an oversized attachment.
+- **After decoding:** once the image is decoded and opened with Pillow, the filter checks its pixel count (width × height). If that exceeds 64,000,000 pixels, the filter rejects it. This guards against a small file that decompresses into a huge pixel grid — a decompression-bomb style input.
+
+### Animated images are left untouched
+
+If Pillow reports the opened image as animated (GIF/APNG/WebP), the filter skips it completely — it does not collapse the animation to a static first frame.
+
+### No cross-turn cache
+
+Open WebUI resends the full message history on every request, so every historical image gets decoded, opened, and measured again each turn — there's no caching. Only the resize-and-re-encode step is skipped for an image that's already at or under `max_dimension`; the decode and inspection work still happens every time.
+
+### Resizing and re-encoding
+
+For a static image whose largest dimension exceeds the `max_dimension` valve, the filter downscales it with Lanczos resampling (preserving aspect ratio) and re-encodes it back into the same `data:` URL in place.
+
+The output format and MIME type come from Pillow's own detection of the decoded bytes, trusted over whatever MIME type the original data URL declared:
+
+1. The image is saved using Pillow's detected format (e.g. `JPEG`, `PNG`).
+2. The new data URL's MIME string is derived from that same detected format via Pillow's `Image.MIME` mapping, falling back to a computed `image/<format lowercased>` string if the format isn't in that mapping.
+
+If Pillow can't open the payload at all, or opens it but reports no identifiable format, the image is treated as corrupted and skipped — both are distinct failure points, caught the same way.
+
+### Error handling boundary
+
+Each image's processing (decode, format detection, resize, either safety limit) is wrapped in its own error handling: any failure there is logged as a warning, and that one image is left unmodified, without failing the whole request or blocking other images from processing. This protection is per-image, not for the outer loop over messages — the filter does not separately verify that every entry in the message list is itself a well-formed structure before working on it.
+
+## Valves
+
+| Field | Required | Default | Description |
+|---|---|---|---|
+| `max_dimension` | no | `768` | Maximum image dimension, in pixels. Minimum `1`, no upper bound. Images with a larger dimension are downscaled; smaller ones are left as-is. |
+
+The filter also declares an empty `UserValves` class and accepts a `__user__` parameter — both are present in the source but currently unused, with no effect on behavior.
+
+The `max_dimension` valve can be edited after install from the function's settings in the Open WebUI admin UI.
+
+## Enabling via ENV
+
+Single-gate opt-in, like the Video Inject Filter. Set in `.env` (from `.env.openwebui.example`):
+
+```bash
+# Image Resizer Filter (optional): set FUNCTION_IMAGE_RESIZER_ENABLED=True to auto-install
+# the image downscaling filter on first boot. max_dimension (default 768px) is
+# controlled via the filter's Valve in the admin UI, not an env var.
+FUNCTION_IMAGE_RESIZER_ENABLED=True
+```
+
+**Install timing:** like every other entrypoint-installed piece documented in this section, this only runs during first-start initialization. Setting `FUNCTION_IMAGE_RESIZER_ENABLED=True` on an already-running instance does not retroactively install the filter.
+
+**Install mechanics** match the Video Inject Filter exactly: this filter is created through Open WebUI's Functions API (`/api/v1/functions/create`), then enabled (`/toggle`), then enabled globally (`/toggle/global`).
+
+**No valve is configurable via ENV for this filter.** `max_dimension` is UI-only — there is no `FUNCTION_IMAGE_RESIZER_MAX_DIMENSION`-style variable, and the entrypoint makes no valve-configuration call after install, unlike the tools elsewhere in this section that have at least one ENV-wired valve.

--- a/docs/tools/image-resizer.mdx
+++ b/docs/tools/image-resizer.mdx
@@ -11,12 +11,6 @@ keywords:
 
 The **Image Resizer Filter** (`image_resizer`) is a mAItion **Filter**, not a Workspace Tool. It runs automatically on every **incoming** message, before the model ever sees it.
 
-## What It Does
-
-The filter scans every message for `content` items whose type is `image_url` and whose `image_url.url` starts with `data:image/`. Everything else — text, non-`data:image/` URLs, malformed `content`/`image_url` structures — is skipped without modification.
-
-For a static image whose largest dimension exceeds the `max_dimension` valve, the filter downscales it, preserving aspect ratio, and re-encodes it back into the same `data:` URL in place. Images already at or under `max_dimension` are left as-is.
-
 ## Valves
 
 | Field | Required | Default | Description |

--- a/docs/tools/image-resizer.mdx
+++ b/docs/tools/image-resizer.mdx
@@ -9,39 +9,13 @@ keywords:
   - downscale
 ---
 
-The **Image Resizer Filter** (`image_resizer`) is an Open WebUI **Filter**, not a Workspace Tool. It uses the `inlet` hook: it runs automatically on every **incoming** message, before the model ever sees it. This is the opposite direction from the [Video Inject Filter](/tools/video-inject), which uses `outlet` and runs on the **response**, after the model replies.
+The **Image Resizer Filter** (`image_resizer`) is a mAItion **Filter**, not a Workspace Tool. It runs automatically on every **incoming** message, before the model ever sees it.
 
 ## What It Does
 
-The filter scans every message for `content` items whose type is `image_url` and whose `image_url.url` starts with `data:image/` (a case-sensitive substring match — a URL like `data:IMAGE/...` would not match). Everything else — text, non-`data:image/` URLs, malformed `content`/`image_url` structures — is skipped without modification.
+The filter scans every message for `content` items whose type is `image_url` and whose `image_url.url` starts with `data:image/`. Everything else — text, non-`data:image/` URLs, malformed `content`/`image_url` structures — is skipped without modification.
 
-### Two safety limits, at two different points
-
-- **Before decoding:** if the base64-encoded payload is longer than 26,214,400 characters (25 × 1024 × 1024 — 25 MiB), the filter rejects it outright, before ever calling `base64.b64decode`. This guards against being forced into a large in-memory decode by an oversized attachment.
-- **After decoding:** once the image is decoded and opened with Pillow, the filter checks its pixel count (width × height). If that exceeds 64,000,000 pixels, the filter rejects it. This guards against a small file that decompresses into a huge pixel grid — a decompression-bomb style input.
-
-### Animated images are left untouched
-
-If Pillow reports the opened image as animated (GIF/APNG/WebP), the filter skips it completely — it does not collapse the animation to a static first frame.
-
-### No cross-turn cache
-
-Open WebUI resends the full message history on every request, so every historical image gets decoded, opened, and measured again each turn — there's no caching. Only the resize-and-re-encode step is skipped for an image that's already at or under `max_dimension`; the decode and inspection work still happens every time.
-
-### Resizing and re-encoding
-
-For a static image whose largest dimension exceeds the `max_dimension` valve, the filter downscales it with Lanczos resampling (preserving aspect ratio) and re-encodes it back into the same `data:` URL in place.
-
-The output format and MIME type come from Pillow's own detection of the decoded bytes, trusted over whatever MIME type the original data URL declared:
-
-1. The image is saved using Pillow's detected format (e.g. `JPEG`, `PNG`).
-2. The new data URL's MIME string is derived from that same detected format via Pillow's `Image.MIME` mapping, falling back to a computed `image/<format lowercased>` string if the format isn't in that mapping.
-
-If Pillow can't open the payload at all, or opens it but reports no identifiable format, the image is treated as corrupted and skipped — both are distinct failure points, caught the same way.
-
-### Error handling boundary
-
-Each image's processing (decode, format detection, resize, either safety limit) is wrapped in its own error handling: any failure there is logged as a warning, and that one image is left unmodified, without failing the whole request or blocking other images from processing. This protection is per-image, not for the outer loop over messages — the filter does not separately verify that every entry in the message list is itself a well-formed structure before working on it.
+For a static image whose largest dimension exceeds the `max_dimension` valve, the filter downscales it, preserving aspect ratio, and re-encodes it back into the same `data:` URL in place. Images already at or under `max_dimension` are left as-is.
 
 ## Valves
 
@@ -49,23 +23,18 @@ Each image's processing (decode, format detection, resize, either safety limit) 
 |---|---|---|---|
 | `max_dimension` | no | `768` | Maximum image dimension, in pixels. Minimum `1`, no upper bound. Images with a larger dimension are downscaled; smaller ones are left as-is. |
 
-The filter also declares an empty `UserValves` class and accepts a `__user__` parameter — both are present in the source but currently unused, with no effect on behavior.
-
-The `max_dimension` valve can be edited after install from the function's settings in the Open WebUI admin UI.
+The `max_dimension` valve can be edited after install from the filter's settings in mAItion.
 
 ## Enabling via ENV
 
-Single-gate opt-in, like the Video Inject Filter. Set in `.env` (from `.env.openwebui.example`):
+Single-gate opt-in. Set in `.env`:
 
 ```bash
-# Image Resizer Filter (optional): set FUNCTION_IMAGE_RESIZER_ENABLED=True to auto-install
-# the image downscaling filter on first boot. max_dimension (default 768px) is
-# controlled via the filter's Valve in the admin UI, not an env var.
 FUNCTION_IMAGE_RESIZER_ENABLED=True
 ```
 
-**Install timing:** like every other entrypoint-installed piece documented in this section, this only runs during first-start initialization. Setting `FUNCTION_IMAGE_RESIZER_ENABLED=True` on an already-running instance does not retroactively install the filter.
+`FUNCTION_IMAGE_RESIZER_ENABLED=True` is the only required condition to install. `max_dimension` is UI-only and stays at its default until changed from the filter's settings.
 
-**Install mechanics** match the Video Inject Filter exactly: this filter is created through Open WebUI's Functions API (`/api/v1/functions/create`), then enabled (`/toggle`), then enabled globally (`/toggle/global`).
-
-**No valve is configurable via ENV for this filter.** `max_dimension` is UI-only — there is no `FUNCTION_IMAGE_RESIZER_MAX_DIMENSION`-style variable, and the entrypoint makes no valve-configuration call after install, unlike the tools elsewhere in this section that have at least one ENV-wired valve.
+<Note>
+This installs only during first-start initialization — the setup that runs only once, the first time the container boots, gated on a marker file. Setting `FUNCTION_IMAGE_RESIZER_ENABLED=True` on an already-running instance does not install it retroactively.
+</Note>


### PR DESCRIPTION
## Summary

Adds Mintlify documentation for the Image Resizer Filter (`functions/image_resizer.py`), under a new "Tools" docs section.

- New nav group `Tools` in `docs/docs.json`, sibling to `Connectors` and `Configuration`.
- New page `docs/tools/image-resizer.mdx` covering:
  - This is an Open WebUI **Filter** using the `inlet` hook (incoming messages, before the model sees them) — explicitly contrasted with the Video Inject Filter's `outlet` hook (the response, after the model replies)
  - The two safety limits (26,214,400-character encoded payload cap, 64,000,000-pixel decoded cap) and, precisely, that only the first is checked *before* decoding — the pixel check happens after
  - Animated-image skip, the no-cross-turn-cache behavior, and the format/MIME derivation chain (Pillow's detected format → `Image.MIME` lookup → computed fallback)
  - The error-handling boundary: per-image failures are caught gracefully, but the outer loop over messages isn't separately guarded
  - Its one real Valve, `max_dimension` — and states plainly it is **not** ENV-configurable (confirmed by `.env.openwebui.example`'s own comment), unlike every ENV-wired valve documented elsewhere in this section
  - The dead `UserValves`/`__user__` (present in source, unused, no effect)
  - How it's enabled via ENV — single-gate, first-start-only, create+toggle+toggle/global install mechanics matching Video Inject

Docs-only change — no code, no runtime impact.

## Scope

Documents only `image_resizer.py`, per ticket.

## Note: two cross-branch dependencies

1. Same as the four prior PRs in this series (#111, #112, #113, #114): all five branches add a `"Tools"` nav group to `docs/docs.json` at the same location. Whichever merges last needs a small manual conflict resolution merging all `pages` arrays into one group.
2. The doc links to `[Video Inject Filter](/tools/video-inject)`, which only exists once WIK-2587 (#114) merges. Correct reference, becomes live once that lands.

## Test plan

- [x] `docs/docs.json` validated as well-formed JSON
- [x] Every factual claim cross-checked line-by-line against `functions/image_resizer.py`, `functions/image_resizer.json`, `helpers/entrypoint.sh`, and `.env.openwebui.example`
- [x] Independent second opinion via `codex exec` consult against the plan and source files before implementation — caught several real precision errors in the first draft (both safety checks claimed as "before decoding" when only one is, an overstated error-handling claim, an imprecise MIME-derivation description), all fixed before implementation
- [x] A further self-check during the post-implementation verification pass caught and removed an unverified "Workspace → Functions" admin-UI claim that had no support anywhere in this repository
- [ ] Optional: preview locally via `cd docs && docker compose up -d --build` on port 3333

Jira: WIK-2586