### PR TITLE
SLOP-145: Remove hardcoded WEBUI_SECRET_KEY from env example

### DIFF
--- a/.env.openwebui.example
+++ b/.env.openwebui.example
@@ -4,7 +4,7 @@ WEBUI_URL=http://localhost:3000
 # on what port to listed on the host
 HTTP_WEB_PORT=3000
 # replace with your key, generate via `openssl rand -hex 32`
-WEBUI_SECRET_KEY=b7989c04e931fbbbf885fef7a4e19434cda1f88c485eac67fb01868418b1be21
+#WEBUI_SECRET_KEY=
 
 # database credentials
 # NOTE: if you change the user from `postgres` you must also update the user


### PR DESCRIPTION
## Summary
- `.env.openwebui.example` shipped a live-format 64-hex-char `WEBUI_SECRET_KEY` (line 7). Unlike every other credential in the file (obvious `your-...`/`xxx` placeholders, commented out), this is real output of `openssl rand -hex 32` presented as ready-to-use.
- OpenWebUI gives the `WEBUI_SECRET_KEY` env var precedence over its auto-generated persisted key, so any deployment that copies the example to `.env` (exactly what the README quick start instructs) signs login JWTs and derives OAuth-session encryption keys from a secret that is public in this repo.
- Replace it with a commented placeholder plus the existing generation hint, matching the file's other placeholder conventions.

## Security follow-up (manual)
- Rotate `WEBUI_SECRET_KEY` on any environment deployed with the committed value. Note: rotation invalidates all existing sessions and stored provider credentials must be re-authenticated.
- Git history is intentionally not rewritten; rotation is the mitigation.

Closes SLOP-145

## Test plan
- [ ] `grep WEBUI_SECRET_KEY .env.openwebui.example` shows only the commented placeholder
- [ ] Fresh `docker compose up -d` with a generated key boots and admin login works