### PR TITLE
MAIT-322: Make MediaWiki tool descriptions dynamic based on wiki_url

### DIFF
--- a/tools/mediawiki_tool.py
+++ b/tools/mediawiki_tool.py
@@ -9,11 +9,12 @@ requirements: mwclient>=0.10.1, pydantic>=2.0.0, markdownify>=0.13.1
 """
 
 import asyncio
+import functools
 import hashlib
+import inspect
 import logging
 import re
 from collections.abc import Awaitable, Callable
-from typing import Literal
 from urllib.parse import quote, urljoin, urlparse
 
 from pydantic import BaseModel, Field
@@ -58,6 +59,97 @@ def to_source_id(text: str) -> str:
     if slug:
         return f"{slug}-{digest}"
     return f"src-{digest}"
+
+
+def _insert_before_args(docstring: str, hint: str) -> str:
+    """
+    Insert `hint` into `docstring` right before the `Args:` section.
+
+    OWUI's own docstring parsing (parse_description/parse_docstring in
+    open_webui/utils/tools.py, and the middleware's `:param`/`:return` regex
+    split) treats everything before `Args:`/`:param` as the tool description
+    and the rest as per-parameter docs. Appending the hint after `Returns:`
+    would risk it being dropped or bleeding into parsed return-value text, so
+    it must land in the description portion instead.
+    """
+    if not hint:
+        return docstring
+    marker = "\n\n        Args:"
+    idx = docstring.find(marker)
+    if idx == -1:
+        return docstring + hint
+    return docstring[:idx] + hint + docstring[idx:]
+
+
+class _DynamicDocMethod:
+    """
+    Descriptor that makes a method's __doc__ computed live from the owning
+    instance's `valves`, instead of a fixed string.
+
+    OWUI rebuilds this tool's function-calling spec on every chat request by
+    reading `callable.__doc__` off the live, cached module instance (after
+    reassigning valves to it) — see open_webui/utils/tools.py::get_tools().
+    A plain docstring is a shared function/class attribute, so it can't
+    reflect per-instance valve values.
+
+    An earlier version of this fix renamed the method to a private "_impl"
+    variant and monkeypatched `self.search_wiki` in the valves setter. That
+    broke in practice: OWUI's get_functions_from_tool() only filters names
+    starting with "__" (true dunders), not a single underscore — and Python's
+    own name-mangling for double-underscore-prefixed methods still produces a
+    single-underscore name at the dir()-visible level. So any second callable
+    on the instance (however it's named) gets picked up as an extra, spurious
+    tool with an empty/wrong description. This descriptor avoids that
+    entirely: `dir(instance)` still reports exactly one name — the same
+    `search_wiki`/`save_to_wiki` as before — with __doc__ computed on access.
+    """
+
+    def __init__(self, func, doc_builder):
+        self._func = func
+        self._doc_builder = doc_builder
+        functools.update_wrapper(self, func)
+        # Signature with `self` stripped, matching what a normal bound method
+        # exposes to inspect.signature(). Computed once: the parameter SHAPE
+        # never changes, only the __doc__ text does.
+        sig = inspect.signature(func)
+        self._bound_signature = sig.replace(parameters=[p for name, p in sig.parameters.items() if name != "self"])
+
+    def __get__(self, instance, owner):
+        if instance is None:
+            return self._func  # class-level access, e.g. Tools.search_wiki
+
+        func = self._func
+        doc = self._doc_builder(instance)
+        bound_signature = self._bound_signature
+
+        @functools.wraps(func)
+        async def bound(*args, **kwargs):
+            return await func(instance, *args, **kwargs)
+
+        bound.__doc__ = doc
+        bound.__signature__ = bound_signature
+        return bound
+
+
+def _dynamic_doc(doc_builder):
+    """Class-body decorator: `doc_builder(instance) -> str` computes __doc__ per-access."""
+
+    def decorator(func):
+        return _DynamicDocMethod(func, doc_builder)
+
+    return decorator
+
+
+def _wiki_hint(valves: "Tools.Valves") -> str:
+    wiki_url = valves.wiki_url.strip()
+    if not wiki_url:
+        return ""
+    return f"\n\nAny URL starting with {wiki_url} belongs to this wiki — use this tool for it."
+
+
+def _wiki_hinted_doc(template: str):
+    """Doc builder: splice the current wiki_url hint into `template` before its Args: section."""
+    return lambda instance: _insert_before_args(template, _wiki_hint(instance.valves))
 
 
 def _parse_wiki_url(wiki_url: str) -> tuple[str, str, str]:
@@ -242,15 +334,10 @@ class Tools:
     def __init__(self):
         self.valves = self.Valves()
 
-    async def search_wiki(
-        self,
-        query: str,
-        content_format: Literal["wikitext", "html", "markdown"] = "wikitext",
-        __event_emitter__: Callable[[dict], Awaitable[None]] | None = None,
-        __request__=None,
-    ) -> str:
-        """
-        Search the MediaWiki wiki for pages matching a query and return their page content.
+    @_dynamic_doc(
+        _wiki_hinted_doc(
+            """
+        Search the MediaWiki wiki for pages matching a query and return their full wikitext content.
 
         Use this tool when the user asks to:
         - "search the wiki for ..." / "find wiki pages about ..."
@@ -273,6 +360,13 @@ class Tools:
         Returns:
             A formatted string with each result's title, URL, and page content, or an error.
         """
+        )
+    )
+    async def search_wiki(
+        self,
+        query: str,
+        __event_emitter__: Callable[[dict], Awaitable[None]] | None = None,
+    ) -> str:
         import mwclient
 
         async def emit(message: str, done: bool = False, hidden: bool = True) -> None:
@@ -472,13 +566,9 @@ class Tools:
         await emit(f"Found {len(pages)} result(s) for '{query}'.", done=True)
         return f"Search results for '{query}' ({len(pages)} page(s)):\n\n" + "\n---\n\n".join(sections)
 
-    async def save_to_wiki(
-        self,
-        title: str,
-        content: str,
-        __event_emitter__: Callable[[dict], Awaitable[None]] | None = None,
-    ) -> str:
-        """
+    @_dynamic_doc(
+        _wiki_hinted_doc(
+            """
         Save content to a MediaWiki page. Use this tool when the user asks to:
         - "save into wiki" / "save into knowledge base"
         - "write to wiki" / "create a wiki page"
@@ -508,6 +598,14 @@ class Tools:
         Returns:
             A URL to the created or updated wiki page, or an error message.
         """
+        )
+    )
+    async def save_to_wiki(
+        self,
+        title: str,
+        content: str,
+        __event_emitter__: Callable[[dict], Awaitable[None]] | None = None,
+    ) -> str:
         import mwclient
 
         async def emit(message: str, done: bool = False, hidden: bool = True) -> None:

--- a/tools/test_mediawiki_dynamic_doc.py
+++ b/tools/test_mediawiki_dynamic_doc.py
@@ -4,13 +4,17 @@ Standalone check for the dynamic, valve-dependent docstrings in mediawiki_tool.p
 wiki_url, refreshed whenever valves are (re)assigned, without leaking across
 Tools() instances or breaking OWUI's parameter-schema introspection.
 
-Run inside the api container (which has pydantic/requests/pyyaml installed):
+Run inside the api container (which has pydantic/mwclient installed):
     docker exec -it <api_container> python /app/tools/test_mediawiki_dynamic_doc.py
 
 Or on a bare host, stub the missing third-party deps first since this repo has
 no test framework/dependencies installed outside the Docker image:
-    pip install --user pydantic
+    pip install --user pydantic mwclient
     python3 tools/test_mediawiki_dynamic_doc.py
+
+No network access is required: the one check that calls search_wiki() patches
+out the mwclient connection so it fails fast on a stubbed error instead of
+making a real outbound request.
 """
 
 import asyncio
@@ -129,11 +133,17 @@ def main() -> int:
     check("get_type_hints resolves 'return' as str", hints.get("return") is str)
 
     # --- the wrapped method still forwards calls correctly to the real impl ---
+    # wiki_url IS configured on `t`, so this exercises the real connection path
+    # rather than the "not configured" short-circuit. The actual mwclient
+    # connection is stubbed to fail immediately -- no real network call to
+    # othersite.com and no 30s connection timeout -- while still proving
+    # args/kwargs are forwarded correctly through to _connect_site.
+    def _stub_connect_site(*args, **kwargs):
+        raise RuntimeError("stubbed: no real network connection in this check")
+
+    mod._connect_site = _stub_connect_site
+
     async def run_call():
-        # wiki_url IS configured on `t`, so this exercises the real connection
-        # path rather than the "not configured" short-circuit; expect it to
-        # fail at connection (no real wiki at othersite.com) rather than at
-        # argument handling, proving args/kwargs are forwarded correctly.
         return await t.search_wiki(query="test query")
 
     result = asyncio.run(run_call())

--- a/tools/test_mediawiki_dynamic_doc.py
+++ b/tools/test_mediawiki_dynamic_doc.py
@@ -1,0 +1,154 @@
+"""
+Standalone check for the dynamic, valve-dependent docstrings in mediawiki_tool.py
+(MAIT-322): search_wiki/save_to_wiki's descriptions should include the configured
+wiki_url, refreshed whenever valves are (re)assigned, without leaking across
+Tools() instances or breaking OWUI's parameter-schema introspection.
+
+Run inside the api container (which has pydantic/requests/pyyaml installed):
+    docker exec -it <api_container> python /app/tools/test_mediawiki_dynamic_doc.py
+
+Or on a bare host, stub the missing third-party deps first since this repo has
+no test framework/dependencies installed outside the Docker image:
+    pip install --user pydantic
+    python3 tools/test_mediawiki_dynamic_doc.py
+"""
+
+import asyncio
+import importlib.util
+import inspect
+import sys
+from pathlib import Path
+from typing import get_type_hints
+
+MODULE_PATH = Path(__file__).parent / "mediawiki_tool.py"
+
+
+def load_mediawiki_tool():
+    spec = importlib.util.spec_from_file_location("mediawiki_tool", MODULE_PATH)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def main() -> int:
+    mod = load_mediawiki_tool()
+    Tools = mod.Tools
+    total = 0
+    failures = []
+
+    def check(label: str, condition: bool):
+        nonlocal total
+        total += 1
+        status = "PASS" if condition else "FAIL"
+        print(f"{status}: {label}")
+        if not condition:
+            failures.append(label)
+
+    # --- OWUI's get_functions_from_tool only filters names starting with "__"
+    #     and excludes classes; anything else callable on the instance is
+    #     treated as a separate, spurious tool. Replicate that filter exactly
+    #     to guard against regressing to the private-"_impl"-method approach,
+    #     which broke in live testing: dir() exposed _search_wiki_impl,
+    #     _save_to_wiki_impl, etc. as extra tools with empty descriptions. ---
+    t_unset = Tools()
+    public_methods = sorted(
+        n
+        for n in dir(t_unset)
+        if callable(getattr(t_unset, n)) and not n.startswith("__") and not inspect.isclass(getattr(t_unset, n))
+    )
+    check(
+        "exactly search_wiki + save_to_wiki are visible to OWUI's tool introspection (no leaked helpers)",
+        public_methods == ["save_to_wiki", "search_wiki"],
+    )
+
+    # --- unset wiki_url: no hint text is present, and re-fetching the
+    #     docstring twice with the same (unset) valves is stable/idempotent.
+    #     (Tools.search_wiki.__doc__ is not a meaningful baseline here: class-
+    #     level access hits the descriptor's `instance is None` branch, which
+    #     returns the raw function whose literal __doc__ was never set --  the
+    #     doc text lives in the _dynamic_doc(...) decorator argument instead.) ---
+    check(
+        "unset wiki_url produces no dynamic hint text",
+        "belongs to this wiki" not in t_unset.search_wiki.__doc__,
+    )
+    check(
+        "docstring is stable across repeated access with unchanged valves",
+        t_unset.search_wiki.__doc__ == t_unset.search_wiki.__doc__,
+    )
+
+    # --- whitespace-only wiki_url must be treated as unset, not as a
+    #     configured (but broken) wiki -- regression test for a bug where
+    #     _wiki_hint checked truthiness without stripping, so a value like
+    #     "   " produced a misleading "connected" hint while every real
+    #     call failed _parse_wiki_url's http://https:// validation. ---
+    t_whitespace = Tools()
+    t_whitespace.valves = Tools.Valves(wiki_url="   ")
+    check(
+        "whitespace-only wiki_url produces no dynamic hint text",
+        "belongs to this wiki" not in t_whitespace.search_wiki.__doc__,
+    )
+
+    # --- setting wiki_url updates the docstring ---
+    wiki_url = "https://wiki.example.com/w/api.php"
+    t = Tools()
+    t.valves = Tools.Valves(wiki_url=wiki_url)
+    check("search_wiki docstring mentions configured wiki_url", wiki_url in t.search_wiki.__doc__)
+    check("save_to_wiki docstring mentions configured wiki_url", wiki_url in t.save_to_wiki.__doc__)
+    check(
+        "hint lands before Args: section (not after Returns:)",
+        t.search_wiki.__doc__.index(wiki_url) < t.search_wiki.__doc__.index("Args:"),
+    )
+
+    # --- reassigning valves updates the docstring again (simulates OWUI's
+    #     per-request module.valves = module.Valves(**stored_valves)) ---
+    other_url = "https://othersite.com/w/api.php"
+    t.valves = Tools.Valves(wiki_url=other_url)
+    check("docstring reflects the newly reassigned wiki_url", other_url in t.search_wiki.__doc__)
+    check("docstring no longer mentions the previous wiki_url", wiki_url not in t.search_wiki.__doc__)
+
+    # --- no cross-instance leakage: mutating t must not affect t2 ---
+    t2 = Tools()
+    check(
+        "a second, freshly-constructed instance is unaffected by t's valves",
+        other_url not in t2.search_wiki.__doc__,
+    )
+
+    # --- inspect.signature must match a normal bound method: no leaked `self`,
+    #     __event_emitter__ preserved with its annotation/default (what OWUI's
+    #     convert_function_to_pydantic_model relies on to build parameters) ---
+    sig = inspect.signature(t.search_wiki)
+    check("search_wiki signature has no leaked 'self' parameter", "self" not in sig.parameters)
+    check("search_wiki signature retains 'query' parameter", "query" in sig.parameters)
+    check(
+        "search_wiki signature retains '__event_emitter__' parameter",
+        "__event_emitter__" in sig.parameters,
+    )
+
+    hints = get_type_hints(t.search_wiki)
+    check("get_type_hints resolves 'query' as str", hints.get("query") is str)
+    check("get_type_hints resolves 'return' as str", hints.get("return") is str)
+
+    # --- the wrapped method still forwards calls correctly to the real impl ---
+    async def run_call():
+        # wiki_url IS configured on `t`, so this exercises the real connection
+        # path rather than the "not configured" short-circuit; expect it to
+        # fail at connection (no real wiki at othersite.com) rather than at
+        # argument handling, proving args/kwargs are forwarded correctly.
+        return await t.search_wiki(query="test query")
+
+    result = asyncio.run(run_call())
+    check(
+        "wrapped search_wiki forwards the call through to the real implementation",
+        isinstance(result, str) and result.startswith("Error:") and "not configured" not in result,
+    )
+
+    if failures:
+        print(f"\n{len(failures)}/{total} check(s) failed")
+        return 1
+
+    print(f"\nAll {total} checks passed")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

The `search_wiki` and `save_to_wiki` descriptions now show the configured `wiki_url` value. This gives the model a text signal that matches a wiki URL the user pastes into chat.

Before, the description was fixed text. It did not name the configured wiki host. So the model could not tell this tool apart from other tools when a URL appeared in the message.

MAIT-322 has the research and the reasons for this change.

## What changed

- In `tools/mediawiki_tool.py`, a Python descriptor now computes the `search_wiki`/`save_to_wiki` docstrings. The descriptor uses the current `wiki_url` valve.
- OpenWebUI reads `__doc__` again on every chat request, after it refreshes `module.valves`. So the description updates itself each time the valve value changes. No cache and no manual refresh step are needed.
- The descriptor does not leak internal helper methods as extra tool entries. Testing found and fixed this issue.
- Added `tools/test_mediawiki_dynamic_doc.py` for regression tests. The tests check three things: the docstring updates on each valve change, no instance leaks data to another instance, and the function signature stays correct for OpenWebUI.

## Related

Closes MAIT-322.
