### PR TITLE
[MAIT-337] End-to-end regression tests

### DIFF
--- a/.github/workflows/e2e-harness.yml
+++ b/.github/workflows/e2e-harness.yml
@@ -1,0 +1,28 @@
+name: E2E harness pre-flight
+
+on:
+  pull_request:
+    paths:
+      - 'tests/e2e/**'
+      - 'Makefile'
+      - '.github/workflows/e2e-harness.yml'
+  push:
+    branches:
+      - main
+    paths:
+      - 'tests/e2e/**'
+      - 'Makefile'
+      - '.github/workflows/e2e-harness.yml'
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install PyYAML for compose validation
+        run: timeout 120 python3 -m pip install --disable-pip-version-check pyyaml
+
+      - name: Pre-flight validate + llm-stub unit tests
+        run: timeout 120 make test-e2e-validate

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,13 @@
+.PHONY: test-e2e test-e2e-validate test-e2e-keep
+
+# End-to-end regression tests (require Docker; skipped with a warning if unavailable).
+test-e2e:
+	./tests/e2e/run.sh
+
+# Keep the stack running after the run for debugging.
+test-e2e-keep:
+	./tests/e2e/run.sh --keep-up
+
+# Fast syntax/wiring pre-flight; does not need Docker.
+test-e2e-validate:
+	python3 tests/e2e/validate.py

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ test-e2e:
 test-e2e-keep:
 	./tests/e2e/run.sh --keep-up
 
-# Fast syntax/wiring pre-flight; does not need Docker.
+# Fast syntax/wiring pre-flight and llm-stub unit tests; does not need Docker.
 test-e2e-validate:
 	python3 tests/e2e/validate.py
+	python3 -m unittest discover -s tests/e2e -p 'test_llm_stub.py' -q

--- a/README.md
+++ b/README.md
@@ -570,7 +570,6 @@ You must set `OPENROUTER_API_KEY` and `OPENROUTER_API_BASE` in the `.env.rag` fi
 The `config.yaml` file contains the main configuration of the service.
 
 > Environment variables (`${...}`) in the config file are evaluated at runtime.
-
 ```yaml
 sources: # holds the list of sources to ingest from (Connectors)
 
@@ -610,6 +609,19 @@ vector_store:
 
 * [Rag-Of-All-Trades](https://github.com/wikiteq/rag-of-all-trades) v0.1 as a RAG backend
 * [OpenWebUI](https://github.com/open-webui/open-webui) v0.6.5 as a front-end
+
+## Testing
+
+End-to-end regression tests live in [`tests/e2e`](tests/e2e/README.md). They boot
+the core compose stack (`openwebui` + `postgres` + `redis`) plus an in-network
+OpenAI-compatible LLM stub, exercise real user journeys through the HTTP API
+(login, chat completion, chat persistence), and tear everything down. No API
+keys or external services are needed.
+
+```bash
+make test-e2e            # full run, requires Docker (<5 min; skips with a warning if Docker is unavailable)
+make test-e2e-validate   # fast syntax/wiring pre-flight, no Docker needed
+```
 
 ## Troubleshooting
 

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -13,10 +13,12 @@ and OpenWebUI's HTTP API. No LLM API keys, no S3, no external services.
    provisioning (admin signup, tool install, provider wiring) is covered too.
 3. Waits for health, waits until first-boot provisioning has created both the
    admin and the regular user, then runs user journeys through public endpoints:
-   - **Journey 1** — admin login → provider model list → create chat → LLM
-     completion (served by the stub) → persist and re-read the chat.
+   - **Journey 1** — admin login → model list (`/openai/models`) → create chat
+     → LLM completion (`/openai/chat/completions`, served by the stub) →
+     persist and re-read the chat (`/api/v1/chats`).
    - **Journey 2** — regular-user (non-admin) login.
-   - **Journey 3** — admin config endpoint sanity check.
+   - **Journey 3** — liveness smoke check of the public config endpoint
+     (`/api/config`).
 4. Tears the stack down (volumes included) unless `--keep-up` is passed.
 
 The RAG services (`api`, `celery_worker`, `celery_beat`) are profiled out by
@@ -50,6 +52,7 @@ Environment knobs:
 | --------------------- | ------------- | ---------------------------------------- |
 | `E2E_HTTP_PORT`       | `3100`        | Host port for the OpenWebUI web UI       |
 | `MAITION_E2E_PROJECT` | `maition-e2e` | Docker Compose project name              |
+| `E2E_FORCE_ENV`       | unset         | Overwrite existing `.env`/`.env.rag` with the stub templates (originals are backed up and restored on exit); without it, reuse mode refuses to run unless `OPENAI_API_BASE_URL` points at `llm-stub` |
 
 ## Adding journeys
 

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -1,0 +1,59 @@
+# End-to-end tests for mAItion
+
+Deterministic, Docker-based smoke tests that exercise the real compose stack
+and OpenWebUI's HTTP API. No LLM API keys, no S3, no external services.
+
+## What it does
+
+1. Boots a trimmed stack via `docker compose`:
+   `postgres` + `redis` + `openwebui`, plus an in-network **`llm-stub`**
+   service — a tiny OpenAI-compatible server (`llm_stub.py`) that returns
+   fixed chat completions.
+2. The stock `helpers/entrypoint.sh` runs unmodified, so first-boot
+   provisioning (admin signup, tool install, provider wiring) is covered too.
+3. Waits for health, waits until first-boot provisioning has created both the
+   admin and the regular user, then runs user journeys through public endpoints:
+   - **Journey 1** — admin login → provider model list → create chat → LLM
+     completion (served by the stub) → persist and re-read the chat.
+   - **Journey 2** — regular-user (non-admin) login.
+   - **Journey 3** — admin config endpoint sanity check.
+4. Tears the stack down (volumes included) unless `--keep-up` is passed.
+
+The RAG services (`api`, `celery_worker`, `celery_beat`) are profiled out by
+`compose.dev.yaml`/`compose.e2e.yaml`, keeping the smoke stack small and fast.
+Because `OPENAI_API_BASE_URL` points at the stub, no outbound LLM calls happen
+and results are fully deterministic.
+
+## Requirements
+
+- Docker with the Compose plugin (the suite exits with code 2 — skip, not
+  fail — when Docker is unavailable).
+- `curl` and `python3` on the host.
+
+## Running
+
+```bash
+./tests/e2e/run.sh              # full run: boot, test, teardown (<5 min)
+./tests/e2e/run.sh --keep-up    # keep stack running afterwards for debugging
+```
+
+Or via make:
+
+```bash
+make test-e2e                   # same as ./tests/e2e/run.sh
+make test-e2e-validate          # syntax/wiring pre-flight, no Docker needed
+```
+
+Environment knobs:
+
+| Variable              | Default       | Purpose                                  |
+| --------------------- | ------------- | ---------------------------------------- |
+| `E2E_HTTP_PORT`       | `3100`        | Host port for the OpenWebUI web UI       |
+| `MAITION_E2E_PROJECT` | `maition-e2e` | Docker Compose project name              |
+
+## Adding journeys
+
+Add a `journey_*()` function in `run.sh` and call it from `run_journeys`.
+Journeys should only use public HTTP endpoints (`http://localhost:$E2E_HTTP_PORT`)
+with the credentials from `tests/e2e/env.openwebui.e2e`, mirroring what real
+users do.

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -51,8 +51,16 @@ Environment knobs:
 | Variable              | Default       | Purpose                                  |
 | --------------------- | ------------- | ---------------------------------------- |
 | `E2E_HTTP_PORT`       | `3100`        | Host port for the OpenWebUI web UI       |
+| `LLM_STUB_HOST_PORT`  | `8090`        | Host port for the llm-stub service       |
 | `MAITION_E2E_PROJECT` | `maition-e2e` | Docker Compose project name              |
-| `E2E_FORCE_ENV`       | unset         | Overwrite existing `.env`/`.env.rag` with the stub templates (originals are backed up and restored on exit); without it, reuse mode refuses to run unless `OPENAI_API_BASE_URL` points at `llm-stub` |
+| `E2E_FORCE_ENV`       | unset         | Required when `.env` already exists: backs up and overwrites `.env`/`.env.rag` with the stub templates for this run (restored on exit) |
+
+If `.env` already exists in the repo root, the runner **refuses to start** unless
+`E2E_FORCE_ENV=1` — journeys always use the fixed E2E accounts from
+`env.openwebui.e2e`, not whatever is in a developer checkout.
+
+For parallel runs on one host, set distinct `E2E_HTTP_PORT`, `LLM_STUB_HOST_PORT`,
+and `MAITION_E2E_PROJECT` values per run.
 
 ## Adding journeys
 

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -55,9 +55,11 @@ Environment knobs:
 | `MAITION_E2E_PROJECT` | `maition-e2e` | Docker Compose project name              |
 | `E2E_FORCE_ENV`       | unset         | Required when `.env` already exists: backs up and overwrites `.env`/`.env.rag` with the stub templates for this run (restored on exit) |
 
-If `.env` already exists in the repo root, the runner **refuses to start** unless
-`E2E_FORCE_ENV=1` — journeys always use the fixed E2E accounts from
-`env.openwebui.e2e`, not whatever is in a developer checkout.
+If `.env` or `.env.rag` already exists in the repo root, the runner **refuses to start**
+unless `E2E_FORCE_ENV=1` — journeys always use the fixed E2E accounts from
+`env.openwebui.e2e`, not whatever is in a developer checkout. With
+`E2E_FORCE_ENV=1`, each existing file is backed up independently and restored
+on exit.
 
 For parallel runs on one host, set distinct `E2E_HTTP_PORT`, `LLM_STUB_HOST_PORT`,
 and `MAITION_E2E_PROJECT` values per run.

--- a/tests/e2e/compose.e2e.yaml
+++ b/tests/e2e/compose.e2e.yaml
@@ -3,7 +3,6 @@ services:
   # LLM provider. Wired into openwebui via the e2e override below.
   llm-stub:
     image: python:3.12-slim
-    container_name: maition-e2e-llm-stub
     volumes:
       # E2E_DIR must be an absolute path to tests/e2e (set by run.sh); relative
       # mounts here would resolve against --project-directory (the repo root).

--- a/tests/e2e/compose.e2e.yaml
+++ b/tests/e2e/compose.e2e.yaml
@@ -1,0 +1,40 @@
+services:
+  # Deterministic OpenAI-compatible stub so E2E journeys never touch a real
+  # LLM provider. Wired into openwebui via the e2e override below.
+  llm-stub:
+    image: python:3.12-slim
+    container_name: maition-e2e-llm-stub
+    volumes:
+      # E2E_DIR must be an absolute path to tests/e2e (set by run.sh); relative
+      # mounts here would resolve against --project-directory (the repo root).
+      - ${E2E_DIR:-./tests/e2e}/llm_stub.py:/srv/llm_stub.py:ro
+    command: >
+      sh -c "python /srv/llm_stub.py"
+    environment:
+      - LLM_STUB_PORT=8090
+      - LLM_STUB_MODEL=stub-model
+    healthcheck:
+      test: ["CMD-SHELL", "python -c \"import urllib.request;urllib.request.urlopen('http://localhost:8090/health')\""]
+      interval: 3s
+      timeout: 5s
+      retries: 20
+      start_period: 2s
+    ports:
+      - "127.0.0.1:${LLM_STUB_HOST_PORT:-8090}:8090"
+
+  openwebui:
+    depends_on:
+      llm-stub:
+        condition: service_healthy
+
+  api:
+    profiles:
+      - rag
+
+  celery_worker:
+    profiles:
+      - rag
+
+  celery_beat:
+    profiles:
+      - rag

--- a/tests/e2e/env.openwebui.e2e
+++ b/tests/e2e/env.openwebui.e2e
@@ -1,0 +1,41 @@
+# E2E OpenWebUI env (copied to .env by run.sh).
+# No real secrets: the OpenAI-compatible provider is the in-network llm-stub.
+
+WEBUI_URL=http://localhost:3100
+HTTP_WEB_PORT=3100
+WEBUI_SECRET_KEY=e2e-only-secret-key-not-for-production
+
+POSTGRES_USER=postgres
+POSTGRES_PASSWORD=postgres
+POSTGRES_DB=openwebui
+POSTGRES_HOST=postgres
+POSTGRES_PORT=5432
+
+X_WEBUI_ADMIN_USER=Admin
+X_WEBUI_ADMIN_EMAIL=admin@example123.com
+X_WEBUI_ADMIN_PASS=q1w2e3r4!
+
+X_WEBUI_USER_NAME=user123
+X_WEBUI_USER_EMAIL=user@example123.com
+X_WEBUI_USER_PASS=q1w2e3r4!
+
+WEBUI_AUTH=True
+ENABLE_SIGNUP=True
+ENABLE_LOGIN_FORM=True
+
+# Point the LLM provider at the in-network stub service (compose.e2e.yaml).
+ENABLE_OPENAI_API=True
+OPENAI_API_BASE_URL=http://llm-stub:8090/v1
+OPENAI_API_KEY=sk-e2e-stub-no-key-needed
+OPENAI_DEFAULT_MODEL=stub-model
+
+ENV=dev
+UVICORN_WORKERS=1
+USER_AGENT=mAItion-e2e-tests/0.1
+ENABLE_BASE_MODELS_CACHE=True
+MODELS_CACHE_TTL=300
+ENABLE_WEB_SEARCH=False
+ENABLE_OLLAMA_API=False
+
+ROAT_API_URL=http://api:8000
+ROAT_API_KEY=e2e-stub-key

--- a/tests/e2e/env.rag.e2e
+++ b/tests/e2e/env.rag.e2e
@@ -1,0 +1,28 @@
+# E2E RAG backend env (copied to .env.rag by run.sh).
+# Mirrors .env.rag.example; no real secrets or connector credentials.
+# POSTGRES_DB must differ from POSTGRES_DB in .env so the shared postgres
+# instance initializes both databases via helpers/01-openwebui-init.sql.
+
+REDIS_URL=redis://redis:6379/0
+POSTGRES_USER=postgres
+POSTGRES_PASSWORD=postgres
+POSTGRES_DB=rag
+POSTGRES_HOST=postgres
+POSTGRES_PORT=5432
+
+OPENROUTER_API_KEY=e2e-stub-key
+OPENROUTER_API_BASE=http://llm-stub:8090/v1
+
+CELERY_CONCURRENCY=2
+MAX_TASK_CHILD=50
+MAX_MEMORY_PER_CHILD=300000
+
+CUDA_VISIBLE_DEVICES=
+ORT_DISABLE_GPU=1
+ORT_DYLD_DISABLE_GPU=1
+
+CORS_ORIGINS=["http://localhost","http://localhost:3000","http://localhost:3100"]
+
+ENABLE_RATE_LIMIT=false
+
+MCP_ENABLE=0

--- a/tests/e2e/llm_stub.py
+++ b/tests/e2e/llm_stub.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+"""Minimal deterministic OpenAI-compatible LLM stub used by the E2E suite.
+
+Serves /v1/models and /v1/chat/completions so OpenWebUI can be pointed at it
+instead of a real provider. Responses are fixed, which keeps the suite free,
+fast and reproducible. Runs on the host or inside the compose network.
+"""
+
+import json
+import os
+import re
+import threading
+import time
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+PORT = int(os.environ.get("LLM_STUB_PORT", "8090"))
+
+MODEL_ID = os.environ.get("LLM_STUB_MODEL", "stub-model")
+
+# Fixed reply so assertions can rely on an exact string.
+FIXED_REPLY = os.environ.get(
+    "LLM_STUB_REPLY",
+    "E2E-STUB-REPLY: The llm-stub service answered this message deterministically.",
+)
+
+_started_at = int(time.time())
+_request_log = []
+_log_lock = threading.Lock()
+
+
+def _record(kind):
+    with _log_lock:
+        _request_log.append((kind, time.time()))
+
+
+class Handler(BaseHTTPRequestHandler):
+    protocol_version = "HTTP/1.1"
+
+    def log_message(self, fmt, *args):
+        return
+
+    def _send_json(self, payload, status=200):
+        body = json.dumps(payload).encode()
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    # --- helpers -----------------------------------------------------------
+
+    def _chat_completion(self):
+        length = int(self.headers.get("Content-Length") or 0)
+        raw = self.rfile.read(length) if length else b""
+        try:
+            req = json.loads(raw.decode() or "{}")
+        except ValueError:
+            req = {}
+
+        messages = req.get("messages") or []
+        user_text = ""
+        for msg in reversed(messages):
+            content = msg.get("content")
+            if isinstance(content, str) and content.strip():
+                user_text = content
+                break
+            if isinstance(content, list):
+                parts = [
+                    p.get("text", "")
+                    for p in content
+                    if isinstance(p, dict) and p.get("type") == "text"
+                ]
+                joined = " ".join(x for x in parts if x)
+                if joined:
+                    user_text = joined
+                    break
+
+        echo = ""
+        if user_text:
+            compact = re.sub(r"\s+", " ", user_text.strip())
+            echo = compact[:200]
+        if echo:
+            content = f"{FIXED_REPLY} You said: {echo}"
+        else:
+            content = FIXED_REPLY
+
+        return {
+            "id": f"chatcmpl-e2e-stub-{int(time.time()*1000)}",
+            "object": "chat.completion",
+            "created": _started_at,
+            "model": req.get("model", MODEL_ID),
+            "choices": [
+                {
+                    "index": 0,
+                    "message": {"role": "assistant", "content": content},
+                    "finish_reason": "stop",
+                }
+            ],
+            "usage": {
+                "prompt_tokens": len(user_text.split()) if user_text else 1,
+                "completion_tokens": 8,
+                "total_tokens": 8,
+            },
+        }
+
+    # --- routes ------------------------------------------------------------
+
+    def do_GET(self):
+        path = self.path.split("?")[0]
+        if path == "/health":
+            self._send_json({"status": "ok"})
+            return
+        if path == "/v1/models":
+            _record("models")
+            self._send_json(
+                {
+                    "object": "list",
+                    "data": [
+                        {
+                            "id": MODEL_ID,
+                            "object": "model",
+                            "created": _started_at,
+                            "owned_by": "llm-stub",
+                        }
+                    ],
+                }
+            )
+            return
+        self._send_json({"error": {"message": f"not found: {path}", "type": "invalid_request_error"}}, 404)
+
+    def do_POST(self):
+        path = self.path.split("?")[0]
+        if path in ("/v1/chat/completions", "/chat/completions"):
+            _record("completions")
+            self._send_json(self._chat_completion())
+            return
+        self._send_json({"error": {"message": f"not found: {path}", "type": "invalid_request_error"}}, 404)
+
+
+def main():
+    server = ThreadingHTTPServer(("0.0.0.0", PORT), Handler)
+    print(f"llm-stub listening on :{PORT} model={MODEL_ID}", flush=True)
+    server.serve_forever()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/e2e/run.sh
+++ b/tests/e2e/run.sh
@@ -22,12 +22,51 @@ export E2E_DIR="$SCRIPT_DIR"
 PASS=0
 FAIL=0
 KEEP_UP=0
-PROVISIONED_ENV=0
+# Per-file state: "provisioned" (we created it; delete on teardown unless
+# KEEP_UP) or "backed_up" (we overwrote a pre-existing file; restore original).
+ENV_FILE_STATE_OPENWEBUI=""
+ENV_FILE_STATE_RAG=""
+ENV_BACKUP_DIR=""
 
 restore_env() {
-  if [[ "$PROVISIONED_ENV" == 1 ]]; then
-    rm -f "$REPO_ROOT/.env" "$REPO_ROOT/.env.rag"
+  local f file state_var state
+  for f in OPENWEBUI RAG; do
+    file="$REPO_ROOT/.env"
+    [[ "$f" == "RAG" ]] && file="$REPO_ROOT/.env.rag"
+    state_var="ENV_FILE_STATE_$f"
+    state="${!state_var}"
+    if [[ "$state" == "provisioned" ]]; then
+      if [[ "$KEEP_UP" == 1 ]]; then
+        log "--keep-up set; leaving provisioned $(basename "$file") in place for stack reuse"
+      else
+        rm -f "$file"
+      fi
+    elif [[ "$state" == "backed_up" ]]; then
+      if [[ "$KEEP_UP" == 1 ]]; then
+        log "--keep-up set; $(basename "$file") stays overwritten by the E2E copy; your original is kept at $ENV_BACKUP_DIR/$(basename "$file").bak"
+      elif mv "$ENV_BACKUP_DIR/$(basename "$file").bak" "$file"; then
+        log "Restored pre-existing $(basename "$file") from backup"
+      else
+        log "WARN: could not restore $(basename "$file"); original preserved at $ENV_BACKUP_DIR/$(basename "$file").bak"
+      fi
+    fi
+  done
+}
+
+cleanup() {
+  if [[ "${_CLEANED_UP:-0}" == 1 ]]; then
+    return
   fi
+  _CLEANED_UP=1
+  if [[ "$KEEP_UP" == 1 ]]; then
+    log "--keep-up set; leaving stack running (project: $PROJECT). Tear down with:"
+    log "  docker compose -p $PROJECT -f $REPO_ROOT/compose.yaml -f $REPO_ROOT/compose.dev.yaml -f $SCRIPT_DIR/compose.e2e.yaml down -v --remove-orphans"
+    restore_env
+    return
+  fi
+  log "Tearing down stack..."
+  dc down --remove-orphans --volumes >/dev/null 2>&1 || true
+  restore_env
 }
 
 if [[ "${1:-}" == "--keep-up" ]]; then
@@ -60,11 +99,13 @@ require_docker() {
 
 wait_for() {
   local url="$1" label="$2" tries="${3:-90}"
-  for ((i = 1; i <= tries; i++)); do
+  i=0
+  while [ "$i" -lt "$tries" ]; do
     if curl -fsS --max-time 5 -o /dev/null "$url" 2>/dev/null; then
       return 0
     fi
     sleep 3
+    i=$((i + 1))
   done
   fail "timeout waiting for $label ($url) after $tries attempts"
   return 1
@@ -80,6 +121,29 @@ api() {
 }
 
 jqget() { python3 -c "import json,sys;d=json.load(sys.stdin);print(d.get(sys.argv[1],''))" "$1"; }
+
+check_provider_guard() {
+  # In reuse-existing-.env mode, refuse to run against anything but the stub:
+  # otherwise Journey 1 traffic would hit the dev's real paid LLM provider.
+  local base_url
+  base_url="$(grep -E '^OPENAI_API_BASE_URL=' "$REPO_ROOT/.env" | tail -n 1 | cut -d= -f2- || true)"
+  base_url="${base_url//\"/}"
+  base_url="${base_url%\'}"
+  if [[ -z "$base_url" ]]; then
+    fail "reuse mode: no OPENAI_API_BASE_URL found in $REPO_ROOT/.env"
+    return 1
+  fi
+  case "$base_url" in
+    *llm-stub*)
+      return 0
+      ;;
+    *)
+      fail "refusing to run E2E: OPENAI_API_BASE_URL ($base_url) does not point at llm-stub."
+      fail "Journey traffic would hit your real LLM provider. Re-run with E2E_FORCE_ENV=1 to force the stub env, or point OPENAI_API_BASE_URL at http://llm-stub:8090/v1."
+      return 1
+      ;;
+  esac
+}
 
 # ---------------------------------------------------------------------------
 # journeys
@@ -107,7 +171,7 @@ ids=[m["id"] for m in items if isinstance(m, dict) and "id" in m]
 pref=[i for i in ids if i.startswith("stub-model")]
 print(pref[0] if pref else (ids[0] if ids else ""))')
   if [[ -z "$model_id" ]]; then
-    fail "no usable model in /api/v1/models/: $(printf '%s' "$resp" | head -c 300)"
+    fail "no usable model in /openai/models: $(printf '%s' "$resp" | head -c 300)"
     return 1
   fi
   pass "model list contains stubbed LLM (id: $model_id)"
@@ -178,9 +242,9 @@ journey_admin_config_endpoints() {
 }
 
 run_journeys() {
-  journey_admin_login_and_chat; J1=$?
-  journey_regular_user_login; J2=$?
-  journey_admin_config_endpoints; J3=$?
+  journey_admin_login_and_chat
+  journey_regular_user_login
+  journey_admin_config_endpoints
 }
 
 # ---------------------------------------------------------------------------
@@ -194,39 +258,60 @@ main() {
   # ships only examples (.env.openwebui.example etc.) and compose requires
   # real ones; both are gitignored so this never touches a dev's own setup.
   if [[ ! -f "$REPO_ROOT/.env" || "${E2E_FORCE_ENV:-0}" == "1" ]] ; then
+    if [[ -f "$REPO_ROOT/.env" && "${E2E_FORCE_ENV:-0}" == "1" ]]; then
+      ENV_BACKUP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/maition-e2e-env-backup.XXXXXX")"
+      chmod 700 "$ENV_BACKUP_DIR"
+      cp "$REPO_ROOT/.env" "$ENV_BACKUP_DIR/.env.bak"
+      ENV_FILE_STATE_OPENWEBUI=backed_up
+      log "Backed up existing .env to $ENV_BACKUP_DIR before overwrite"
+    fi
+    if [[ -f "$REPO_ROOT/.env.rag" ]]; then
+      if [[ "${E2E_FORCE_ENV:-0}" == "1" ]]; then
+        [[ -n "$ENV_BACKUP_DIR" ]] || { ENV_BACKUP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/maition-e2e-env-backup.XXXXXX")"; chmod 700 "$ENV_BACKUP_DIR"; }
+        cp "$REPO_ROOT/.env.rag" "$ENV_BACKUP_DIR/.env.rag.bak"
+        ENV_FILE_STATE_RAG=backed_up
+        log "Backed up existing .env.rag to $ENV_BACKUP_DIR before overwrite"
+      fi
+    elif [[ "${E2E_FORCE_ENV:-0}" == "1" ]]; then
+      log "No existing .env.rag found; provisioning from tests/e2e template"
+    fi
     log "Provisioning .env / .env.rag from tests/e2e templates"
     cp "$SCRIPT_DIR/env.openwebui.e2e" "$REPO_ROOT/.env"
     cp "$SCRIPT_DIR/env.rag.e2e" "$REPO_ROOT/.env.rag"
-    PROVISIONED_ENV=1
+    [[ -z "$ENV_FILE_STATE_OPENWEBUI" ]] && ENV_FILE_STATE_OPENWEBUI=provisioned
+    [[ -z "$ENV_FILE_STATE_RAG" ]] && ENV_FILE_STATE_RAG=provisioned
   else
     log "Using existing $REPO_ROOT/.env (E2E credentials may differ)"
+    check_provider_guard || { cleanup; exit 1; }
   fi
-  trap restore_env EXIT
+  trap cleanup EXIT
 
   log "Using project '$PROJECT'; web UI will bind http://localhost:${HTTP_PORT}"
   log "Booting core stack (postgres, redis, llm-stub, openwebui)..."
 
   dc down --remove-orphans --volumes >/dev/null 2>&1 || true
-  dc up -d --build --quiet-pull || { fail "docker compose up failed"; dc logs openwebui 2>/dev/null | timeout 10 tail -40; cleanup; exit 1; }
+  dc up -d --build --quiet-pull || { fail "docker compose up failed"; dc logs openwebui 2>/dev/null | tail -40; cleanup; exit 1; }
 
   log "Waiting for health endpoints..."
-  wait_for "http://localhost:${HTTP_PORT}/health" "openwebui /health" 60 || { dc logs openwebui 2>/dev/null | timeout 10 tail -40; cleanup; exit 1; }
+  wait_for "http://localhost:${HTTP_PORT}/health" "openwebui /health" 60 || { dc logs openwebui 2>/dev/null | tail -40; cleanup; exit 1; }
 
   # The custom entrypoint provisions the admin account, then continues with
   # provider wiring and the optional regular user; wait until BOTH accounts
   # can sign in so journeys never race first-boot provisioning.
   ok=0
-  for ((i = 1; i <= 40; i++)); do
+  i=0
+  while [ "$i" -lt 40 ]; do
     admin_code=$(curl -s -o /dev/null -w '%{http_code}' --max-time 10 -X POST "http://localhost:${HTTP_PORT}/api/v1/auths/signin" \
       -H "Content-Type: application/json" -d '{"email":"admin@example123.com","password":"q1w2e3r4!"}')
     user_code=$(curl -s -o /dev/null -w '%{http_code}' --max-time 10 -X POST "http://localhost:${HTTP_PORT}/api/v1/auths/signin" \
       -H "Content-Type: application/json" -d '{"email":"user@example123.com","password":"q1w2e3r4!"}')
     [[ "$admin_code" == "200" && "$user_code" == "200" ]] && { ok=1; break; }
     sleep 3
+    i=$((i + 1))
   done
   if [[ "$ok" != 1 ]]; then
     fail "provisioned accounts not ready before timeout (admin=$admin_code user=$user_code)"
-    dc logs openwebui 2>/dev/null | timeout 10 tail -40
+    dc logs openwebui 2>/dev/null | tail -40
     cleanup
     exit 1
   fi
@@ -242,16 +327,6 @@ main() {
   fi
   log "All E2E checks passed."
   exit 0
-}
-
-cleanup() {
-  if [[ "$KEEP_UP" == 1 ]]; then
-    log "--keep-up set; leaving stack running (project: $PROJECT). Tear down with:"
-    log "  docker compose -p $PROJECT -f $REPO_ROOT/compose.yaml -f $REPO_ROOT/compose.dev.yaml -f $SCRIPT_DIR/compose.e2e.yaml down -v --remove-orphans"
-    return
-  fi
-  log "Tearing down stack..."
-  dc down --remove-orphans --volumes >/dev/null 2>&1 || true
 }
 
 main

--- a/tests/e2e/run.sh
+++ b/tests/e2e/run.sh
@@ -144,7 +144,7 @@ api_expect() {
   return 0
 }
 
-jqget() { python3 -c "import json,sys;d=json.load(sys.stdin);print(d.get(sys.argv[1],''))" "$1"; }
+jqget() { python3 -c "import json,sys;d=json.load(sys.stdin);v=d.get(sys.argv[1],'');print('' if v is None else v)" "$1"; }
 
 check_port_free() {
   local port="$1" label="$2"
@@ -160,6 +160,11 @@ check_port_free() {
       fail "port $port ($label) is already in use — set E2E_HTTP_PORT or LLM_STUB_HOST_PORT for parallel runs"
       return 1
     fi
+    return 0
+  fi
+  if (echo >/dev/tcp/127.0.0.1/"$port") 2>/dev/null; then
+    fail "port $port ($label) is already in use — set E2E_HTTP_PORT or LLM_STUB_HOST_PORT for parallel runs"
+    return 1
   fi
   return 0
 }
@@ -182,7 +187,7 @@ signin() {
 # ---------------------------------------------------------------------------
 
 journey_admin_login_and_chat() {
-  local token resp model_id chat_id content title
+  local token model_id chat_id content title
 
   log "Journey 1: admin login -> models -> chat completion -> chat persistence"
 
@@ -198,8 +203,8 @@ journey_admin_login_and_chat() {
   fi
   pass "admin signin returns JWT"
 
-  resp=$(api GET /openai/models "" "$token")
-  model_id=$(printf '%s' "$resp" | python3 -c '
+  api_expect 200 GET /openai/models "" "$token" || return 1
+  model_id=$(printf '%s' "$API_BODY" | python3 -c '
 import json,sys
 d=json.load(sys.stdin)
 items=d if isinstance(d, list) else d.get("data", [])
@@ -207,42 +212,47 @@ ids=[m["id"] for m in items if isinstance(m, dict) and "id" in m]
 pref=[i for i in ids if i.startswith("stub-model")]
 print(pref[0] if pref else (ids[0] if ids else ""))')
   if [[ -z "$model_id" ]]; then
-    fail "no usable model in /openai/models: $(printf '%s' "$resp" | head -c 300)"
+    fail "no usable model in /openai/models: $(printf '%s' "$API_BODY" | head -c 300)"
     return 1
   fi
   pass "model list contains stubbed LLM (id: $model_id)"
 
-  resp=$(api POST /api/v1/chats/new "{\"chat\":{\"title\":\"e2e-journey-1\",\"messages\":[],\"models\":[\"$model_id\"],\"params\":{}},\"model_id\":\"$model_id\",\"messages\":[]}" "$token")
-  chat_id=$(printf '%s' "$resp" | jqget id)
+  api_expect 200 POST /api/v1/chats/new "{\"chat\":{\"title\":\"e2e-journey-1\",\"messages\":[],\"models\":[\"$model_id\"],\"params\":{}},\"model_id\":\"$model_id\",\"messages\":[]}" "$token" || return 1
+  chat_id=$(printf '%s' "$API_BODY" | jqget id)
   if [[ -z "$chat_id" ]]; then
-    fail "chat creation failed: $(printf '%s' "$resp" | head -c 300)"
+    fail "chat creation failed: $(printf '%s' "$API_BODY" | head -c 300)"
     return 1
   fi
   pass "created chat $chat_id"
 
-  resp=$(api POST /openai/chat/completions "{\"model\":\"$model_id\",\"stream\":false,\"messages\":[{\"role\":\"user\",\"content\":\"What is the capital of France?\"}]}" "$token")
-  content=$(printf '%s' "$resp" | python3 -c 'import json,sys;d=json.load(sys.stdin);print(d.get("choices",[{}])[0].get("message",{}).get("content",""))')
+  api_expect 200 POST /openai/chat/completions "{\"model\":\"$model_id\",\"stream\":false,\"messages\":[{\"role\":\"user\",\"content\":\"What is the capital of France?\"}]}" "$token" || return 1
+  content=$(printf '%s' "$API_BODY" | python3 -c 'import json,sys;d=json.load(sys.stdin);print(d.get("choices",[{}])[0].get("message",{}).get("content",""))')
   if [[ "$content" != E2E-STUB-REPLY* ]]; then
-    fail "completion did not come from stub: $(printf '%s' "$resp" | head -c 300)"
+    fail "completion did not come from stub: $(printf '%s' "$API_BODY" | head -c 300)"
     return 1
   fi
   pass "LLM completion served by llm-stub"
 
-  # Persist a completed conversation, then read it back to verify storage.
-  resp=$(api POST "/api/v1/chats/$chat_id" "{\"chat\":{\"title\":\"e2e-journey-1\",\"models\":[\"$model_id\"],\"messages\":[{\"role\":\"user\",\"content\":\"What is the capital of France?\"},{\"role\":\"assistant\",\"content\":\"stubbed answer\"}],\"params\":{}}}" "$token") ||
-    resp=$(api POST "/api/v1/chats/$chat_id" "{\"title\":\"e2e-journey-1\",\"models\":[\"$model_id\"],\"messages\":[{\"role\":\"user\",\"content\":\"What is the capital of France?\"},{\"role\":\"assistant\",\"content\":\"stubbed answer\"}],\"params\":{}}" "$token")
-  title=$(printf '%s' "$resp" | jqget title)
-  if [[ "$title" != "e2e-journey-1" ]]; then
-    fail "chat update/persistence failed: $(printf '%s' "$resp" | head -c 300)"
+  api POST "/api/v1/chats/$chat_id" "{\"chat\":{\"title\":\"e2e-journey-1\",\"models\":[\"$model_id\"],\"messages\":[{\"role\":\"user\",\"content\":\"What is the capital of France?\"},{\"role\":\"assistant\",\"content\":\"stubbed answer\"}],\"params\":{}}}" "$token"
+  if [[ "$API_CODE" != "200" ]]; then
+    api POST "/api/v1/chats/$chat_id" "{\"title\":\"e2e-journey-1\",\"models\":[\"$model_id\"],\"messages\":[{\"role\":\"user\",\"content\":\"What is the capital of France?\"},{\"role\":\"assistant\",\"content\":\"stubbed answer\"}],\"params\":{}}" "$token"
+  fi
+  if [[ "$API_CODE" != "200" ]]; then
+    fail "chat update/persistence failed (HTTP $API_CODE): $(printf '%s' "$API_BODY" | head -c 300)"
     return 1
   fi
-  resp=$(api GET "/api/v1/chats/$chat_id" "" "$token")
-  if ! printf '%s' "$resp" | python3 -c '
+  title=$(printf '%s' "$API_BODY" | jqget title)
+  if [[ "$title" != "e2e-journey-1" ]]; then
+    fail "chat update/persistence failed: $(printf '%s' "$API_BODY" | head -c 300)"
+    return 1
+  fi
+  api_expect 200 GET "/api/v1/chats/$chat_id" "" "$token" || return 1
+  if ! printf '%s' "$API_BODY" | python3 -c '
 import json,sys
 d=json.load(sys.stdin)
 msgs=d.get("chat",{}).get("messages") or d.get("messages") or []
 assert any(m.get("content")=="stubbed answer" for m in msgs), "assistant msg missing"' 2>/dev/null; then
-    fail "persisted chat does not contain the saved messages: $(printf '%s' "$resp" | head -c 300)"
+    fail "persisted chat does not contain the saved messages: $(printf '%s' "$API_BODY" | head -c 300)"
     return 1
   fi
   pass "chat persisted and re-readable with full message history"
@@ -266,7 +276,7 @@ journey_regular_user_login() {
 
 journey_admin_config_endpoints() {
   log "Journey 3: admin config endpoints reachable"
-  local resp token
+  local token
   signin "$E2E_ADMIN_EMAIL" "$E2E_ADMIN_PASS"
   if [[ "$SIGNIN_CODE" != "200" ]]; then
     fail "signin for config journey failed (HTTP $SIGNIN_CODE)"
@@ -277,9 +287,9 @@ journey_admin_config_endpoints() {
     fail "signin for config journey returned no token"
     return 1
   fi
-  resp=$(api GET /api/config "" "$token")
-  if ! printf '%s' "$resp" | python3 -c 'import json,sys;json.load(sys.stdin)' 2>/dev/null; then
-    fail "GET /api/config returned invalid JSON: $(printf '%s' "$resp" | head -c 200)"
+  api_expect 200 GET /api/config "" "$token" || return 1
+  if ! printf '%s' "$API_BODY" | python3 -c 'import json,sys;json.load(sys.stdin)' 2>/dev/null; then
+    fail "GET /api/config returned invalid JSON: $(printf '%s' "$API_BODY" | head -c 200)"
     return 1
   fi
   pass "public config endpoint responds with JSON"
@@ -300,21 +310,23 @@ main() {
 
   # Provision throwaway env files from the committed E2E templates. The repo
   # ships only examples (.env.openwebui.example etc.) and compose requires
-  # real ones; both are gitignored. Refuse to clobber an existing dev .env
+  # real ones; both are gitignored. Refuse to clobber existing env files
   # unless E2E_FORCE_ENV=1 (backs up and restores on exit).
-  if [[ -f "$REPO_ROOT/.env" && "${E2E_FORCE_ENV:-0}" != "1" ]]; then
-    log "refusing to run: $REPO_ROOT/.env already exists."
+  if [[ ( -f "$REPO_ROOT/.env" || -f "$REPO_ROOT/.env.rag" ) && "${E2E_FORCE_ENV:-0}" != "1" ]]; then
+    log "refusing to run: existing env file(s) detected (.env and/or .env.rag)."
     log "E2E journeys require the committed stub templates (see tests/e2e/env.openwebui.e2e)."
     log "Re-run with E2E_FORCE_ENV=1 to back up and overwrite .env/.env.rag for this run."
     exit 1
   fi
 
-  if [[ -f "$REPO_ROOT/.env" && "${E2E_FORCE_ENV:-0}" == "1" ]]; then
+  if [[ "${E2E_FORCE_ENV:-0}" == "1" ]]; then
     ENV_BACKUP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/maition-e2e-env-backup.XXXXXX")"
     chmod 700 "$ENV_BACKUP_DIR"
-    cp "$REPO_ROOT/.env" "$ENV_BACKUP_DIR/.env.bak"
-    ENV_FILE_STATE_OPENWEBUI=backed_up
-    log "Backed up existing .env to $ENV_BACKUP_DIR before overwrite"
+    if [[ -f "$REPO_ROOT/.env" ]]; then
+      cp "$REPO_ROOT/.env" "$ENV_BACKUP_DIR/.env.bak"
+      ENV_FILE_STATE_OPENWEBUI=backed_up
+      log "Backed up existing .env to $ENV_BACKUP_DIR before overwrite"
+    fi
     if [[ -f "$REPO_ROOT/.env.rag" ]]; then
       cp "$REPO_ROOT/.env.rag" "$ENV_BACKUP_DIR/.env.rag.bak"
       ENV_FILE_STATE_RAG=backed_up

--- a/tests/e2e/run.sh
+++ b/tests/e2e/run.sh
@@ -120,12 +120,28 @@ wait_for() {
 }
 
 api() {
-  # api METHOD PATH [JSON_BODY] [TOKEN]
-  local method="$1" path="$2" body="${3:-}" token="${4:-}"
-  local args=(-sS --max-time 30 -X "$method" "http://localhost:${HTTP_PORT}${path}")
+  # api METHOD PATH [JSON_BODY] [TOKEN] -> sets API_CODE and API_BODY
+  local method="$1" path="$2" body="${3:-}" token="${4:-}" tmp code
+  tmp="$(mktemp)"
+  local args=(-sS --max-time 30 -o "$tmp" -w '%{http_code}' -X "$method" "http://localhost:${HTTP_PORT}${path}")
   [[ -n "$body" ]] && args+=(-H "Content-Type: application/json" -d "$body")
   [[ -n "$token" ]] && args+=(-H "Authorization: Bearer $token")
-  curl "${args[@]}"
+  code=$(curl "${args[@]}") || code="000"
+  API_BODY="$(cat "$tmp")"
+  API_CODE="$code"
+  rm -f "$tmp"
+}
+
+api_expect() {
+  # api_expect EXPECTED_STATUS METHOD PATH [JSON_BODY] [TOKEN]
+  local expected="$1"
+  shift
+  api "$@"
+  if [[ "$API_CODE" != "$expected" ]]; then
+    fail "expected HTTP $expected for $2, got $API_CODE: $(printf '%s' "$API_BODY" | head -c 300)"
+    return 1
+  fi
+  return 0
 }
 
 jqget() { python3 -c "import json,sys;d=json.load(sys.stdin);print(d.get(sys.argv[1],''))" "$1"; }

--- a/tests/e2e/run.sh
+++ b/tests/e2e/run.sh
@@ -15,7 +15,15 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 
 PROJECT="${MAITION_E2E_PROJECT:-maition-e2e}"
 HTTP_PORT="${E2E_HTTP_PORT:-3100}"
+LLM_STUB_PORT="${LLM_STUB_HOST_PORT:-8090}"
 export HTTP_WEB_PORT="$HTTP_PORT"
+export LLM_STUB_HOST_PORT="$LLM_STUB_PORT"
+
+# Must stay in sync with tests/e2e/env.openwebui.e2e (validated by validate.py).
+E2E_ADMIN_EMAIL="admin@example123.com"
+E2E_ADMIN_PASS="q1w2e3r4!"
+E2E_USER_EMAIL="user@example123.com"
+E2E_USER_PASS="q1w2e3r4!"
 # compose.e2e.yaml uses this for its bind mounts (see comment there).
 export E2E_DIR="$SCRIPT_DIR"
 
@@ -122,27 +130,35 @@ api() {
 
 jqget() { python3 -c "import json,sys;d=json.load(sys.stdin);print(d.get(sys.argv[1],''))" "$1"; }
 
-check_provider_guard() {
-  # In reuse-existing-.env mode, refuse to run against anything but the stub:
-  # otherwise Journey 1 traffic would hit the dev's real paid LLM provider.
-  local base_url
-  base_url="$(grep -E '^OPENAI_API_BASE_URL=' "$REPO_ROOT/.env" | tail -n 1 | cut -d= -f2- || true)"
-  base_url="${base_url//\"/}"
-  base_url="${base_url%\'}"
-  if [[ -z "$base_url" ]]; then
-    fail "reuse mode: no OPENAI_API_BASE_URL found in $REPO_ROOT/.env"
-    return 1
-  fi
-  case "$base_url" in
-    *llm-stub*)
-      return 0
-      ;;
-    *)
-      fail "refusing to run E2E: OPENAI_API_BASE_URL ($base_url) does not point at llm-stub."
-      fail "Journey traffic would hit your real LLM provider. Re-run with E2E_FORCE_ENV=1 to force the stub env, or point OPENAI_API_BASE_URL at http://llm-stub:8090/v1."
+check_port_free() {
+  local port="$1" label="$2"
+  if command -v ss >/dev/null 2>&1; then
+    if ss -tlnH "sport = :$port" 2>/dev/null | grep -q .; then
+      fail "port $port ($label) is already in use — set E2E_HTTP_PORT or LLM_STUB_HOST_PORT for parallel runs"
       return 1
-      ;;
-  esac
+    fi
+    return 0
+  fi
+  if command -v nc >/dev/null 2>&1; then
+    if nc -z 127.0.0.1 "$port" 2>/dev/null; then
+      fail "port $port ($label) is already in use — set E2E_HTTP_PORT or LLM_STUB_HOST_PORT for parallel runs"
+      return 1
+    fi
+  fi
+  return 0
+}
+
+signin() {
+  # signin EMAIL PASSWORD -> sets SIGNIN_CODE and SIGNIN_BODY
+  local email="$1" password="$2" tmp code
+  tmp="$(mktemp)"
+  code=$(curl -sS --max-time 30 -o "$tmp" -w '%{http_code}' -X POST \
+    "http://localhost:${HTTP_PORT}/api/v1/auths/signin" \
+    -H "Content-Type: application/json" \
+    -d "{\"email\":\"$email\",\"password\":\"$password\"}") || code="000"
+  SIGNIN_BODY="$(cat "$tmp")"
+  SIGNIN_CODE="$code"
+  rm -f "$tmp"
 }
 
 # ---------------------------------------------------------------------------
@@ -154,10 +170,14 @@ journey_admin_login_and_chat() {
 
   log "Journey 1: admin login -> models -> chat completion -> chat persistence"
 
-  resp=$(api POST /api/v1/auths/signin '{"email":"admin@example123.com","password":"q1w2e3r4!"}')
-  token=$(printf '%s' "$resp" | jqget token)
-  if [[ -z "$token" || "$resp" == *"detail"* && "$resp" == *"$token"* ]]; then
-    fail "admin signin failed: $(printf '%s' "$resp" | head -c 300)"
+  signin "$E2E_ADMIN_EMAIL" "$E2E_ADMIN_PASS"
+  if [[ "$SIGNIN_CODE" != "200" ]]; then
+    fail "admin signin failed (HTTP $SIGNIN_CODE): $(printf '%s' "$SIGNIN_BODY" | head -c 300)"
+    return 1
+  fi
+  token=$(printf '%s' "$SIGNIN_BODY" | jqget token)
+  if [[ -z "$token" ]]; then
+    fail "admin signin returned no token: $(printf '%s' "$SIGNIN_BODY" | head -c 300)"
     return 1
   fi
   pass "admin signin returns JWT"
@@ -214,11 +234,15 @@ assert any(m.get("content")=="stubbed answer" for m in msgs), "assistant msg mis
 
 journey_regular_user_login() {
   log "Journey 2: regular user login"
-  local resp token
-  resp=$(api POST /api/v1/auths/signin '{"email":"user@example123.com","password":"q1w2e3r4!"}')
-  token=$(printf '%s' "$resp" | jqget token)
+  local token
+  signin "$E2E_USER_EMAIL" "$E2E_USER_PASS"
+  if [[ "$SIGNIN_CODE" != "200" ]]; then
+    fail "regular user signin failed (HTTP $SIGNIN_CODE): $(printf '%s' "$SIGNIN_BODY" | head -c 300)"
+    return 1
+  fi
+  token=$(printf '%s' "$SIGNIN_BODY" | jqget token)
   if [[ -z "$token" ]]; then
-    fail "regular user signin failed: $(printf '%s' "$resp" | head -c 300)"
+    fail "regular user signin returned no token: $(printf '%s' "$SIGNIN_BODY" | head -c 300)"
     return 1
   fi
   pass "regular user signin returns JWT"
@@ -227,10 +251,14 @@ journey_regular_user_login() {
 journey_admin_config_endpoints() {
   log "Journey 3: admin config endpoints reachable"
   local resp token
-  resp=$(api POST /api/v1/auths/signin '{"email":"admin@example123.com","password":"q1w2e3r4!"}')
-  token=$(printf '%s' "$resp" | jqget token)
+  signin "$E2E_ADMIN_EMAIL" "$E2E_ADMIN_PASS"
+  if [[ "$SIGNIN_CODE" != "200" ]]; then
+    fail "signin for config journey failed (HTTP $SIGNIN_CODE)"
+    return 1
+  fi
+  token=$(printf '%s' "$SIGNIN_BODY" | jqget token)
   if [[ -z "$token" ]]; then
-    fail "signin for config journey failed"
+    fail "signin for config journey returned no token"
     return 1
   fi
   resp=$(api GET /api/config "" "$token")
@@ -256,37 +284,38 @@ main() {
 
   # Provision throwaway env files from the committed E2E templates. The repo
   # ships only examples (.env.openwebui.example etc.) and compose requires
-  # real ones; both are gitignored so this never touches a dev's own setup.
-  if [[ ! -f "$REPO_ROOT/.env" || "${E2E_FORCE_ENV:-0}" == "1" ]] ; then
-    if [[ -f "$REPO_ROOT/.env" && "${E2E_FORCE_ENV:-0}" == "1" ]]; then
-      ENV_BACKUP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/maition-e2e-env-backup.XXXXXX")"
-      chmod 700 "$ENV_BACKUP_DIR"
-      cp "$REPO_ROOT/.env" "$ENV_BACKUP_DIR/.env.bak"
-      ENV_FILE_STATE_OPENWEBUI=backed_up
-      log "Backed up existing .env to $ENV_BACKUP_DIR before overwrite"
-    fi
-    if [[ -f "$REPO_ROOT/.env.rag" ]]; then
-      if [[ "${E2E_FORCE_ENV:-0}" == "1" ]]; then
-        [[ -n "$ENV_BACKUP_DIR" ]] || { ENV_BACKUP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/maition-e2e-env-backup.XXXXXX")"; chmod 700 "$ENV_BACKUP_DIR"; }
-        cp "$REPO_ROOT/.env.rag" "$ENV_BACKUP_DIR/.env.rag.bak"
-        ENV_FILE_STATE_RAG=backed_up
-        log "Backed up existing .env.rag to $ENV_BACKUP_DIR before overwrite"
-      fi
-    elif [[ "${E2E_FORCE_ENV:-0}" == "1" ]]; then
-      log "No existing .env.rag found; provisioning from tests/e2e template"
-    fi
-    log "Provisioning .env / .env.rag from tests/e2e templates"
-    cp "$SCRIPT_DIR/env.openwebui.e2e" "$REPO_ROOT/.env"
-    cp "$SCRIPT_DIR/env.rag.e2e" "$REPO_ROOT/.env.rag"
-    [[ -z "$ENV_FILE_STATE_OPENWEBUI" ]] && ENV_FILE_STATE_OPENWEBUI=provisioned
-    [[ -z "$ENV_FILE_STATE_RAG" ]] && ENV_FILE_STATE_RAG=provisioned
-  else
-    log "Using existing $REPO_ROOT/.env (E2E credentials may differ)"
-    check_provider_guard || { cleanup; exit 1; }
+  # real ones; both are gitignored. Refuse to clobber an existing dev .env
+  # unless E2E_FORCE_ENV=1 (backs up and restores on exit).
+  if [[ -f "$REPO_ROOT/.env" && "${E2E_FORCE_ENV:-0}" != "1" ]]; then
+    log "refusing to run: $REPO_ROOT/.env already exists."
+    log "E2E journeys require the committed stub templates (see tests/e2e/env.openwebui.e2e)."
+    log "Re-run with E2E_FORCE_ENV=1 to back up and overwrite .env/.env.rag for this run."
+    exit 1
   fi
+
+  if [[ -f "$REPO_ROOT/.env" && "${E2E_FORCE_ENV:-0}" == "1" ]]; then
+    ENV_BACKUP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/maition-e2e-env-backup.XXXXXX")"
+    chmod 700 "$ENV_BACKUP_DIR"
+    cp "$REPO_ROOT/.env" "$ENV_BACKUP_DIR/.env.bak"
+    ENV_FILE_STATE_OPENWEBUI=backed_up
+    log "Backed up existing .env to $ENV_BACKUP_DIR before overwrite"
+    if [[ -f "$REPO_ROOT/.env.rag" ]]; then
+      cp "$REPO_ROOT/.env.rag" "$ENV_BACKUP_DIR/.env.rag.bak"
+      ENV_FILE_STATE_RAG=backed_up
+      log "Backed up existing .env.rag to $ENV_BACKUP_DIR before overwrite"
+    fi
+  fi
+
+  log "Provisioning .env / .env.rag from tests/e2e templates"
+  cp "$SCRIPT_DIR/env.openwebui.e2e" "$REPO_ROOT/.env"
+  cp "$SCRIPT_DIR/env.rag.e2e" "$REPO_ROOT/.env.rag"
+  [[ -z "$ENV_FILE_STATE_OPENWEBUI" ]] && ENV_FILE_STATE_OPENWEBUI=provisioned
+  [[ -z "$ENV_FILE_STATE_RAG" ]] && ENV_FILE_STATE_RAG=provisioned
   trap cleanup EXIT
 
-  log "Using project '$PROJECT'; web UI will bind http://localhost:${HTTP_PORT}"
+  log "Using project '$PROJECT'; web UI http://localhost:${HTTP_PORT}; llm-stub 127.0.0.1:${LLM_STUB_PORT}"
+  check_port_free "$HTTP_PORT" "OpenWebUI" || exit 1
+  check_port_free "$LLM_STUB_PORT" "llm-stub" || exit 1
   log "Booting core stack (postgres, redis, llm-stub, openwebui)..."
 
   dc down --remove-orphans --volumes >/dev/null 2>&1 || true
@@ -302,9 +331,9 @@ main() {
   i=0
   while [ "$i" -lt 40 ]; do
     admin_code=$(curl -s -o /dev/null -w '%{http_code}' --max-time 10 -X POST "http://localhost:${HTTP_PORT}/api/v1/auths/signin" \
-      -H "Content-Type: application/json" -d '{"email":"admin@example123.com","password":"q1w2e3r4!"}')
+      -H "Content-Type: application/json" -d "{\"email\":\"$E2E_ADMIN_EMAIL\",\"password\":\"$E2E_ADMIN_PASS\"}")
     user_code=$(curl -s -o /dev/null -w '%{http_code}' --max-time 10 -X POST "http://localhost:${HTTP_PORT}/api/v1/auths/signin" \
-      -H "Content-Type: application/json" -d '{"email":"user@example123.com","password":"q1w2e3r4!"}')
+      -H "Content-Type: application/json" -d "{\"email\":\"$E2E_USER_EMAIL\",\"password\":\"$E2E_USER_PASS\"}")
     [[ "$admin_code" == "200" && "$user_code" == "200" ]] && { ok=1; break; }
     sleep 3
     i=$((i + 1))

--- a/tests/e2e/run.sh
+++ b/tests/e2e/run.sh
@@ -1,0 +1,257 @@
+#!/usr/bin/env bash
+# E2E smoke tests for mAItion.
+#
+# Boots a trimmed compose stack (openwebui + postgres + redis + llm-stub),
+# waits for health, runs deterministic API journeys against OpenWebUI's HTTP
+# API, then tears everything down. Requires Docker; exits with a clear
+# skip-with-warning when Docker is unavailable so CI can treat it as skipped.
+#
+# Usage: ./run.sh [--keep-up]     (env: MAITION_E2E_PROJECT to name the compose project)
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+PROJECT="${MAITION_E2E_PROJECT:-maition-e2e}"
+HTTP_PORT="${E2E_HTTP_PORT:-3100}"
+export HTTP_WEB_PORT="$HTTP_PORT"
+# compose.e2e.yaml uses this for its bind mounts (see comment there).
+export E2E_DIR="$SCRIPT_DIR"
+
+PASS=0
+FAIL=0
+KEEP_UP=0
+PROVISIONED_ENV=0
+
+restore_env() {
+  if [[ "$PROVISIONED_ENV" == 1 ]]; then
+    rm -f "$REPO_ROOT/.env" "$REPO_ROOT/.env.rag"
+  fi
+}
+
+if [[ "${1:-}" == "--keep-up" ]]; then
+  KEEP_UP=1
+fi
+
+log()  { printf '\033[1;34m[e2e]\033[0m %s\n' "$*"; }
+pass() { printf '\033[1;32m[PASS]\033[0m %s\n' "$*"; PASS=$((PASS+1)); }
+fail() { printf '\033[1;31m[FAIL]\033[0m %s\n' "$*"; FAIL=$((FAIL+1)); }
+
+dc() {
+  docker compose -p "$PROJECT" \
+    -f "$REPO_ROOT/compose.yaml" \
+    -f "$REPO_ROOT/compose.dev.yaml" \
+    -f "$SCRIPT_DIR/compose.e2e.yaml" \
+    --project-directory "$REPO_ROOT" \
+    "$@"
+}
+
+require_docker() {
+  if ! command -v docker >/dev/null 2>&1; then
+    log "SKIP: docker not found — mAItion E2E suite requires Docker. Skipping."
+    exit 2
+  fi
+  if ! docker info >/dev/null 2>&1; then
+    log "SKIP: Docker daemon unreachable — mAItion E2E suite requires Docker. Skipping."
+    exit 2
+  fi
+}
+
+wait_for() {
+  local url="$1" label="$2" tries="${3:-90}"
+  for ((i = 1; i <= tries; i++)); do
+    if curl -fsS --max-time 5 -o /dev/null "$url" 2>/dev/null; then
+      return 0
+    fi
+    sleep 3
+  done
+  fail "timeout waiting for $label ($url) after $tries attempts"
+  return 1
+}
+
+api() {
+  # api METHOD PATH [JSON_BODY] [TOKEN]
+  local method="$1" path="$2" body="${3:-}" token="${4:-}"
+  local args=(-sS --max-time 30 -X "$method" "http://localhost:${HTTP_PORT}${path}")
+  [[ -n "$body" ]] && args+=(-H "Content-Type: application/json" -d "$body")
+  [[ -n "$token" ]] && args+=(-H "Authorization: Bearer $token")
+  curl "${args[@]}"
+}
+
+jqget() { python3 -c "import json,sys;d=json.load(sys.stdin);print(d.get(sys.argv[1],''))" "$1"; }
+
+# ---------------------------------------------------------------------------
+# journeys
+# ---------------------------------------------------------------------------
+
+journey_admin_login_and_chat() {
+  local token resp model_id chat_id content title
+
+  log "Journey 1: admin login -> models -> chat completion -> chat persistence"
+
+  resp=$(api POST /api/v1/auths/signin '{"email":"admin@example123.com","password":"q1w2e3r4!"}')
+  token=$(printf '%s' "$resp" | jqget token)
+  if [[ -z "$token" || "$resp" == *"detail"* && "$resp" == *"$token"* ]]; then
+    fail "admin signin failed: $(printf '%s' "$resp" | head -c 300)"
+    return 1
+  fi
+  pass "admin signin returns JWT"
+
+  resp=$(api GET /openai/models "" "$token")
+  model_id=$(printf '%s' "$resp" | python3 -c '
+import json,sys
+d=json.load(sys.stdin)
+items=d if isinstance(d, list) else d.get("data", [])
+ids=[m["id"] for m in items if isinstance(m, dict) and "id" in m]
+pref=[i for i in ids if i.startswith("stub-model")]
+print(pref[0] if pref else (ids[0] if ids else ""))')
+  if [[ -z "$model_id" ]]; then
+    fail "no usable model in /api/v1/models/: $(printf '%s' "$resp" | head -c 300)"
+    return 1
+  fi
+  pass "model list contains stubbed LLM (id: $model_id)"
+
+  resp=$(api POST /api/v1/chats/new "{\"chat\":{\"title\":\"e2e-journey-1\",\"messages\":[],\"models\":[\"$model_id\"],\"params\":{}},\"model_id\":\"$model_id\",\"messages\":[]}" "$token")
+  chat_id=$(printf '%s' "$resp" | jqget id)
+  if [[ -z "$chat_id" ]]; then
+    fail "chat creation failed: $(printf '%s' "$resp" | head -c 300)"
+    return 1
+  fi
+  pass "created chat $chat_id"
+
+  resp=$(api POST /openai/chat/completions "{\"model\":\"$model_id\",\"stream\":false,\"messages\":[{\"role\":\"user\",\"content\":\"What is the capital of France?\"}]}" "$token")
+  content=$(printf '%s' "$resp" | python3 -c 'import json,sys;d=json.load(sys.stdin);print(d.get("choices",[{}])[0].get("message",{}).get("content",""))')
+  if [[ "$content" != E2E-STUB-REPLY* ]]; then
+    fail "completion did not come from stub: $(printf '%s' "$resp" | head -c 300)"
+    return 1
+  fi
+  pass "LLM completion served by llm-stub"
+
+  # Persist a completed conversation, then read it back to verify storage.
+  resp=$(api POST "/api/v1/chats/$chat_id" "{\"chat\":{\"title\":\"e2e-journey-1\",\"models\":[\"$model_id\"],\"messages\":[{\"role\":\"user\",\"content\":\"What is the capital of France?\"},{\"role\":\"assistant\",\"content\":\"stubbed answer\"}],\"params\":{}}}" "$token") ||
+    resp=$(api POST "/api/v1/chats/$chat_id" "{\"title\":\"e2e-journey-1\",\"models\":[\"$model_id\"],\"messages\":[{\"role\":\"user\",\"content\":\"What is the capital of France?\"},{\"role\":\"assistant\",\"content\":\"stubbed answer\"}],\"params\":{}}" "$token")
+  title=$(printf '%s' "$resp" | jqget title)
+  if [[ "$title" != "e2e-journey-1" ]]; then
+    fail "chat update/persistence failed: $(printf '%s' "$resp" | head -c 300)"
+    return 1
+  fi
+  resp=$(api GET "/api/v1/chats/$chat_id" "" "$token")
+  if ! printf '%s' "$resp" | python3 -c '
+import json,sys
+d=json.load(sys.stdin)
+msgs=d.get("chat",{}).get("messages") or d.get("messages") or []
+assert any(m.get("content")=="stubbed answer" for m in msgs), "assistant msg missing"' 2>/dev/null; then
+    fail "persisted chat does not contain the saved messages: $(printf '%s' "$resp" | head -c 300)"
+    return 1
+  fi
+  pass "chat persisted and re-readable with full message history"
+}
+
+journey_regular_user_login() {
+  log "Journey 2: regular user login"
+  local resp token
+  resp=$(api POST /api/v1/auths/signin '{"email":"user@example123.com","password":"q1w2e3r4!"}')
+  token=$(printf '%s' "$resp" | jqget token)
+  if [[ -z "$token" ]]; then
+    fail "regular user signin failed: $(printf '%s' "$resp" | head -c 300)"
+    return 1
+  fi
+  pass "regular user signin returns JWT"
+}
+
+journey_admin_config_endpoints() {
+  log "Journey 3: admin config endpoints reachable"
+  local resp token
+  resp=$(api POST /api/v1/auths/signin '{"email":"admin@example123.com","password":"q1w2e3r4!"}')
+  token=$(printf '%s' "$resp" | jqget token)
+  if [[ -z "$token" ]]; then
+    fail "signin for config journey failed"
+    return 1
+  fi
+  resp=$(api GET /api/config "" "$token")
+  if ! printf '%s' "$resp" | python3 -c 'import json,sys;json.load(sys.stdin)' 2>/dev/null; then
+    fail "GET /api/config returned invalid JSON: $(printf '%s' "$resp" | head -c 200)"
+    return 1
+  fi
+  pass "public config endpoint responds with JSON"
+}
+
+run_journeys() {
+  journey_admin_login_and_chat; J1=$?
+  journey_regular_user_login; J2=$?
+  journey_admin_config_endpoints; J3=$?
+}
+
+# ---------------------------------------------------------------------------
+# main
+# ---------------------------------------------------------------------------
+
+main() {
+  require_docker
+
+  # Provision throwaway env files from the committed E2E templates. The repo
+  # ships only examples (.env.openwebui.example etc.) and compose requires
+  # real ones; both are gitignored so this never touches a dev's own setup.
+  if [[ ! -f "$REPO_ROOT/.env" || "${E2E_FORCE_ENV:-0}" == "1" ]] ; then
+    log "Provisioning .env / .env.rag from tests/e2e templates"
+    cp "$SCRIPT_DIR/env.openwebui.e2e" "$REPO_ROOT/.env"
+    cp "$SCRIPT_DIR/env.rag.e2e" "$REPO_ROOT/.env.rag"
+    PROVISIONED_ENV=1
+  else
+    log "Using existing $REPO_ROOT/.env (E2E credentials may differ)"
+  fi
+  trap restore_env EXIT
+
+  log "Using project '$PROJECT'; web UI will bind http://localhost:${HTTP_PORT}"
+  log "Booting core stack (postgres, redis, llm-stub, openwebui)..."
+
+  dc down --remove-orphans --volumes >/dev/null 2>&1 || true
+  dc up -d --build --quiet-pull || { fail "docker compose up failed"; dc logs openwebui 2>/dev/null | timeout 10 tail -40; cleanup; exit 1; }
+
+  log "Waiting for health endpoints..."
+  wait_for "http://localhost:${HTTP_PORT}/health" "openwebui /health" 60 || { dc logs openwebui 2>/dev/null | timeout 10 tail -40; cleanup; exit 1; }
+
+  # The custom entrypoint provisions the admin account, then continues with
+  # provider wiring and the optional regular user; wait until BOTH accounts
+  # can sign in so journeys never race first-boot provisioning.
+  ok=0
+  for ((i = 1; i <= 40; i++)); do
+    admin_code=$(curl -s -o /dev/null -w '%{http_code}' --max-time 10 -X POST "http://localhost:${HTTP_PORT}/api/v1/auths/signin" \
+      -H "Content-Type: application/json" -d '{"email":"admin@example123.com","password":"q1w2e3r4!"}')
+    user_code=$(curl -s -o /dev/null -w '%{http_code}' --max-time 10 -X POST "http://localhost:${HTTP_PORT}/api/v1/auths/signin" \
+      -H "Content-Type: application/json" -d '{"email":"user@example123.com","password":"q1w2e3r4!"}')
+    [[ "$admin_code" == "200" && "$user_code" == "200" ]] && { ok=1; break; }
+    sleep 3
+  done
+  if [[ "$ok" != 1 ]]; then
+    fail "provisioned accounts not ready before timeout (admin=$admin_code user=$user_code)"
+    dc logs openwebui 2>/dev/null | timeout 10 tail -40
+    cleanup
+    exit 1
+  fi
+  pass "stack healthy; admin and regular user provisioned by entrypoint"
+
+  run_journeys
+
+  log "-------------------------------------------"
+  log "Results: $PASS passed, $FAIL failed"
+  cleanup
+  if [[ "$FAIL" -gt 0 ]]; then
+    exit 1
+  fi
+  log "All E2E checks passed."
+  exit 0
+}
+
+cleanup() {
+  if [[ "$KEEP_UP" == 1 ]]; then
+    log "--keep-up set; leaving stack running (project: $PROJECT). Tear down with:"
+    log "  docker compose -p $PROJECT -f $REPO_ROOT/compose.yaml -f $REPO_ROOT/compose.dev.yaml -f $SCRIPT_DIR/compose.e2e.yaml down -v --remove-orphans"
+    return
+  fi
+  log "Tearing down stack..."
+  dc down --remove-orphans --volumes >/dev/null 2>&1 || true
+}
+
+main

--- a/tests/e2e/test_llm_stub.py
+++ b/tests/e2e/test_llm_stub.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+"""Unit tests for the deterministic LLM stub (no Docker required)."""
+
+import json
+import os
+import threading
+import unittest
+import urllib.error
+import urllib.request
+from http.server import ThreadingHTTPServer
+
+# Import after setting port so the module binds correctly when started.
+os.environ["LLM_STUB_PORT"] = "0"
+
+import llm_stub  # noqa: E402
+
+
+class LlmStubHandlerTests(unittest.TestCase):
+    def setUp(self):
+        self.server = ThreadingHTTPServer(("127.0.0.1", 0), llm_stub.Handler)
+        self.port = self.server.server_address[1]
+        self.thread = threading.Thread(target=self.server.serve_forever, daemon=True)
+        self.thread.start()
+        self.base = f"http://127.0.0.1:{self.port}"
+
+    def tearDown(self):
+        self.server.shutdown()
+        self.server.server_close()
+        self.thread.join(timeout=5)
+
+    def _get(self, path):
+        with urllib.request.urlopen(f"{self.base}{path}", timeout=5) as resp:
+            return resp.status, json.loads(resp.read().decode())
+
+    def _post(self, path, payload):
+        data = json.dumps(payload).encode()
+        req = urllib.request.Request(
+            f"{self.base}{path}",
+            data=data,
+            headers={"Content-Type": "application/json"},
+            method="POST",
+        )
+        with urllib.request.urlopen(req, timeout=5) as resp:
+            return resp.status, json.loads(resp.read().decode())
+
+    def test_health(self):
+        status, body = self._get("/health")
+        self.assertEqual(status, 200)
+        self.assertEqual(body["status"], "ok")
+
+    def test_models_lists_stub_model(self):
+        status, body = self._get("/v1/models")
+        self.assertEqual(status, 200)
+        ids = [m["id"] for m in body.get("data", [])]
+        self.assertIn(llm_stub.MODEL_ID, ids)
+
+    def test_chat_completion_echoes_user_text(self):
+        status, body = self._post(
+            "/v1/chat/completions",
+            {"model": "stub-model", "messages": [{"role": "user", "content": "hello"}]},
+        )
+        self.assertEqual(status, 200)
+        content = body["choices"][0]["message"]["content"]
+        self.assertTrue(content.startswith(llm_stub.FIXED_REPLY))
+        self.assertIn("hello", content)
+
+    def test_unknown_route_returns_404(self):
+        with self.assertRaises(urllib.error.HTTPError) as ctx:
+            self._get("/v1/unknown")
+        self.assertEqual(ctx.exception.code, 404)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/e2e/validate.py
+++ b/tests/e2e/validate.py
@@ -2,9 +2,9 @@
 """Syntax and wiring validation for the E2E harness.
 
 Runs without Docker: checks Python syntax of the stub server, parses compose
-files, verifies required files exist and are executable, and confirms the
-runner's journeys reference real OpenWebUI endpoints. Intended as a fast
-pre-flight for environments without a Docker daemon.
+files, verifies required files exist and are executable, confirms the
+runner's journeys reference documented OpenWebUI endpoints, and checks that
+run.sh credentials stay in sync with env.openwebui.e2e.
 """
 
 import os
@@ -20,13 +20,33 @@ REQUIRED = [
     "env.openwebui.e2e",
     "env.rag.e2e",
     "__init__.py",
+    "test_llm_stub.py",
 ]
+
+# Journey endpoints documented in tests/e2e/README.md; run.sh must reference each.
+REQUIRED_RUNNER_ENDPOINTS = (
+    "/api/v1/auths/signin",
+    "/openai/models",
+    "/api/v1/chats/new",
+    "/openai/chat/completions",
+    "/api/v1/chats/",
+    "/api/config",
+    "/health",
+)
+
+CREDENTIAL_MAP = (
+    ("E2E_ADMIN_EMAIL", "X_WEBUI_ADMIN_EMAIL"),
+    ("E2E_ADMIN_PASS", "X_WEBUI_ADMIN_PASS"),
+    ("E2E_USER_EMAIL", "X_WEBUI_USER_EMAIL"),
+    ("E2E_USER_PASS", "X_WEBUI_USER_PASS"),
+)
 
 
 def check_python_syntax():
-    path = os.path.join(HERE, "llm_stub.py")
-    py_compile.compile(path, doraise=True)
-    print(f"OK   python syntax: {path}")
+    for name in ("llm_stub.py", "validate.py", "test_llm_stub.py"):
+        path = os.path.join(HERE, name)
+        py_compile.compile(path, doraise=True)
+        print(f"OK   python syntax: {name}")
     return True
 
 
@@ -41,21 +61,40 @@ def check_files():
             print(f"OK   present: {name}")
     runner = os.path.join(HERE, "run.sh")
     if os.path.exists(runner) and not os.access(runner, os.X_OK):
-        print(f"FAIL run.sh is not executable")
+        print("FAIL run.sh is not executable")
         ok = False
     return ok
 
 
-# Journey endpoints documented in tests/e2e/README.md; run.sh must reference each.
-REQUIRED_RUNNER_ENDPOINTS = (
-    "/api/v1/auths/signin",
-    "/openai/models",
-    "/api/v1/chats/new",
-    "/openai/chat/completions",
-    "/api/v1/chats/",
-    "/api/config",
-    "/health",
-)
+def _parse_env_file(path):
+    values = {}
+    with open(path) as fh:
+        for line in fh:
+            line = line.strip()
+            if not line or line.startswith("#"):
+                continue
+            if "=" in line:
+                key, _, value = line.partition("=")
+                values[key.strip()] = value.strip()
+    return values
+
+
+def check_credential_sync():
+    env_path = os.path.join(HERE, "env.openwebui.e2e")
+    runner_path = os.path.join(HERE, "run.sh")
+    env_vals = _parse_env_file(env_path)
+    with open(runner_path) as fh:
+        runner = fh.read()
+    ok = True
+    for runner_var, env_key in CREDENTIAL_MAP:
+        expected = env_vals.get(env_key, "")
+        needle = f'{runner_var}="{expected}"'
+        if needle not in runner:
+            print(f"FAIL run.sh {runner_var} does not match {env_key} in env.openwebui.e2e")
+            ok = False
+    if ok:
+        print("OK   run.sh E2E credentials match env.openwebui.e2e")
+    return ok
 
 
 def check_runner_endpoints():
@@ -110,9 +149,13 @@ def check_compose_yaml():
 
 
 def main():
-    results = [check_python_syntax(), check_files(), check_runner_endpoints()]
-    r = check_compose_yaml()
-    results.append(r)
+    results = [
+        check_python_syntax(),
+        check_files(),
+        check_credential_sync(),
+        check_runner_endpoints(),
+        check_compose_yaml(),
+    ]
     if all(results):
         print("\nAll E2E harness pre-flight checks passed.")
         return 0

--- a/tests/e2e/validate.py
+++ b/tests/e2e/validate.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+"""Syntax and wiring validation for the E2E harness.
+
+Runs without Docker: checks Python syntax of the stub server, parses compose
+files, verifies required files exist and are executable, and confirms the
+runner's journeys reference real OpenWebUI endpoints. Intended as a fast
+pre-flight for environments without a Docker daemon.
+"""
+
+import os
+import py_compile
+import sys
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+
+REQUIRED = [
+    "llm_stub.py",
+    "compose.e2e.yaml",
+    "run.sh",
+    "env.openwebui.e2e",
+    "env.rag.e2e",
+    "__init__.py",
+]
+
+
+def check_python_syntax():
+    path = os.path.join(HERE, "llm_stub.py")
+    py_compile.compile(path, doraise=True)
+    print(f"OK   python syntax: {path}")
+    return True
+
+
+def check_files():
+    ok = True
+    for name in REQUIRED:
+        path = os.path.join(HERE, name)
+        if not os.path.exists(path):
+            print(f"FAIL missing file: {path}")
+            ok = False
+        else:
+            print(f"OK   present: {name}")
+    runner = os.path.join(HERE, "run.sh")
+    if os.path.exists(runner) and not os.access(runner, os.X_OK):
+        print(f"FAIL run.sh is not executable")
+        ok = False
+    return ok
+
+
+def check_compose_yaml():
+    try:
+        import yaml
+    except ImportError:
+        try:
+            import json
+        except ImportError:
+            print("SKIP yaml module unavailable; skipping compose parse check")
+            return True
+        # fall through to docker-based check in main()
+    import yaml
+
+    with open(os.path.join(HERE, "compose.e2e.yaml")) as fh:
+        doc = yaml.safe_load(fh)
+    services = doc.get("services", {})
+    expected = {"llm-stub", "openwebui", "api", "celery_worker", "celery_beat"}
+    missing = expected - set(services)
+    if missing:
+        print(f"FAIL compose.e2e.yaml missing service keys: {sorted(missing)}")
+        return False
+    rag_profiled = all(
+        "profiles" in services[s] for s in ("api", "celery_worker", "celery_beat")
+    )
+    if not rag_profiled:
+        print("FAIL rag services must keep their 'rag' profile so they stay out of the smoke stack")
+        return False
+    print("OK   compose.e2e.yaml structure valid (llm-stub + profiled RAG services)")
+    return True
+
+
+def main():
+    results = [check_python_syntax(), check_files()]
+    r = check_compose_yaml()
+    results.append(r)
+    if all(results):
+        print("\nAll E2E harness pre-flight checks passed.")
+        return 0
+    print("\nE2E harness pre-flight FAILED", file=sys.stderr)
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/e2e/validate.py
+++ b/tests/e2e/validate.py
@@ -50,13 +50,8 @@ def check_compose_yaml():
     try:
         import yaml
     except ImportError:
-        try:
-            import json
-        except ImportError:
-            print("SKIP yaml module unavailable; skipping compose parse check")
-            return True
-        # fall through to docker-based check in main()
-    import yaml
+        print("SKIP yaml module unavailable; skipping compose parse check")
+        return True
 
     with open(os.path.join(HERE, "compose.e2e.yaml")) as fh:
         doc = yaml.safe_load(fh)

--- a/tests/e2e/validate.py
+++ b/tests/e2e/validate.py
@@ -46,6 +46,30 @@ def check_files():
     return ok
 
 
+# Journey endpoints documented in tests/e2e/README.md; run.sh must reference each.
+REQUIRED_RUNNER_ENDPOINTS = (
+    "/api/v1/auths/signin",
+    "/openai/models",
+    "/api/v1/chats/new",
+    "/openai/chat/completions",
+    "/api/v1/chats/",
+    "/api/config",
+    "/health",
+)
+
+
+def check_runner_endpoints():
+    runner = os.path.join(HERE, "run.sh")
+    with open(runner) as fh:
+        contents = fh.read()
+    missing = [ep for ep in REQUIRED_RUNNER_ENDPOINTS if ep not in contents]
+    if missing:
+        print(f"FAIL run.sh missing documented journey endpoints: {missing}")
+        return False
+    print("OK   run.sh references documented journey endpoints")
+    return True
+
+
 def check_compose_yaml():
     try:
         import yaml
@@ -61,18 +85,32 @@ def check_compose_yaml():
     if missing:
         print(f"FAIL compose.e2e.yaml missing service keys: {sorted(missing)}")
         return False
-    rag_profiled = all(
-        "profiles" in services[s] for s in ("api", "celery_worker", "celery_beat")
-    )
-    if not rag_profiled:
-        print("FAIL rag services must keep their 'rag' profile so they stay out of the smoke stack")
+
+    rag_services = ("api", "celery_worker", "celery_beat")
+    for svc in rag_services:
+        profiles = services[svc].get("profiles", [])
+        if "rag" not in profiles:
+            print(f"FAIL {svc} must include the 'rag' profile so it stays out of the smoke stack")
+            return False
+
+    stub = services.get("llm-stub", {})
+    if not stub.get("healthcheck"):
+        print("FAIL llm-stub must define a healthcheck")
         return False
+
+    openwebui = services.get("openwebui", {})
+    depends = openwebui.get("depends_on", {})
+    llm_dep = depends.get("llm-stub") if isinstance(depends, dict) else None
+    if not isinstance(llm_dep, dict) or llm_dep.get("condition") != "service_healthy":
+        print("FAIL openwebui must depend on llm-stub with condition: service_healthy")
+        return False
+
     print("OK   compose.e2e.yaml structure valid (llm-stub + profiled RAG services)")
     return True
 
 
 def main():
-    results = [check_python_syntax(), check_files()]
+    results = [check_python_syntax(), check_files(), check_runner_endpoints()]
     r = check_compose_yaml()
     results.append(r)
     if all(results):


### PR DESCRIPTION
Implements [MAIT-337](https://wikiteq.atlassian.net/browse/MAIT-337): E2E testing for mAItion to capture potential regressions.

## Summary

- Adds a Docker-based E2E harness under `tests/e2e/` that boots the core stack (`openwebui` + `postgres` + `redis`) plus a new in-network **`llm-stub`** service — a deterministic OpenAI-compatible server (`tests/e2e/llm_stub.py`) — so no LLM API keys, S3, or external services are required
- Reuses the stock `compose.yaml` + `compose.dev.yaml` (RAG services stay profiled out) via an override file, so first-boot provisioning through `helpers/entrypoint.sh` is exercised unmodified
- Exercises real user journeys over public HTTP endpoints: admin login → provider model list → create chat → LLM completion (served by the stub) → chat persistence read-back; regular-user login; admin config endpoint sanity
- Runner provisions throwaway `.env` / `.env.rag` from committed templates and restores them afterwards; waits for both provisioned accounts before running journeys to avoid first-boot races
- Adds `make test-e2e` (full run), `make test-e2e-validate` (syntax/wiring pre-flight, no Docker), documented in README "Testing" section and `tests/e2e/README.md`
- Skip-with-warning pattern: exits with code 2 when Docker is unavailable so CI can treat it as skipped

## Validation

Full suite run locally with Docker: **8 passed, 0 failed** in ~2m17s including image pulls, boot, journeys, and teardown (well under the 5-minute budget). Pre-flight validate target passes without Docker.

## Test plan

- [x] `make test-e2e-validate` passes (Python/compose syntax + wiring checks)
- [x] `./tests/e2e/run.sh` full run green on a clean checkout (fresh volumes)
- [x] Confirmed teardown removes all containers/volumes; `.env` files restored
- [ ] CI (if wired later): suite is designed to exit 2 (skip) on runners without Docker

[MAIT-337]: https://wikiteq.atlassian.net/browse/MAIT-337?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ