### PR TITLE
MAIT-382: Fix TypeError in image_resizer when tool-call message has content: null

### DIFF
--- a/functions/image_resizer.py
+++ b/functions/image_resizer.py
@@ -30,7 +30,7 @@ def resize_images_in_messages(messages, max_dimension=768):
     # re-opened every turn. Only the encode+save step is skipped once an
     # image is already at/under max_dimension.
     for message in messages:
-        for item in message.get("content", []):
+        for item in message.get("content") or []:
             if not isinstance(item, dict):
                 continue
             if item.get("type") != "image_url":


### PR DESCRIPTION
## Root cause

`image_resizer`'s `inlet` filter iterates messages with:

```python
for item in message.get("content", []):
```

`.get(key, default)` only falls back to `default` when the key is **missing**. An assistant message representing a text-free tool call has the standard shape `{"role": "assistant", "content": null, "tool_calls": [...]}` — the key is present with value `None`, so `.get()` returns `None` directly, and the loop crashes:

```
TypeError: 'NoneType' object is not iterable
```

This surfaces to users as `Error: 'NoneType' object is not iterable`, wrapped by OpenWebUI's inlet-filter exception handler.

## Fix

```python
for item in message.get("content") or []:
```

Handles both cases (missing key, and key present with `None`) identically.

Related: MAIT-382