### PR TITLE
Update rag-of-all-trades image to 3237d7b

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -100,7 +100,7 @@ services:
 
   # rag-of-all-trades API
   api:
-    image: ghcr.io/wikiteq/rag-of-all-trades:01d6a7d
+    image: ghcr.io/wikiteq/rag-of-all-trades:3237d7b
     extra_hosts:
       - "host.docker.internal:host-gateway"
     depends_on:
@@ -124,7 +124,7 @@ services:
 
   # rag-of-all-trades WORKER
   celery_worker:
-    image: ghcr.io/wikiteq/rag-of-all-trades:01d6a7d
+    image: ghcr.io/wikiteq/rag-of-all-trades:3237d7b
     extra_hosts:
       - "host.docker.internal:host-gateway"
     depends_on:
@@ -150,7 +150,7 @@ services:
 
   # rag-of-all-trades BEAT
   celery_beat:
-    image: ghcr.io/wikiteq/rag-of-all-trades:01d6a7d
+    image: ghcr.io/wikiteq/rag-of-all-trades:3237d7b
     depends_on:
       postgres:
         condition: service_healthy


### PR DESCRIPTION
## Summary
- Bumps `rag-of-all-trades` image tag to `3237d7b` across all three services (`api`, `celery_worker`, `celery_beat`) in `compose.yaml`