### PR TITLE
Update rag-of-all-trades image to f7eaa20

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -100,7 +100,7 @@ services:
 
   # rag-of-all-trades API
   api:
-    image: ghcr.io/wikiteq/rag-of-all-trades:3237d7b
+    image: ghcr.io/wikiteq/rag-of-all-trades:f7eaa20
     extra_hosts:
       - "host.docker.internal:host-gateway"
     depends_on:
@@ -124,7 +124,7 @@ services:
 
   # rag-of-all-trades WORKER
   celery_worker:
-    image: ghcr.io/wikiteq/rag-of-all-trades:3237d7b
+    image: ghcr.io/wikiteq/rag-of-all-trades:f7eaa20
     extra_hosts:
       - "host.docker.internal:host-gateway"
     depends_on:
@@ -150,7 +150,7 @@ services:
 
   # rag-of-all-trades BEAT
   celery_beat:
-    image: ghcr.io/wikiteq/rag-of-all-trades:3237d7b
+    image: ghcr.io/wikiteq/rag-of-all-trades:f7eaa20
     depends_on:
       postgres:
         condition: service_healthy


### PR DESCRIPTION
## Summary
- Bumps `rag-of-all-trades` image tag to `f7eaa20` across all three services (`api`, `celery_worker`, `celery_beat`) in `compose.yaml`